### PR TITLE
Update Zap to latest. Add --logtostdout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added `--logtostdout` command line flag to redirect log output to terminal.
+
+### Changed
+- Updated Zap logging library to latest stable version.
+- Command line `--verbose` flag no longer alters the logging output to print to both terminal and file.
+- Log output format is set to JSON.
 
 ## [0.12.1] - 2017-03-28
 ### Added

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -20,24 +20,25 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/gorhill/cronexpr"
-	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
 	"net/url"
 	"os"
+
+	"github.com/gorhill/cronexpr"
+	"github.com/satori/go.uuid"
+	"go.uber.org/zap"
 )
 
 type adminService struct {
 	DSNS   string
-	logger zap.Logger
+	logger *zap.Logger
 }
 
-func AdminParse(args []string, logger zap.Logger) {
+func AdminParse(args []string, logger *zap.Logger) {
 	if len(args) == 0 {
 		logger.Fatal("Admin requires a subcommand. Available commands are: 'create-leaderboard'.")
 	}
 
-	var exec func([]string, zap.Logger)
+	var exec func([]string, *zap.Logger)
 	switch args[0] {
 	case "create-leaderboard":
 		exec = createLeaderboard
@@ -49,7 +50,7 @@ func AdminParse(args []string, logger zap.Logger) {
 	os.Exit(0)
 }
 
-func createLeaderboard(args []string, logger zap.Logger) {
+func createLeaderboard(args []string, logger *zap.Logger) {
 	var dsns string
 	var id string
 	var authoritative bool

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -18,15 +18,15 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"time"
 
-	"math"
 	"nakama/build/generated/migration"
 
 	"github.com/rubenv/sql-migrate"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 const (
@@ -44,12 +44,12 @@ type statusRow struct {
 type migrationService struct {
 	DSNS       string
 	Limit      int
-	logger     zap.Logger
+	logger     *zap.Logger
 	migrations *migrate.AssetMigrationSource
 	db         *sql.DB
 }
 
-func MigrationStartupCheck(logger zap.Logger, db *sql.DB) {
+func MigrationStartupCheck(logger *zap.Logger, db *sql.DB) {
 	migrate.SetTable(migrationTable)
 	ms := &migrate.AssetMigrationSource{
 		Asset:    migration.Asset,
@@ -67,14 +67,14 @@ func MigrationStartupCheck(logger zap.Logger, db *sql.DB) {
 
 	diff := len(migrations) - len(records)
 	if diff > 0 {
-		logger.Warn("DB schema outdated, run `nakama migrate up`", zap.Object("migrations", diff))
+		logger.Warn("DB schema outdated, run `nakama migrate up`", zap.Int("migrations", diff))
 	}
 	if diff < 0 {
-		logger.Warn("DB schema newer, update Nakama", zap.Object("migrations", int64(math.Abs(float64(diff)))))
+		logger.Warn("DB schema newer, update Nakama", zap.Int64("migrations", int64(math.Abs(float64(diff)))))
 	}
 }
 
-func MigrateParse(args []string, logger zap.Logger) {
+func MigrateParse(args []string, logger *zap.Logger) {
 	if len(args) == 0 {
 		logger.Fatal("Migrate requires a subcommand. Available commands are: 'up', 'down', 'redo', 'status'.")
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d332790eaf0dd90a5d91b4fddfd82897055e261ff360d616cf363c0e689ab4f6
-updated: 2017-03-10T18:12:22.221261057Z
+hash: 150ab75d51b17b2fb2b097193ea43bac8e07dfcb8ce0905c115be7e71639f506
+updated: 2017-04-13T23:43:22.128299698+01:00
 imports:
 - name: github.com/armon/go-metrics
   version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
@@ -12,10 +12,11 @@ imports:
 - name: github.com/go-gorp/gorp
   version: 4deece61034873cb5b5416e81abe4cea7bd0da72
 - name: github.com/go-yaml/yaml
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 - name: github.com/gogo/protobuf
   version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
+  - jsonpb
   - proto
 - name: github.com/golang/protobuf
   version: 8ee79997227bf9b34611aee7946ae64735e6fd93
@@ -42,7 +43,20 @@ imports:
 - name: github.com/uber-go/atomic
   version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 - name: github.com/uber-go/zap
-  version: a5783ee4b216a927da8f839c45cfbf9d694e1467
+  version: a2773be06b9ac7c318a3a105b5c310af5730c6b4
+  subpackages:
+  - zapcore
+- name: go.uber.org/atomic
+  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+- name: go.uber.org/zap
+  version: a2773be06b9ac7c318a3a105b5c310af5730c6b4
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore
 - name: golang.org/x/crypto
   version: f6b343c37ca80bfa8ea539da67a0b621f84fab1d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,8 +31,10 @@ import:
 - package: github.com/go-yaml/yaml
   version: v2
 - package: github.com/armon/go-metrics
-- package: github.com/uber-go/zap
-- package: github.com/uber-go/atomic
+- package: go.uber.org/zap
+  version: ~1.1.0
+- package: go.uber.org/atomic
+  version: ~1.2.0
 - package: github.com/satori/go.uuid
 - package: github.com/dgrijalva/jwt-go
   version: ~3.0.0

--- a/server/log.go
+++ b/server/log.go
@@ -1,0 +1,113 @@
+// Copyright 2017 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"os"
+
+	"fmt"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// By default, log all messages with Warn and Error messages to a log file inside Data/Log/<name>.log file. The content will be in JSON.
+// if --verbose is passed, log messages with Debug and higher levels.
+// if --logtostdout is passed, logs are only printed to stdout.
+// In all cases, Error messages trigger the stacktrace to be dumped as well.
+var (
+	VerboseLogging = true
+	StdoutLogging  = false
+)
+
+type loggerEnabler struct{}
+
+func (l *loggerEnabler) Enabled(level zapcore.Level) bool {
+	return VerboseLogging || level > zapcore.DebugLevel
+}
+
+func NewLogger(consoleLogger *zap.Logger, config Config) *zap.Logger {
+	output := os.Stdout
+	if !StdoutLogging {
+		err := os.MkdirAll(filepath.FromSlash(config.GetDataDir()+"/log"), 0755)
+		if err != nil {
+			consoleLogger.Fatal("Could not create log directory", zap.Error(err))
+			return nil
+		}
+
+		output, err = os.Create(filepath.FromSlash(fmt.Sprintf("%v/log/%v.log", config.GetDataDir(), config.GetName())))
+		if err != nil {
+			consoleLogger.Fatal("Could not create log file", zap.Error(err))
+			return nil
+		}
+	}
+
+	logger := NewJSONLogger(output)
+	logger = logger.With(zap.String("server", config.GetName()))
+
+	return logger
+}
+
+func NewConsoleLogger(output *os.File) *zap.Logger {
+	consoleEncoder := zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
+		TimeKey:        "ts",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	})
+
+	core := zapcore.NewCore(consoleEncoder, output, &loggerEnabler{})
+	options := []zap.Option{zap.AddStacktrace(zap.ErrorLevel)}
+
+	return zap.New(core, options...)
+}
+
+func NewJSONLogger(output *os.File) *zap.Logger {
+	jsonEncoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		TimeKey:        "ts",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	})
+
+	core := zapcore.NewCore(jsonEncoder, output, &loggerEnabler{})
+	options := []zap.Option{zap.AddStacktrace(zap.ErrorLevel)}
+
+	return zap.New(core, options...)
+}
+
+func NewMultiLogger(loggers ...*zap.Logger) *zap.Logger {
+	cores := []zapcore.Core{}
+	for _, logger := range loggers {
+		cores = append(cores, logger.Core())
+	}
+
+	teeCore := zapcore.NewTee(cores...)
+	options := []zap.Option{zap.AddStacktrace(zap.ErrorLevel)}
+	return zap.New(teeCore, options...)
+}

--- a/server/message_router.go
+++ b/server/message_router.go
@@ -16,12 +16,12 @@ package server
 
 import (
 	"github.com/gogo/protobuf/proto"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // MessageRouter is responsible for sending a message to a list of presences
 type MessageRouter interface {
-	Send(zap.Logger, []Presence, proto.Message)
+	Send(*zap.Logger, []Presence, proto.Message)
 }
 
 type messageRouterService struct {
@@ -34,7 +34,7 @@ func NewMessageRouterService(registry *SessionRegistry) *messageRouterService {
 	}
 }
 
-func (m *messageRouterService) Send(logger zap.Logger, ps []Presence, msg proto.Message) {
+func (m *messageRouterService) Send(logger *zap.Logger, ps []Presence, msg proto.Message) {
 	if len(ps) == 0 {
 		return
 	}
@@ -50,10 +50,10 @@ func (m *messageRouterService) Send(logger zap.Logger, ps []Presence, msg proto.
 		if session != nil {
 			err := session.SendBytes(payload)
 			if err != nil {
-				logger.Error("Failed to route to", zap.Object("p", p), zap.Error(err))
+				logger.Error("Failed to route to", zap.Any("p", p), zap.Error(err))
 			}
 		} else {
-			logger.Warn("No session to route to", zap.Object("p", p))
+			logger.Warn("No session to route to", zap.Any("p", p))
 		}
 	}
 }

--- a/server/ops_accepter.go
+++ b/server/ops_accepter.go
@@ -26,12 +26,12 @@ import (
 	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // opsService is responsible for serving the dashboard and all of its required resources
 type opsService struct {
-	logger              zap.Logger
+	logger              *zap.Logger
 	version             string
 	config              Config
 	statsService        StatsService
@@ -40,7 +40,7 @@ type opsService struct {
 }
 
 // NewOpsService creates a new opsService
-func NewOpsService(logger zap.Logger, multiLogger zap.Logger, version string, config Config, statsService StatsService) *opsService {
+func NewOpsService(logger *zap.Logger, multiLogger *zap.Logger, version string, config Config, statsService StatsService) *opsService {
 	service := &opsService{
 		logger:       logger,
 		version:      version,

--- a/server/ops_service.go
+++ b/server/ops_service.go
@@ -18,7 +18,7 @@ import (
 	"net"
 	"runtime"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // StatsService is responsible for gathering and reading stats information from metrics
@@ -28,14 +28,14 @@ type StatsService interface {
 }
 
 type statsService struct {
-	logger  zap.Logger
+	logger  *zap.Logger
 	version string
 	config  Config
 	tracker Tracker
 }
 
 // NewStatsService creates a new StatsService
-func NewStatsService(logger zap.Logger, config Config, version string, tracker Tracker) StatsService {
+func NewStatsService(logger *zap.Logger, config Config, version string, tracker Tracker) StatsService {
 	return &statsService{
 		logger:  logger,
 		version: version,

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -18,9 +18,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	"nakama/pkg/social"
+	"go.uber.org/zap"
 
-	"github.com/uber-go/zap"
+	"nakama/pkg/social"
 )
 
 type pipeline struct {
@@ -44,7 +44,7 @@ func NewPipeline(config Config, db *sql.DB, socialClient *social.Client, tracker
 	}
 }
 
-func (p *pipeline) processRequest(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) processRequest(logger *zap.Logger, session *session, envelope *Envelope) {
 	logger.Debug(fmt.Sprintf("Received %T message", envelope.Payload))
 
 	switch envelope.Payload.(type) {

--- a/server/pipeline_friend.go
+++ b/server/pipeline_friend.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
-func (p *pipeline) querySocialGraph(logger zap.Logger, filterQuery string, params []interface{}) ([]*User, error) {
+func (p *pipeline) querySocialGraph(logger *zap.Logger, filterQuery string, params []interface{}) ([]*User, error) {
 	users := []*User{}
 
 	query := `
@@ -80,7 +80,7 @@ FROM users ` + filterQuery
 	return users, nil
 }
 
-func (p *pipeline) addFacebookFriends(logger zap.Logger, userID []byte, accessToken string) {
+func (p *pipeline) addFacebookFriends(logger *zap.Logger, userID []byte, accessToken string) {
 	var tx *sql.Tx
 	var err error
 
@@ -195,7 +195,7 @@ FROM users, user_edge ` + filterQuery
 	return friends, nil
 }
 
-func (p *pipeline) friendAdd(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) friendAdd(l *zap.Logger, session *session, envelope *Envelope) {
 	addFriendRequest := envelope.GetFriendAdd()
 	if len(addFriendRequest.UserId) == 0 {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "User ID must be present"))
@@ -296,7 +296,7 @@ OR source_id = $3`,
 	}
 }
 
-func (p *pipeline) friendRemove(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) friendRemove(l *zap.Logger, session *session, envelope *Envelope) {
 	removeFriendRequest := envelope.GetFriendRemove()
 	if len(removeFriendRequest.UserId) == 0 {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "User ID must be present"))
@@ -364,7 +364,7 @@ func (p *pipeline) friendRemove(l zap.Logger, session *session, envelope *Envelo
 	}
 }
 
-func (p *pipeline) friendBlock(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) friendBlock(l *zap.Logger, session *session, envelope *Envelope) {
 	blockUserRequest := envelope.GetFriendBlock()
 	if len(blockUserRequest.UserId) == 0 {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "User ID must be present"))
@@ -442,7 +442,7 @@ func (p *pipeline) friendBlock(l zap.Logger, session *session, envelope *Envelop
 	}
 }
 
-func (p *pipeline) friendsList(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) friendsList(logger *zap.Logger, session *session, envelope *Envelope) {
 	friends, err := p.getFriends("WHERE id = destination_id AND source_id = $1", session.userID.Bytes())
 	if err != nil {
 		logger.Error("Could not get friends", zap.Error(err))

--- a/server/pipeline_group.go
+++ b/server/pipeline_group.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 type scanner interface {
@@ -89,7 +89,7 @@ func (p *pipeline) extractGroup(r scanner) (*Group, error) {
 	}, nil
 }
 
-func (p *pipeline) groupCreate(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupCreate(logger *zap.Logger, session *session, envelope *Envelope) {
 	g := envelope.GetGroupCreate()
 
 	if g.Name == "" {
@@ -210,7 +210,7 @@ VALUES ($1, $2, $2, $3, 0), ($3, $2, $2, $1, 0)`,
 	}
 }
 
-func (p *pipeline) groupUpdate(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupUpdate(l *zap.Logger, session *session, envelope *Envelope) {
 	//TODO notify members that group has been updated.
 	g := envelope.GetGroupUpdate()
 	groupID, err := uuid.FromBytes(g.GroupId)
@@ -280,7 +280,7 @@ EXISTS (SELECT source_id FROM group_edge WHERE source_id = $1 AND destination_id
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) groupRemove(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupRemove(l *zap.Logger, session *session, envelope *Envelope) {
 	//TODO kick all users out
 	g := envelope.GetGroupRemove()
 
@@ -344,7 +344,7 @@ AND
 	_, err = tx.Exec("DELETE FROM group_edge WHERE source_id = $1 OR destination_id = $1", groupID.Bytes())
 }
 
-func (p *pipeline) groupsFetch(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupsFetch(logger *zap.Logger, session *session, envelope *Envelope) {
 	g := envelope.GetGroupsFetch()
 
 	statements := []string{}
@@ -402,7 +402,7 @@ FROM groups WHERE disabled_at = 0 AND ( `+strings.Join(statements, " OR ")+" )",
 	session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_Groups{Groups: &TGroups{Groups: groups}}})
 }
 
-func (p *pipeline) groupsList(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupsList(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetGroupsList()
 	params := make([]interface{}, 0)
 
@@ -514,7 +514,7 @@ LIMIT $` + strconv.Itoa(len(params))
 	}}})
 }
 
-func (p *pipeline) groupsSelfList(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupsSelfList(logger *zap.Logger, session *session, envelope *Envelope) {
 	envelope.GetGroupsSelfList()
 	rows, err := p.db.Query(`
 SELECT id, creator_id, name, description, avatar_url, lang, utc_offset_ms, metadata, groups.state, count, created_at, groups.updated_at
@@ -545,7 +545,7 @@ WHERE group_edge.destination_id = $1 AND disabled_at = 0 AND (group_edge.state =
 	session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_Groups{Groups: &TGroups{Groups: groups}}})
 }
 
-func (p *pipeline) groupUsersList(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupUsersList(l *zap.Logger, session *session, envelope *Envelope) {
 	g := envelope.GetGroupUsersList()
 
 	groupID, err := uuid.FromBytes(g.GroupId)
@@ -614,7 +614,7 @@ WHERE u.id = ge.source_id AND ge.destination_id = $1`
 	session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_GroupUsers{GroupUsers: &TGroupUsers{Users: users}}})
 }
 
-func (p *pipeline) groupJoin(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupJoin(l *zap.Logger, session *session, envelope *Envelope) {
 	g := envelope.GetGroupJoin()
 
 	groupID, err := uuid.FromBytes(g.GroupId)
@@ -692,7 +692,7 @@ VALUES ($1, $2, $2, $3, $4), ($3, $2, $2, $1, $4)`,
 	}
 }
 
-func (p *pipeline) groupLeave(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupLeave(l *zap.Logger, session *session, envelope *Envelope) {
 	g := envelope.GetGroupLeave()
 
 	groupID, err := uuid.FromBytes(g.GroupId)
@@ -802,7 +802,7 @@ OR
 	}
 }
 
-func (p *pipeline) groupUserAdd(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupUserAdd(l *zap.Logger, session *session, envelope *Envelope) {
 	g := envelope.GetGroupUserAdd()
 
 	groupID, err := uuid.FromBytes(g.GroupId)
@@ -894,7 +894,7 @@ DO UPDATE SET state = 1, updated_at = $2::INT`,
 	}
 }
 
-func (p *pipeline) groupUserKick(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupUserKick(l *zap.Logger, session *session, envelope *Envelope) {
 	// TODO Force kick the user out.
 	g := envelope.GetGroupUserKick()
 
@@ -991,7 +991,7 @@ AND
 	}
 }
 
-func (p *pipeline) groupUserPromote(l zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) groupUserPromote(l *zap.Logger, session *session, envelope *Envelope) {
 	g := envelope.GetGroupUserPromote()
 
 	groupID, err := uuid.FromBytes(g.GroupId)

--- a/server/pipeline_leaderboard.go
+++ b/server/pipeline_leaderboard.go
@@ -19,11 +19,12 @@ import (
 	"database/sql"
 	"encoding/gob"
 	"encoding/json"
-	"github.com/gorhill/cronexpr"
-	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
 	"strconv"
 	"strings"
+
+	"github.com/gorhill/cronexpr"
+	"github.com/satori/go.uuid"
+	"go.uber.org/zap"
 )
 
 type leaderboardCursor struct {
@@ -41,7 +42,7 @@ type leaderboardRecordListCursor struct {
 	Id        []byte
 }
 
-func (p *pipeline) leaderboardsList(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) leaderboardsList(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetLeaderboardsList()
 
 	limit := incoming.Limit
@@ -133,7 +134,7 @@ func (p *pipeline) leaderboardsList(logger zap.Logger, session *session, envelop
 	}}})
 }
 
-func (p *pipeline) leaderboardRecordWrite(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) leaderboardRecordWrite(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetLeaderboardRecordWrite()
 	if len(incoming.LeaderboardId) == 0 {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Leaderboard ID must be present"))
@@ -293,7 +294,7 @@ func (p *pipeline) leaderboardRecordWrite(logger zap.Logger, session *session, e
 	}}}})
 }
 
-func (p *pipeline) leaderboardRecordsFetch(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) leaderboardRecordsFetch(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetLeaderboardRecordsFetch()
 	leaderboardIds := incoming.LeaderboardIds
 	if len(leaderboardIds) == 0 {
@@ -420,7 +421,7 @@ func (p *pipeline) leaderboardRecordsFetch(logger zap.Logger, session *session, 
 	}}})
 }
 
-func (p *pipeline) leaderboardRecordsList(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) leaderboardRecordsList(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetLeaderboardRecordsList()
 
 	if len(incoming.LeaderboardId) == 0 {
@@ -623,7 +624,7 @@ func (p *pipeline) leaderboardRecordsList(logger zap.Logger, session *session, e
 	p.normalizeAndSendLeaderboardRecords(logger, session, envelope, leaderboardRecords, outgoingCursor)
 }
 
-func (p *pipeline) loadLeaderboardRecordsHaystack(logger zap.Logger, session *session, envelope *Envelope, leaderboardId, findOwnerId []byte, currentExpiresAt, limit, sortOrder int64, query string, params []interface{}) {
+func (p *pipeline) loadLeaderboardRecordsHaystack(logger *zap.Logger, session *session, envelope *Envelope, leaderboardId, findOwnerId []byte, currentExpiresAt, limit, sortOrder int64, query string, params []interface{}) {
 	// Find the owner's record.
 	var id []byte
 	var score int64
@@ -802,7 +803,7 @@ func (p *pipeline) loadLeaderboardRecordsHaystack(logger zap.Logger, session *se
 	p.normalizeAndSendLeaderboardRecords(logger, session, envelope, leaderboardRecords, outgoingCursor)
 }
 
-func (p *pipeline) normalizeAndSendLeaderboardRecords(logger zap.Logger, session *session, envelope *Envelope, records []*LeaderboardRecord, cursor []byte) {
+func (p *pipeline) normalizeAndSendLeaderboardRecords(logger *zap.Logger, session *session, envelope *Envelope, records []*LeaderboardRecord, cursor []byte) {
 	var bestRank int64
 	for _, record := range records {
 		if record.Rank != 0 && record.Rank < bestRank {

--- a/server/pipeline_link_unlink.go
+++ b/server/pipeline_link_unlink.go
@@ -17,12 +17,13 @@ package server
 import (
 	"strconv"
 
-	"github.com/uber-go/zap"
-	"golang.org/x/crypto/bcrypt"
 	"strings"
+
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
 )
 
-func (p *pipeline) linkID(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkID(logger *zap.Logger, session *session, envelope *Envelope) {
 	// Route to correct link handler
 	switch envelope.GetLink().Payload.(type) {
 	case *TLink_Device:
@@ -46,7 +47,7 @@ func (p *pipeline) linkID(logger zap.Logger, session *session, envelope *Envelop
 	}
 }
 
-func (p *pipeline) linkDevice(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkDevice(logger *zap.Logger, session *session, envelope *Envelope) {
 	deviceID := envelope.GetLink().GetDevice()
 	if deviceID == "" {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Device ID is required"))
@@ -111,7 +112,7 @@ func (p *pipeline) linkDevice(logger zap.Logger, session *session, envelope *Env
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) linkFacebook(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkFacebook(logger *zap.Logger, session *session, envelope *Envelope) {
 	accessToken := envelope.GetLink().GetFacebook()
 	if accessToken == "" {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Access token is required"))
@@ -154,7 +155,7 @@ AND NOT EXISTS
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) linkGoogle(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkGoogle(logger *zap.Logger, session *session, envelope *Envelope) {
 	accessToken := envelope.GetLink().GetGoogle()
 	if accessToken == "" {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Access token is required"))
@@ -195,7 +196,7 @@ AND NOT EXISTS
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) linkGameCenter(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkGameCenter(logger *zap.Logger, session *session, envelope *Envelope) {
 	gc := envelope.GetLink().GetGameCenter()
 	if gc == nil || gc.PlayerId == "" || gc.BundleId == "" || gc.Timestamp == 0 || gc.Salt == "" || gc.Signature == "" || gc.PublicKeyUrl == "" {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Game Center credentials required"))
@@ -233,7 +234,7 @@ AND NOT EXISTS
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) linkSteam(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkSteam(logger *zap.Logger, session *session, envelope *Envelope) {
 	if p.config.GetSocial().Steam.PublisherKey == "" || p.config.GetSocial().Steam.AppID == 0 {
 		session.Send(ErrorMessage(envelope.CollationId, USER_LINK_PROVIDER_UNAVAILABLE, "Steam link not available"))
 		return
@@ -279,7 +280,7 @@ AND NOT EXISTS
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) linkEmail(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkEmail(logger *zap.Logger, session *session, envelope *Envelope) {
 	email := envelope.GetLink().GetEmail()
 	if email == nil {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Invalid payload"))
@@ -328,7 +329,7 @@ AND NOT EXISTS
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) linkCustom(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) linkCustom(logger *zap.Logger, session *session, envelope *Envelope) {
 	customID := envelope.GetLink().GetCustom()
 	if customID == "" {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Custom ID is required"))
@@ -365,7 +366,7 @@ AND NOT EXISTS
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) unlinkID(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) unlinkID(logger *zap.Logger, session *session, envelope *Envelope) {
 	// Select correct unlink query
 	var query string
 	var param interface{}

--- a/server/pipeline_match.go
+++ b/server/pipeline_match.go
@@ -16,10 +16,10 @@ package server
 
 import (
 	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
-func (p *pipeline) matchCreate(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) matchCreate(logger *zap.Logger, session *session, envelope *Envelope) {
 	matchID := uuid.NewV4()
 
 	handle := session.handle.Load()
@@ -41,7 +41,7 @@ func (p *pipeline) matchCreate(logger zap.Logger, session *session, envelope *En
 	}}})
 }
 
-func (p *pipeline) matchJoin(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) matchJoin(logger *zap.Logger, session *session, envelope *Envelope) {
 	matchIDBytes := envelope.GetMatchJoin().MatchId
 	matchID, err := uuid.FromBytes(matchIDBytes)
 	if err != nil {
@@ -85,7 +85,7 @@ func (p *pipeline) matchJoin(logger zap.Logger, session *session, envelope *Enve
 	}}})
 }
 
-func (p *pipeline) matchLeave(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) matchLeave(logger *zap.Logger, session *session, envelope *Envelope) {
 	matchIDBytes := envelope.GetMatchLeave().MatchId
 	matchID, err := uuid.FromBytes(matchIDBytes)
 	if err != nil {
@@ -119,7 +119,7 @@ func (p *pipeline) matchLeave(logger zap.Logger, session *session, envelope *Env
 	session.Send(&Envelope{CollationId: envelope.CollationId})
 }
 
-func (p *pipeline) matchDataSend(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) matchDataSend(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetMatchDataSend()
 	matchIDBytes := incoming.MatchId
 	matchID, err := uuid.FromBytes(matchIDBytes)

--- a/server/pipeline_self.go
+++ b/server/pipeline_self.go
@@ -20,10 +20,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
-func (p *pipeline) selfFetch(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) selfFetch(logger *zap.Logger, session *session, envelope *Envelope) {
 	var fullname sql.NullString
 	var handle sql.NullString
 	var email sql.NullString
@@ -107,7 +107,7 @@ WHERE u.id = $1`,
 	session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_Self{Self: &TSelf{Self: s}}})
 }
 
-func (p *pipeline) selfUpdate(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) selfUpdate(logger *zap.Logger, session *session, envelope *Envelope) {
 	update := envelope.GetSelfUpdate()
 	index := 1
 	statements := make([]string, 0)

--- a/server/pipeline_storage.go
+++ b/server/pipeline_storage.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 func (p *pipeline) fetchStorageData(r scanner) (*TStorageData_StorageData, error) {
@@ -61,7 +61,7 @@ func (p *pipeline) fetchStorageData(r scanner) (*TStorageData_StorageData, error
 	}, nil
 }
 
-func (p *pipeline) storageFetch(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) storageFetch(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetStorageFetch()
 	storageData := make([]*TStorageData_StorageData, 0)
 
@@ -120,7 +120,7 @@ WHERE bucket = $1 AND collection = $2 AND user_id = $3 AND record = $4 AND delet
 	session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_StorageData{StorageData: &TStorageData{Data: storageData}}})
 }
 
-func (p *pipeline) storageWrite(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) storageWrite(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetStorageWrite()
 
 	tx, err := p.db.Begin()
@@ -226,7 +226,7 @@ DO UPDATE SET value = $6, version = $7, updated_at = $8
 	}
 }
 
-func (p *pipeline) storageRemove(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) storageRemove(logger *zap.Logger, session *session, envelope *Envelope) {
 	incoming := envelope.GetStorageRemove()
 
 	tx, err := p.db.Begin()

--- a/server/pipeline_user.go
+++ b/server/pipeline_user.go
@@ -19,10 +19,10 @@ import (
 	"strings"
 
 	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
-func (p *pipeline) usersFetch(logger zap.Logger, session *session, envelope *Envelope) {
+func (p *pipeline) usersFetch(logger *zap.Logger, session *session, envelope *Envelope) {
 	userIds := envelope.GetUsersFetch().UserIds
 	if len(userIds) == 0 {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "List must contain at least one user ID"))

--- a/server/presence_notifier.go
+++ b/server/presence_notifier.go
@@ -18,19 +18,19 @@ import (
 	"strings"
 
 	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // PresenceNotifier is responsible for updating clients when a presence change occurs
 type presenceNotifier struct {
-	logger        zap.Logger
+	logger        *zap.Logger
 	name          string
 	tracker       Tracker
 	messageRouter MessageRouter
 }
 
 // NewPresenceNotifier creates a new PresenceNotifier
-func NewPresenceNotifier(logger zap.Logger, name string, tracker Tracker, messageRouter MessageRouter) *presenceNotifier {
+func NewPresenceNotifier(logger *zap.Logger, name string, tracker Tracker, messageRouter MessageRouter) *presenceNotifier {
 	return &presenceNotifier{
 		logger:        logger,
 		name:          name,
@@ -116,7 +116,7 @@ func (pn *presenceNotifier) HandleDiff(joins, leaves []Presence) {
 				pn.handleDiffTopic(t, to, tjs, nil)
 			}
 		default:
-			pn.logger.Warn("Skipping presence notifications for unknown topic", zap.Object("topic", topic))
+			pn.logger.Warn("Skipping presence notifications for unknown topic", zap.Any("topic", topic))
 		}
 	}
 
@@ -150,7 +150,7 @@ func (pn *presenceNotifier) HandleDiff(joins, leaves []Presence) {
 			t := &TopicId{Id: &TopicId_GroupId{GroupId: uuid.FromStringOrNil(splitTopic[1]).Bytes()}}
 			pn.handleDiffTopic(t, to, nil, tls)
 		default:
-			pn.logger.Warn("Skipping presence notifications for unknown topic", zap.Object("topic", topic))
+			pn.logger.Warn("Skipping presence notifications for unknown topic", zap.Any("topic", topic))
 		}
 	}
 }
@@ -182,7 +182,7 @@ func (pn *presenceNotifier) handleDiffMatch(matchID []byte, to, joins, leaves []
 		}
 		msg.Leaves = muLeaves
 	}
-	pn.logger.Debug("Routing match diff", zap.Object("to", to), zap.Object("msg", msg))
+	pn.logger.Debug("Routing match diff", zap.Any("to", to), zap.Any("msg", msg))
 
 	// Send the presence notification.
 	pn.messageRouter.Send(pn.logger, to, &Envelope{Payload: &Envelope_MatchPresence{MatchPresence: msg}})
@@ -214,7 +214,7 @@ func (pn *presenceNotifier) handleDiffTopic(topic *TopicId, to, joins, leaves []
 		}
 		msg.Leaves = tuLeaves
 	}
-	pn.logger.Debug("Routing topic diff", zap.Object("to", to), zap.Object("msg", msg))
+	pn.logger.Debug("Routing topic diff", zap.Any("to", to), zap.Any("msg", msg))
 
 	// Send the presence notification.
 	pn.messageRouter.Send(pn.logger, to, &Envelope{Payload: &Envelope_TopicPresence{TopicPresence: msg}})

--- a/server/session_registry.go
+++ b/server/session_registry.go
@@ -19,20 +19,20 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/satori/go.uuid"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // SessionRegistry maintains a list of sessions to their IDs. This is thread-safe.
 type SessionRegistry struct {
 	sync.RWMutex
-	logger   zap.Logger
+	logger   *zap.Logger
 	config   Config
 	tracker  Tracker
 	sessions map[uuid.UUID]*session
 }
 
 // NewSessionRegistry creates a new SessionRegistry
-func NewSessionRegistry(logger zap.Logger, config Config, tracker Tracker) *SessionRegistry {
+func NewSessionRegistry(logger *zap.Logger, config Config, tracker Tracker) *SessionRegistry {
 	return &SessionRegistry{
 		logger:   logger,
 		config:   config,
@@ -62,7 +62,7 @@ func (a *SessionRegistry) Get(sessionID uuid.UUID) *session {
 	return s
 }
 
-func (a *SessionRegistry) add(userID uuid.UUID, handle string, lang string, conn *websocket.Conn, processRequest func(logger zap.Logger, session *session, envelope *Envelope)) {
+func (a *SessionRegistry) add(userID uuid.UUID, handle string, lang string, conn *websocket.Conn, processRequest func(logger *zap.Logger, session *session, envelope *Envelope)) {
 	s := NewSession(a.logger, a.config, userID, handle, lang, conn, a.remove)
 	a.Lock()
 	a.sessions[s.id] = s


### PR DESCRIPTION
This introduces a breaking change on how logging was done on previous versions of Nakama.

- Update Zap to latest version.
- Add `--logtostdout` option. This will *only* print the logs to Stdout.
- Tweaked `--verbose` option. This will *only* set the log level printed to Debug and over. Without this flag, Info level logs are printed.
- Log format is set to only JSON. This includes even the messages printed on server start. This is because of Zap no longer offers plain-text logging. 
- The server start messages are printed to both file and Stdout, unless you set the `--logtostdout` flag, in which case they are only printed to stdout and the file is skipped.
- If there are any Error-level logs, the stacktrace is automatically printed.