### PR TITLE
Update Homebrew formula for stable builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Have a look at our [documentation](https://heroiclabs.com/docs/start-server/) fo
 To start a server locally and bind it to all network interfaces once it's installed and on your path - `nakama`. The server output will show how it's been configured by default.
 
 ```
-$ nakama
+$> nakama
 [I] Nakama starting at=$$now$$
 [I] Node name=nakama-97f4 version=$$version$$
 [I] Data directory path=$$datadir$$

--- a/install/local/nakama.rb
+++ b/install/local/nakama.rb
@@ -19,9 +19,9 @@ require "language/go"
 class Nakama < Formula
   desc "Distributed server for social and realtime games and apps."
   homepage "https://heroiclabs.com"
-  url "https://github.com/heroiclabs/nakama/releases/download/v0.10.0/nakama-0.10.0-darwin-amd64.tar.gz"
-  sha256 "cd3a65eacedba9d1b14523ddf0cff44a19814fd35c8d82293ed79f9377e40240"
-  version "0.10.0"
+  url "https://github.com/heroiclabs/nakama/releases/download/v0.11.0/nakama-0.11.0-darwin-amd64.tar.gz"
+  sha256 "c9b83743ef42f095d7483b4a32e0b19c68f457a6aec417218efb125bf1152886"
+  version "0.11.0"
 
   head "https://github.com/heroiclabs/nakama.git"
 

--- a/install/local/nakama.rb
+++ b/install/local/nakama.rb
@@ -16,36 +16,45 @@
 
 require "language/go"
 
-# TODO(novabyte) update this formula to support tarball builds as well
 class Nakama < Formula
   desc "Distributed server for social and realtime games and apps."
   homepage "https://heroiclabs.com"
-  url  "https://github.com/heroiclabs/nakama.git", :tag => "0.10.0"
+  url "https://github.com/heroiclabs/nakama/releases/download/v0.10.0/nakama-0.10.0-darwin-amd64.tar.gz"
+  sha256 "cd3a65eacedba9d1b14523ddf0cff44a19814fd35c8d82293ed79f9377e40240"
+  version "0.10.0"
+
   head "https://github.com/heroiclabs/nakama.git"
 
-  depends_on "glide" => :build
-  depends_on "go" => :build
-  depends_on "node" => :build
-  depends_on "protobuf" => :build
+  if build.head?
+    depends_on "glide" => :build
+    depends_on "go" => :build
+    depends_on "node" => :build
+    depends_on "protobuf" => :build
+  end
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV["GOBIN"]  = buildpath/"bin"
-    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    if build.head?
+      ENV["GOPATH"] = buildpath
+      ENV["GOBIN"]  = buildpath/"bin"
+      ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
 
-    (buildpath/"src/github.com/heroiclabs/nakama").install buildpath.children
-    cd "src/github.com/heroiclabs/nakama" do
-      system "glide", "install"
-      system "make", "gettools", "nakama"
-      bin.install "build/dev/nakama" => "nakama"
+      (buildpath/"src/github.com/heroiclabs/nakama").install buildpath.children
+      cd "src/github.com/heroiclabs/nakama" do
+        system "glide", "install"
+        system "make", "gettools", "nakama"
+        bin.install "build/dev/nakama" => "nakama"
+      end
+    else
+      bin.install "nakama"
+      prefix.install "README.md", "CHANGELOG.md", "LICENSE"
     end
   end
 
   def caveats
     <<-EOS.undent
     You will need to install cockroachdb as the database.
-    Start the nakama server:
-        nakama --dsns "root@localhost:26257"
+    You can start a nakama server with:
+        nakama
     EOS
   end
 


### PR DESCRIPTION
This switches the brew formula over to use stable releases by default.

The `HEAD` builds do not work right now. I'll investigate further but it's related to the ephemeral `GOPATH` is setup by Homebrew for the build and the tools are not on the `PATH` when executed by the Makefile.