### PR TITLE
Update db schema to support 64 characters with device IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+- Update db schema to support 64 characters with device IDs. This enables `SystemInfo.deviceUniqueIdentifier` to be used as a source for device IDs on Windows 10.
+
 ## [0.10.0] - 2017-01-14
 ### Added
 - Initial public release.

--- a/main.go
+++ b/main.go
@@ -49,10 +49,6 @@ var (
 func main() {
 	semver := fmt.Sprintf("%s+%s", version, commitID)
 
-	memoryMetricSink := metrics.NewInmemSink(10*time.Second, time.Minute)
-	metric := &metrics.FanoutSink{memoryMetricSink}
-	metrics.NewGlobal(&metrics.Config{EnableRuntimeMetrics: true, ProfileInterval: 5 * time.Second}, metric)
-
 	clogger := zap.New(zap.NewTextEncoder(zap.TextNoTime()), zap.Output(os.Stdout))
 
 	if len(os.Args) > 1 {
@@ -69,6 +65,10 @@ func main() {
 	}
 
 	config := parseArgs(clogger)
+
+	memoryMetricSink := metrics.NewInmemSink(10*time.Second, time.Minute)
+	metric := &metrics.FanoutSink{memoryMetricSink}
+	metrics.NewGlobal(&metrics.Config{EnableRuntimeMetrics: true, ProfileInterval: 5 * time.Second}, metric)
 
 	logger, mlogger := configureLogger(clogger, config)
 
@@ -94,7 +94,7 @@ func main() {
 	// Always set default timeout on HTTP client
 	http.DefaultClient.Timeout = 1500 * time.Millisecond
 
-	gaenabled := len(os.Getenv("NAKAMA_TELEMETRY")) > 0
+	gaenabled := len(os.Getenv("NAKAMA_TELEMETRY")) < 1
 
 	cookie := newOrLoadCookie(config.GetDataDir())
 	gacode := "UA-89792135-1"

--- a/migrations/20170115200001_initial_schema.sql
+++ b/migrations/20170115200001_initial_schema.sql
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS user_device (
     PRIMARY KEY (id),
     FOREIGN KEY (user_id) REFERENCES users(id),
-    id VARCHAR(36) NOT NULL,
+    id VARCHAR(64) NOT NULL,
     user_id BYTES NOT NULL,
 
     INDEX user_id_idx (user_id)

--- a/server/session_auth.go
+++ b/server/session_auth.go
@@ -226,8 +226,8 @@ func (a *authenticationService) loginDevice(authReq *AuthenticateRequest) ([]byt
 		return nil, 0, "Device ID is required", 400
 	} else if invalidCharsRegex.MatchString(deviceID) {
 		return nil, 0, "Invalid device ID, no spaces or control characters allowed", 400
-	} else if len(deviceID) < 10 || len(deviceID) > 36 {
-		return nil, 0, "Invalid device ID, must be 10-36 bytes", 400
+	} else if len(deviceID) < 10 || len(deviceID) > 64 {
+		return nil, 0, "Invalid device ID, must be 10-64 bytes", 400
 	}
 
 	var userID []byte
@@ -472,8 +472,8 @@ func (a *authenticationService) registerDevice(txn *sql.Tx, authReq *Authenticat
 		return nil, "Device ID is required", 400
 	} else if invalidCharsRegex.MatchString(deviceID) {
 		return nil, "Invalid device ID, no spaces or control characters allowed", 400
-	} else if len(deviceID) < 10 || len(deviceID) > 36 {
-		return nil, "Invalid device ID, must be 10-36 bytes", 400
+	} else if len(deviceID) < 10 || len(deviceID) > 64 {
+		return nil, "Invalid device ID, must be 10-64 bytes", 400
 	}
 
 	updatedAt := nowMs()


### PR DESCRIPTION
In Unity `SystemInfo.deviceUniqueIdentifier` is not guaranteed to be a string with a fixed length. The length of the UDID depends on the platform which it's run on. Windows 10 appears to generate IDs which are 40 characters and exceed our input limit in the database.