### PR TITLE
Topic presence diff improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ### Added
 - Include Dockerfile and Docker instructions.
 - Use a default limit in topic message listings if one is not provided.
+- Improve logging around topic presence diff processing.
 
 ### Changed
 - Improve warning message on migration database creation.
 - Print database connections to logs on server start.
+- Use byte slices for most database operations.
 
 ### Fixed
 - Enforce concurrency control on outgoing socket messages.
@@ -20,6 +22,8 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Correct handling of IDs in various login options.
 - Fix presence service shutdown sequence.
 - More graceful handling of session operations while connection is closing.
+- Fix batch user fetch query construction.
+- Fix duplicate leaves reported in topic presence diff messages.
 
 ## [0.11.1] - 2017-02-12
 ### Changed

--- a/server/pipeline_friend.go
+++ b/server/pipeline_friend.go
@@ -39,14 +39,14 @@ FROM users ` + filterQuery
 	}
 	defer rows.Close()
 
-	var id sql.RawBytes
+	var id []byte
 	var handle sql.NullString
 	var fullname sql.NullString
 	var avatarURL sql.NullString
 	var lang sql.NullString
 	var location sql.NullString
 	var timezone sql.NullString
-	var metadata sql.RawBytes
+	var metadata []byte
 	var createdAt sql.NullInt64
 	var updatedAt sql.NullInt64
 	var lastOnlineAt sql.NullInt64
@@ -117,7 +117,7 @@ func (p *pipeline) addFacebookFriends(logger zap.Logger, userID []byte, accessTo
 
 	friendAddedCounter := 0
 	for _, fbFriend := range fbFriends {
-		var friendID sql.RawBytes
+		var friendID []byte
 		err = tx.QueryRow("SELECT id FROM users WHERE facebook_id = $1", fbFriend.ID).Scan(&friendID)
 		if err != nil {
 			return
@@ -156,14 +156,14 @@ FROM users, user_edge ` + filterQuery
 	friends := make([]*Friend, 0)
 
 	for rows.Next() {
-		var id sql.RawBytes
+		var id []byte
 		var handle sql.NullString
 		var fullname sql.NullString
 		var avatarURL sql.NullString
 		var lang sql.NullString
 		var location sql.NullString
 		var timezone sql.NullString
-		var metadata sql.RawBytes
+		var metadata []byte
 		var createdAt sql.NullInt64
 		var updatedAt sql.NullInt64
 		var lastOnlineAt sql.NullInt64

--- a/server/pipeline_group.go
+++ b/server/pipeline_group.go
@@ -550,14 +550,14 @@ WHERE u.id = ge.source_id AND ge.destination_id = $1`
 	users := make([]*GroupUser, 0)
 
 	for rows.Next() {
-		var id sql.RawBytes
+		var id []byte
 		var handle sql.NullString
 		var fullname sql.NullString
 		var avatarURL sql.NullString
 		var lang sql.NullString
 		var location sql.NullString
 		var timezone sql.NullString
-		var metadata sql.RawBytes
+		var metadata []byte
 		var createdAt sql.NullInt64
 		var updatedAt sql.NullInt64
 		var lastOnlineAt sql.NullInt64

--- a/server/pipeline_self.go
+++ b/server/pipeline_self.go
@@ -35,7 +35,7 @@ func (p *pipeline) selfFetch(logger zap.Logger, session *session, envelope *Enve
 	var timezone sql.NullString
 	var location sql.NullString
 	var lang sql.NullString
-	var metadata sql.RawBytes
+	var metadata []byte
 	var avatarURL sql.NullString
 	var verifiedAt sql.NullInt64
 	var createdAt sql.NullInt64

--- a/server/pipeline_user.go
+++ b/server/pipeline_user.go
@@ -34,9 +34,10 @@ func (p *pipeline) usersFetch(logger zap.Logger, session *session, envelope *Env
 
 	counter := 1
 	for _, uid := range userIds {
-		statement := "$" + strconv.Itoa(counter)
 		userID, err := uuid.FromBytes(uid)
 		if err == nil {
+			statement := "$" + strconv.Itoa(counter)
+			counter += 1
 			statements = append(statements, statement)
 			params = append(params, userID.Bytes())
 		}


### PR DESCRIPTION
* Improve logging around topic presence diff processing.
* Use byte slices for most database operations.
* Fix batch user fetch query construction.
* Fix duplicate leaves reported in topic presence diff messages.