### PR TITLE
Add Debug build flag. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/*
 !dashboard/build
 data/*
 .GITHUB_TOKEN
+.idea
 
 ### Go ###
 # Compiled Object files, Static and Dynamic libs (Shared Objects)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Update db schema to support 64 characters with device IDs. This enables `SystemInfo.deviceUniqueIdentifier` to be used as a source for device IDs on Windows 10.
 - Add Debug build flag to enable debug logging and console output in development builds.
 - Fix issue where random handle generator wasn't seeded properly.
-- Fix issues in executing Friend queries.
+- Fix issues in executing Friend and Storage queries.
 - Fix sending Close frame message in the Websocket to gracefully close connection.
 - Logout messages now close the connection as well and won't reply.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 - Update db schema to support 64 characters with device IDs. This enables `SystemInfo.deviceUniqueIdentifier` to be used as a source for device IDs on Windows 10.
+- Add Debug build flag to enable debug logging and console output in development builds.
+- Fix issue where random handle generator wasn't seeded properly.
+- Fix issues in executing Friend queries.
+- Fix sending Close frame message in the Websocket to gracefully close connection.
+- Logout messages now close the connection as well and won't reply.
 
 ## [0.10.0] - 2017-01-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,20 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Add verbose command-line flag to enable debug logging and console output.
+
 ### Changed
 - Update db schema to support 64 characters with device IDs. This enables `SystemInfo.deviceUniqueIdentifier` to be used as a source for device IDs on Windows 10.
-- Add Debug build flag to enable debug logging and console output in development builds.
+- Logout messages now close the connection as well and won't reply.
+- Changed Logout message type from `TLogout` to `Logout`.
+
+### Fixed
+
 - Fix issue where random handle generator wasn't seeded properly.
 - Fix issues in executing Friend and Storage queries.
 - Fix sending Close frame message in the Websocket to gracefully close connection.
-- Logout messages now close the connection as well and won't reply.
 
 ## [0.10.0] - 2017-01-14
 ### Added

--- a/server/api.proto
+++ b/server/api.proto
@@ -76,7 +76,7 @@ message Envelope {
 
     Heartbeat heartbeat = 3;
 
-    TLogout logout = 4;
+    Logout logout = 4;
     TLink link = 5;
     TUnlink unlink = 6;
 
@@ -135,7 +135,7 @@ message Envelope {
   }
 }
 
-message TLogout {}
+message Logout {}
 
 // Link expects same input as an authentication.
 message TLink {

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -16,10 +16,10 @@ package server
 
 import (
 	"database/sql"
-
-	"nakama/pkg/social"
+	"fmt"
 
 	"github.com/uber-go/zap"
+	"nakama/pkg/social"
 )
 
 type pipeline struct {
@@ -42,11 +42,11 @@ func NewPipeline(config Config, db *sql.DB, socialClient *social.Client, tracker
 }
 
 func (p *pipeline) processRequest(logger zap.Logger, session *session, envelope *Envelope) {
+	logger.Debug(fmt.Sprintf("Received %T message", envelope.Payload))
+
 	switch envelope.Payload.(type) {
 	case *Envelope_Logout:
 		// TODO Store JWT into a blacklist until remaining JWT expiry.
-		logger.Info("Recieved logout message")
-		session.Send(&Envelope{CollationId: envelope.CollationId})
 		session.Close()
 
 	case *Envelope_Link:

--- a/server/pipeline_friend.go
+++ b/server/pipeline_friend.go
@@ -18,6 +18,7 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/lib/pq"
 	"github.com/satori/go.uuid"
 	"github.com/uber-go/zap"
 )
@@ -341,7 +342,7 @@ func (p *pipeline) friendRemove(l zap.Logger, session *session, envelope *Envelo
 
 	updatedAt := nowMs()
 
-	res, err := tx.Exec("DELETE FROM user_edge WHERE source_id = $1 AND destination_id = $2", session.userID.Bytes(), friendIDBytes, updatedAt)
+	res, err := tx.Exec("DELETE FROM user_edge WHERE source_id = $1 AND destination_id = $2", session.userID.Bytes(), friendIDBytes)
 	rowsAffected, _ := res.RowsAffected()
 	if err == nil && rowsAffected > 0 {
 		_, err = tx.Exec("UPDATE user_edge_metadata SET count = count - 1, updated_at = $2 WHERE source_id = $1", session.userID.Bytes(), updatedAt)
@@ -351,7 +352,7 @@ func (p *pipeline) friendRemove(l zap.Logger, session *session, envelope *Envelo
 		return
 	}
 
-	res, err = tx.Exec("DELETE FROM user_edge WHERE source_id = $1 AND destination_id = $2", friendIDBytes, session.userID.Bytes(), updatedAt)
+	res, err = tx.Exec("DELETE FROM user_edge WHERE source_id = $1 AND destination_id = $2", friendIDBytes, session.userID.Bytes())
 	rowsAffected, _ = res.RowsAffected()
 	if err == nil && rowsAffected > 0 {
 		_, err = tx.Exec("UPDATE user_edge_metadata SET count = count - 1, updated_at = $2 WHERE source_id = $1", friendIDBytes, updatedAt)
@@ -389,7 +390,11 @@ func (p *pipeline) friendBlock(l zap.Logger, session *session, envelope *Envelop
 	}
 	defer func() {
 		if err != nil {
-			logger.Error("Could not remove friend", zap.Error(err))
+			if _, ok := err.(*pq.Error); ok {
+				logger.Error("Could not block user", zap.Error(err))
+			} else {
+				logger.Warn("Could not block user", zap.Error(err))
+			}
 			err = tx.Rollback()
 			if err != nil {
 				logger.Error("Could not rollback transaction", zap.Error(err))

--- a/server/pipeline_friend.go
+++ b/server/pipeline_friend.go
@@ -143,7 +143,7 @@ func (p *pipeline) getFriends(filterQuery string, userID []byte) ([]*Friend, err
 	query := `
 SELECT id, handle, fullname, avatar_url,
 	lang, location, timezone, metadata,
-	created_at, updated_at, last_online_at, state
+	created_at, users.updated_at, last_online_at, state
 FROM users, user_edge ` + filterQuery
 
 	rows, err := p.db.Query(query, userID)

--- a/server/pipeline_friend.go
+++ b/server/pipeline_friend.go
@@ -245,7 +245,7 @@ func (p *pipeline) friendAdd(l zap.Logger, session *session, envelope *Envelope)
 	}()
 
 	updatedAt := nowMs()
-	res, err := tx.Exec("UPDATE user_edge SET state = 0, updated_at = $3 WHERE source_id = $1 AND destination_id = $2 AND state = 2", addFriendRequest.UserId, session.userID.Bytes(), updatedAt)
+	res, err := tx.Exec("UPDATE user_edge SET state = 0, updated_at = $3 WHERE source_id = $1 AND destination_id = $2 AND state = 2", friendIDBytes, session.userID.Bytes(), updatedAt)
 	if err != nil {
 		return
 	}

--- a/server/pipeline_storage.go
+++ b/server/pipeline_storage.go
@@ -184,7 +184,7 @@ func (p *pipeline) storageWrite(logger zap.Logger, session *session, envelope *E
 			query = `
 INSERT INTO storage (user_id, bucket, collection, record, value, version, created_at, updated_at, deleted_at)
 SELECT ($1, $2, $3, $4, $5, $6, $7, $7, 0)
-WHERE NOT EXISTS (SELECT record FROM storage WHERE user_id = $1 AND bucket = $2 AND collection = $3 and record = $4 AND deleted_at = 0 AND write = 0)
+WHERE NOT EXISTS (SELECT record FROM storage WHERE user_id = $1 AND bucket = $2 AND collection = $3 AND record = $4 AND deleted_at = 0 AND write = 0)
 ON CONFLICT (bucket, collection, user_id, record, deleted_at)
 DO UPDATE SET value = $5, version = $6, updated_at = $7
 `
@@ -195,7 +195,7 @@ DO UPDATE SET value = $5, version = $6, updated_at = $7
 			query = `
 INSERT INTO storage (user_id, bucket, collection, record, value, version, created_at, updated_at, deleted_at)
 SELECT ($1, $2, $3, $4, $5, $6, $7, $7, 0)
-WHERE NOT EXISTS (SELECT record FROM storage WHERE user_id = $1 AND bucket = $2 AND collection = $3 and record = $4 AND deleted_at = 0)
+WHERE NOT EXISTS (SELECT record FROM storage WHERE user_id = $1 AND bucket = $2 AND collection = $3 AND record = $4 AND deleted_at = 0)
 `
 			params = []interface{}{session.userID.Bytes(), data.Bucket, data.Collection, data.Record, data.Value, version, updatedAt}
 			errorMessage = "Could not store data. This could be caused by failure of if-none-match version check"
@@ -281,7 +281,7 @@ func (p *pipeline) storageRemove(logger zap.Logger, session *session, envelope *
 		if key.Version != nil {
 			query := `
 UPDATE storage SET deleted_at = $1, updated_at = $1
-WHERE bucket = $2 AND collection = $3 AND record = $4 AND user_id = $5 AND version = $6 deleted_at = 0 AND write = 1`
+WHERE bucket = $2 AND collection = $3 AND record = $4 AND user_id = $5 AND version = $6 AND deleted_at = 0 AND write = 1`
 			res, err = tx.Exec(query, updatedAt, key.Bucket, key.Collection, key.Record, session.userID.Bytes(), key.Version)
 		} else {
 			query := `

--- a/server/session.go
+++ b/server/session.go
@@ -39,7 +39,7 @@ type session struct {
 // NewSession creates a new session which encapsulates a socket connection
 func NewSession(logger zap.Logger, config Config, userID uuid.UUID, websocketConn *websocket.Conn, unregister func(s *session)) *session {
 	sessionID := uuid.NewV4()
-	sessionLogger := logger.With(zap.String("uid", userID.String()), zap.String("session", sessionID.String()))
+	sessionLogger := logger.With(zap.String("uid", userID.String()), zap.String("sid", sessionID.String()))
 
 	sessionLogger.Info("New session connected")
 

--- a/server/session_auth.go
+++ b/server/session_auth.go
@@ -458,7 +458,7 @@ func (a *authenticationService) register(authReq *AuthenticateRequest) ([]byte, 
 		return nil, errorCouldNotRegister, 500
 	}
 
-	a.logger.Info("Registration complete", zap.String("userid", uuid.FromBytesOrNil(userID).String()))
+	a.logger.Info("Registration complete", zap.String("uid", uuid.FromBytesOrNil(userID).String()))
 	return userID, errorMessage, errorCode
 }
 

--- a/server/session_auth.go
+++ b/server/session_auth.go
@@ -21,10 +21,8 @@ import (
 	"math/rand"
 	"net/http"
 	"regexp"
-	"time"
-
-	"nakama/pkg/social"
 	"strconv"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gogo/protobuf/proto"
@@ -33,6 +31,7 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/uber-go/zap"
 	"golang.org/x/crypto/bcrypt"
+	"nakama/pkg/social"
 )
 
 const (
@@ -60,6 +59,7 @@ type authenticationService struct {
 	hmacSecretByte []byte
 	upgrader       *websocket.Upgrader
 	socialClient   *social.Client
+	random         *rand.Rand
 }
 
 // NewAuthenticationService creates a new AuthenticationService
@@ -75,6 +75,7 @@ func NewAuthenticationService(logger zap.Logger, config Config, db *sql.DB, regi
 		hmacSecretByte: []byte(config.GetSession().EncryptionKey),
 		upgrader:       &websocket.Upgrader{ReadBufferSize: 1024, WriteBufferSize: 1024},
 		socialClient:   s,
+		random: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 
 	a.configure()
@@ -457,7 +458,7 @@ func (a *authenticationService) register(authReq *AuthenticateRequest) ([]byte, 
 		return nil, errorCouldNotRegister, 500
 	}
 
-	a.logger.Info("Registration complete")
+	a.logger.Info("Registration complete", zap.String("userid", uuid.FromBytesOrNil(userID).String()))
 	return userID, errorMessage, errorCode
 }
 
@@ -785,7 +786,7 @@ WHERE NOT EXISTS
 func (a *authenticationService) generateHandle() string {
 	b := make([]byte, 10)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[a.random.Intn(len(letters))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
Changes in this PR:

- Add Debug build flag to enable debug logging and console output in development builds. This will disable processing of messages with `Zap.Level.Debug`. It will also enable mirroring log out to the console in development builds.

- Various query tweaks for Friends and Storage.

- Add additional log messages and enhancing a couple of existing ones.

- Fix issue where random handle generator wasn't seeded properly.

- Logout messages now close the connection as well and won't reply.

- Fix sending Close frame message in the Websocket in order to gracefully close connection.