### PR TITLE
Ban users and create groups from within the Runtime environment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,13 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Added
 - New storage list feature.
+- Ban users and create groups from within the Runtime environment.
 
 ### Changed
 - Run Facebook friends import after registration completes.
-- Streamline command line flags to be inline with the config file. 
-
-### Changed
+- Streamline command line flags to be inline with the config file.
 - Restructure and stabilize API messages.
-- Add batch operations Friends social graph.
+- Update Runtime modules to uses plural function names for batch operations. (`users_fetch_id` and `users_fetch_handle`)
 
 ### Fixed
 - Invocation type was always set to "Before" in After Runtime scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Run Facebook friends import after registration completes.
 - Streamline command line flags to be inline with the config file.
 - Restructure and stabilize API messages.
-- Update Runtime modules to uses plural function names for batch operations. (`users_fetch_id` and `users_fetch_handle`)
+- Update Runtime modules to use plural function names for batch operations. (`users_fetch_id` and `users_fetch_handle`)
 
 ### Fixed
 - Invocation type was always set to "Before" in After Runtime scripts.

--- a/server/api.proto
+++ b/server/api.proto
@@ -213,50 +213,48 @@ message Envelope {
     TGroupUsersAdd group_users_add = 26;
     TGroupUsersKick group_users_kick = 27;
     TGroupUsersPromote group_users_promote = 28;
-    TGroup group = 29;
-    TGroups groups = 30;
-    TGroupUsers group_users = 31;
+    TGroups groups = 29;
+    TGroupUsers group_users = 30;
 
-    TTopicsJoin topics_join = 32;
-    TTopicsLeave topics_leave = 33;
-    TTopicMessageSend topic_message_send = 34;
-    TTopicMessagesList topic_messages_list = 35;
-    TTopics topics = 36;
-    TTopicMessageAck topic_message_ack = 37;
-    TopicMessage topic_message = 38;
-    TTopicMessages topic_messages = 39;
-    TopicPresence topic_presence = 40;
+    TTopicsJoin topics_join = 31;
+    TTopicsLeave topics_leave = 32;
+    TTopicMessageSend topic_message_send = 33;
+    TTopicMessagesList topic_messages_list = 34;
+    TTopics topics = 35;
+    TTopicMessageAck topic_message_ack = 36;
+    TopicMessage topic_message = 37;
+    TTopicMessages topic_messages = 38;
+    TopicPresence topic_presence = 39;
 
-    TMatchCreate match_create = 41;
-    TMatchesJoin matches_join = 42;
-    TMatchesLeave matches_leave = 43;
-    MatchDataSend match_data_send = 44;
-    TMatch match = 45;
-    TMatches matches = 46;
-    MatchData match_data = 47;
-    MatchPresence match_presence = 48;
+    TMatchCreate match_create = 40;
+    TMatchesJoin matches_join = 41;
+    TMatchesLeave matches_leave = 42;
+    MatchDataSend match_data_send = 43;
+    TMatch match = 44;
+    TMatches matches = 45;
+    MatchData match_data = 46;
+    MatchPresence match_presence = 47;
 
-    TStorageList storage_list = 49;
-    TStorageFetch storage_fetch = 50;
-    TStorageWrite storage_write = 51;
-    TStorageRemove storage_remove = 52;
-    TStorageData storage_data = 53;
-    TStorageKeys storage_keys = 54;
+    TStorageList storage_list = 48;
+    TStorageFetch storage_fetch = 49;
+    TStorageWrite storage_write = 50;
+    TStorageRemove storage_remove = 51;
+    TStorageData storage_data = 52;
+    TStorageKeys storage_keys = 53;
 
-    TLeaderboardsList leaderboards_list = 55;
-    TLeaderboardRecordsWrite leaderboard_records_write = 56;
-    TLeaderboardRecordsFetch leaderboard_records_fetch = 57;
-    TLeaderboardRecordsList leaderboard_records_list = 58;
-    TLeaderboards leaderboards = 59;
+    TLeaderboardsList leaderboards_list = 54;
+    TLeaderboardRecordsWrite leaderboard_records_write = 55;
+    TLeaderboardRecordsFetch leaderboard_records_fetch = 56;
+    TLeaderboardRecordsList leaderboard_records_list = 57;
+    TLeaderboards leaderboards = 58;
+    TLeaderboardRecords leaderboard_records = 59;
 
-    TLeaderboardRecords leaderboard_records = 60;
+    TMatchmakeAdd matchmake_add = 60;
+    TMatchmakeRemove matchmake_remove = 61;
+    TMatchmakeTicket matchmake_ticket = 62;
+    MatchmakeMatched matchmake_matched = 63;
 
-    TMatchmakeAdd matchmake_add = 61;
-    TMatchmakeRemove matchmake_remove = 62;
-    TMatchmakeTicket matchmake_ticket = 63;
-    MatchmakeMatched matchmake_matched = 64;
-
-    TRpc rpc = 65;
+    TRpc rpc = 64;
   }
 }
 
@@ -509,7 +507,7 @@ message Group {
 /**
  * TGroupsCreate creates a new group.
  *
- * @returns TGroup
+ * @returns TGroups
  *
  * NOTE: The server only processes the first item of the list, and will ignore and logs a warning message for other items.
  */
@@ -527,13 +525,6 @@ message TGroupsCreate {
     bool private = 6;
   }
   repeated GroupCreate groups = 1;
-}
-
-/**
- * TGroup contains the group information.
- */
-message TGroup {
-  Group group = 1;
 }
 
 /**

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -1,0 +1,192 @@
+package server
+
+import (
+	"go.uber.org/zap"
+	"strings"
+	"github.com/satori/go.uuid"
+	"strconv"
+	"encoding/json"
+	"database/sql"
+	"errors"
+	"golang.org/x/tools/go/gcimporter15/testdata"
+)
+
+func extractGroup(r scanner) (*Group, error) {
+	var id []byte
+	var creatorID []byte
+	var name sql.NullString
+	var description sql.NullString
+	var avatarURL sql.NullString
+	var lang sql.NullString
+	var utcOffsetMs sql.NullInt64
+	var metadata []byte
+	var state sql.NullInt64
+	var count sql.NullInt64
+	var createdAt sql.NullInt64
+	var updatedAt sql.NullInt64
+
+	err := r.Scan(&id, &creatorID, &name,
+		&description, &avatarURL, &lang,
+		&utcOffsetMs, &metadata, &state,
+		&count, &createdAt, &updatedAt)
+
+	if err != nil {
+		return &Group{}, err
+	}
+
+	desc := ""
+	if description.Valid {
+		desc = description.String
+	}
+
+	avatar := ""
+	if avatarURL.Valid {
+		avatar = avatarURL.String
+	}
+
+	private := state.Int64 == 1
+
+	return &Group{
+		Id:          id,
+		CreatorId:   creatorID,
+		Name:        name.String,
+		Description: desc,
+		AvatarUrl:   avatar,
+		Lang:        lang.String,
+		UtcOffsetMs: utcOffsetMs.Int64,
+		Metadata:    metadata,
+		Private:     private,
+		Count:       count.Int64,
+		CreatedAt:   createdAt.Int64,
+		UpdatedAt:   updatedAt.Int64,
+	}, nil
+}
+
+func groupCreate(logger *zap.Logger, db *sql.DB, session *session, envelope *Envelope) {
+	e := envelope.GetGroupsCreate()
+
+	if len(e.Groups) == 0 {
+		session.Send(ErrorMessageBadInput(envelope.CollationId, "At least one item must be present"))
+		return
+	} else if len(e.Groups) > 1 {
+		logger.Warn("There are more than one item passed to the request - only processing the first item.")
+	}
+
+	g := e.Groups[0]
+	if g.Name == "" {
+		session.Send(ErrorMessageBadInput(envelope.CollationId, "Group name is mandatory."))
+		return
+	}
+
+	var group *Group
+
+	tx, err := db.Begin()
+	if err != nil {
+		logger.Error("Could not create group", zap.Error(err))
+		session.Send(ErrorMessageBadInput(envelope.CollationId, "Could not create group"))
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			logger.Error("Could not create group", zap.Error(err))
+			if tx != nil {
+				txErr := tx.Rollback()
+				if txErr != nil {
+					logger.Error("Could not rollback transaction", zap.Error(txErr))
+				}
+			}
+			if strings.HasSuffix(err.Error(), "violates unique constraint \"groups_name_key\"") {
+				session.Send(ErrorMessage(envelope.CollationId, GROUP_NAME_INUSE, "Name is in use"))
+			} else {
+				session.Send(ErrorMessageRuntimeException(envelope.CollationId, "Could not create group"))
+			}
+		} else {
+			err = tx.Commit()
+			if err != nil {
+				logger.Error("Could not commit transaction", zap.Error(err))
+				session.Send(ErrorMessageRuntimeException(envelope.CollationId, "Could not create group"))
+			} else {
+				logger.Info("Created new group", zap.String("name", group.Name))
+				session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_Group{Group: &TGroup{Group: group}}})
+			}
+		}
+	}()
+
+	state := 0
+	if g.Private {
+		state = 1
+	}
+
+	columns := make([]string, 0)
+	params := make([]string, 0)
+	values := make([]interface{}, 5)
+
+	updatedAt := nowMs()
+
+	values[0] = uuid.NewV4().Bytes()
+	values[1] = session.userID.Bytes()
+	values[2] = g.Name
+	values[3] = state
+	values[4] = updatedAt
+
+	if g.Description != "" {
+		columns = append(columns, "description")
+		params = append(params, "$"+strconv.Itoa(len(values)+1))
+		values = append(values, g.Description)
+	}
+
+	if g.AvatarUrl != "" {
+		columns = append(columns, "avatar_url")
+		params = append(params, "$"+strconv.Itoa(len(values)+1))
+		values = append(values, g.AvatarUrl)
+	}
+
+	if g.Lang != "" {
+		columns = append(columns, "lang")
+		params = append(params, "$"+strconv.Itoa(len(values)+1))
+		values = append(values, g.Lang)
+	}
+
+	if g.Metadata != nil {
+		// Make this `var js interface{}` if we want to allow top-level JSON arrays.
+		var maybeJSON map[string]interface{}
+		if json.Unmarshal(g.Metadata, &maybeJSON) != nil {
+			session.Send(ErrorMessageBadInput(envelope.CollationId, "Metadata must be a valid JSON object"))
+			return
+		}
+
+		columns = append(columns, "metadata")
+		params = append(params, "$"+strconv.Itoa(len(values)))
+		values = append(values, g.Metadata)
+	}
+
+	r := tx.QueryRow(`
+INSERT INTO groups (id, creator_id, name, state, count, created_at, updated_at, `+strings.Join(columns, ", ")+")"+`
+VALUES ($1, $2, $3, $4, 1, $5, $5, `+strings.Join(params, ",")+")"+`
+RETURNING id, creator_id, name, description, avatar_url, lang, utc_offset_ms, metadata, state, count, created_at, updated_at
+`, values...)
+
+	group, err = extractGroup(r)
+	if err != nil {
+		return
+	}
+
+	res, err := tx.Exec(`
+INSERT INTO group_edge (source_id, position, updated_at, destination_id, state)
+VALUES ($1, $2, $2, $3, 0), ($3, $2, $2, $1, 0)`,
+		group.Id, updatedAt, session.userID.Bytes())
+
+	if err != nil {
+		return
+	}
+
+	rowAffected, err := res.RowsAffected()
+	if err != nil {
+		return
+	}
+	if rowAffected == 0 {
+		err = errors.New("Could not insert into group_edge table")
+		return
+	}
+}

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -1,15 +1,38 @@
+// Copyright 2017 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (
-	"go.uber.org/zap"
-	"strings"
-	"github.com/satori/go.uuid"
-	"strconv"
-	"encoding/json"
 	"database/sql"
 	"errors"
-	"golang.org/x/tools/go/gcimporter15/testdata"
+	"strconv"
+	"strings"
+
+	"github.com/satori/go.uuid"
+	"go.uber.org/zap"
 )
+
+type GroupCreateParam struct {
+	Name        string    // mandatory
+	Creator     uuid.UUID // mandatory
+	Description string
+	AvatarURL   string
+	Lang        string
+	Metadata    []byte
+	Private     bool
+}
 
 func extractGroup(r scanner) (*Group, error) {
 	var id []byte
@@ -62,56 +85,61 @@ func extractGroup(r scanner) (*Group, error) {
 	}, nil
 }
 
-func groupCreate(logger *zap.Logger, db *sql.DB, session *session, envelope *Envelope) {
-	e := envelope.GetGroupsCreate()
-
-	if len(e.Groups) == 0 {
-		session.Send(ErrorMessageBadInput(envelope.CollationId, "At least one item must be present"))
-		return
-	} else if len(e.Groups) > 1 {
-		logger.Warn("There are more than one item passed to the request - only processing the first item.")
+func GroupsCreate(logger *zap.Logger, db *sql.DB, groupCreateParams []*GroupCreateParam) ([]*Group, error) {
+	if groupCreateParams == nil || len(groupCreateParams) == 0 {
+		return nil, errors.New("Could not create groups. At least one group param must be supplied")
 	}
 
-	g := e.Groups[0]
-	if g.Name == "" {
-		session.Send(ErrorMessageBadInput(envelope.CollationId, "Group name is mandatory."))
-		return
-	}
-
-	var group *Group
-
+	groups := make([]*Group, 0)
 	tx, err := db.Begin()
 	if err != nil {
-		logger.Error("Could not create group", zap.Error(err))
-		session.Send(ErrorMessageBadInput(envelope.CollationId, "Could not create group"))
-		return
+		logger.Error("Could not create groups", zap.Error(err))
+		return nil, err
 	}
 
 	defer func() {
 		if err != nil {
-			logger.Error("Could not create group", zap.Error(err))
+			logger.Error("Could not create groups", zap.Error(err))
 			if tx != nil {
 				txErr := tx.Rollback()
 				if txErr != nil {
 					logger.Error("Could not rollback transaction", zap.Error(txErr))
 				}
 			}
-			if strings.HasSuffix(err.Error(), "violates unique constraint \"groups_name_key\"") {
-				session.Send(ErrorMessage(envelope.CollationId, GROUP_NAME_INUSE, "Name is in use"))
-			} else {
-				session.Send(ErrorMessageRuntimeException(envelope.CollationId, "Could not create group"))
-			}
 		} else {
 			err = tx.Commit()
 			if err != nil {
 				logger.Error("Could not commit transaction", zap.Error(err))
-				session.Send(ErrorMessageRuntimeException(envelope.CollationId, "Could not create group"))
 			} else {
-				logger.Info("Created new group", zap.String("name", group.Name))
-				session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_Group{Group: &TGroup{Group: group}}})
+				groupNames := make([]string, 0)
+				for _, p := range groups {
+					groupNames = append(groupNames, p.Name)
+				}
+				logger.Info("Created new groups", zap.Strings("names", groupNames))
 			}
 		}
 	}()
+
+	for _, g := range groupCreateParams {
+		newGroup, err := groupCreate(tx, g)
+		if err != nil {
+			logger.Warn("Could not create group", zap.String("name", g.Name), zap.Error(err))
+			return nil, err
+		}
+
+		groups = append(groups, newGroup)
+	}
+
+	return groups, err
+}
+
+func groupCreate(tx *sql.Tx, g *GroupCreateParam) (*Group, error) {
+	if g.Name == "" {
+		return nil, errors.New("Group name must not be empty")
+	}
+	if uuid.Equal(uuid.Nil, g.Creator) {
+		return nil, errors.New("Group creator must be set")
+	}
 
 	state := 0
 	if g.Private {
@@ -125,7 +153,7 @@ func groupCreate(logger *zap.Logger, db *sql.DB, session *session, envelope *Env
 	updatedAt := nowMs()
 
 	values[0] = uuid.NewV4().Bytes()
-	values[1] = session.userID.Bytes()
+	values[1] = g.Creator.Bytes()
 	values[2] = g.Name
 	values[3] = state
 	values[4] = updatedAt
@@ -136,10 +164,10 @@ func groupCreate(logger *zap.Logger, db *sql.DB, session *session, envelope *Env
 		values = append(values, g.Description)
 	}
 
-	if g.AvatarUrl != "" {
+	if g.AvatarURL != "" {
 		columns = append(columns, "avatar_url")
 		params = append(params, "$"+strconv.Itoa(len(values)+1))
-		values = append(values, g.AvatarUrl)
+		values = append(values, g.AvatarURL)
 	}
 
 	if g.Lang != "" {
@@ -149,15 +177,8 @@ func groupCreate(logger *zap.Logger, db *sql.DB, session *session, envelope *Env
 	}
 
 	if g.Metadata != nil {
-		// Make this `var js interface{}` if we want to allow top-level JSON arrays.
-		var maybeJSON map[string]interface{}
-		if json.Unmarshal(g.Metadata, &maybeJSON) != nil {
-			session.Send(ErrorMessageBadInput(envelope.CollationId, "Metadata must be a valid JSON object"))
-			return
-		}
-
 		columns = append(columns, "metadata")
-		params = append(params, "$"+strconv.Itoa(len(values)))
+		params = append(params, "$"+strconv.Itoa(len(values)+1))
 		values = append(values, g.Metadata)
 	}
 
@@ -167,26 +188,28 @@ VALUES ($1, $2, $3, $4, 1, $5, $5, `+strings.Join(params, ",")+")"+`
 RETURNING id, creator_id, name, description, avatar_url, lang, utc_offset_ms, metadata, state, count, created_at, updated_at
 `, values...)
 
-	group, err = extractGroup(r)
+	group, err := extractGroup(r)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	res, err := tx.Exec(`
 INSERT INTO group_edge (source_id, position, updated_at, destination_id, state)
 VALUES ($1, $2, $2, $3, 0), ($3, $2, $2, $1, 0)`,
-		group.Id, updatedAt, session.userID.Bytes())
+		group.Id, updatedAt, g.Creator.Bytes())
 
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	rowAffected, err := res.RowsAffected()
 	if err != nil {
-		return
+		return nil, err
 	}
 	if rowAffected == 0 {
 		err = errors.New("Could not insert into group_edge table")
-		return
+		return nil, err
 	}
+
+	return group, nil
 }

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -54,7 +54,7 @@ func extractGroup(r scanner) (*Group, error) {
 		&count, &createdAt, &updatedAt)
 
 	if err != nil {
-		return &Group{}, err
+		return nil, err
 	}
 
 	desc := ""
@@ -115,7 +115,7 @@ func GroupsCreate(logger *zap.Logger, db *sql.DB, groupCreateParams []*GroupCrea
 				for _, p := range groups {
 					groupNames = append(groupNames, p.Name)
 				}
-				logger.Info("Created new groups", zap.Strings("names", groupNames))
+				logger.Debug("Created new groups", zap.Strings("names", groupNames))
 			}
 		}
 	}()
@@ -148,15 +148,14 @@ func groupCreate(tx *sql.Tx, g *GroupCreateParam) (*Group, error) {
 
 	columns := make([]string, 0)
 	params := make([]string, 0)
-	values := make([]interface{}, 5)
 
-	updatedAt := nowMs()
-
-	values[0] = uuid.NewV4().Bytes()
-	values[1] = g.Creator.Bytes()
-	values[2] = g.Name
-	values[3] = state
-	values[4] = updatedAt
+	values := []interface{}{
+		uuid.NewV4().Bytes(),
+		g.Creator.Bytes(),
+		g.Name,
+		state,
+		nowMs(), // updated_at
+	}
 
 	if g.Description != "" {
 		columns = append(columns, "description")

--- a/server/pipeline_group.go
+++ b/server/pipeline_group.go
@@ -133,7 +133,7 @@ func (p *pipeline) groupCreate(logger *zap.Logger, session *session, envelope *E
 		}
 
 		columns = append(columns, "metadata")
-		params = append(params, "$"+strconv.Itoa(len(values)))
+		params = append(params, "$"+strconv.Itoa(len(values)+1))
 		values = append(values, g.Metadata)
 	}
 

--- a/server/runtime_nakama_module.go
+++ b/server/runtime_nakama_module.go
@@ -311,7 +311,7 @@ func (n *NakamaModule) usersBan(l *lua.LState) int {
 	handles := make([]string, 0)
 	for _, d := range usersRaw {
 		if m, ok := d.(string); !ok {
-			l.ArgError(1, "expects a valid set of users")
+			l.ArgError(1, "expects a valid set of user IDs or handles")
 			return 0
 		} else {
 			uid, err := uuid.FromString(m)

--- a/tests/core_storage_test.go
+++ b/tests/core_storage_test.go
@@ -16,34 +16,13 @@ package tests
 
 import (
 	"crypto/sha256"
-	"database/sql"
 	"fmt"
+	"nakama/server"
+	"testing"
+
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-	"nakama/server"
-	"net/url"
-	"strconv"
-	"testing"
-	"time"
 )
-
-func setupDB() (*sql.DB, error) {
-	rawurl := fmt.Sprintf("postgresql://%s?sslmode=disable", "root@localhost:26257/nakama")
-	url, err := url.Parse(rawurl)
-	if err != nil {
-		return nil, err
-	}
-	db, err := sql.Open("postgres", url.String())
-	if err != nil {
-		return nil, err
-	}
-	return db, nil
-}
-
-func generateString() string {
-	return strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
-}
 
 func TestStorageWriteRuntimeGlobalSingle(t *testing.T) {
 	db, err := setupDB()
@@ -51,7 +30,6 @@ func TestStorageWriteRuntimeGlobalSingle(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -105,7 +83,6 @@ func TestStorageWriteRuntimeGlobalMultiple(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -162,7 +139,6 @@ func TestStorageWriteRuntimeUserMultiple(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -222,7 +198,6 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchNotExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -249,7 +224,6 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -304,7 +278,6 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchExistsFail(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -354,7 +327,6 @@ func TestStorageWriteRuntimeGlobalSingleIfNoneMatchNotExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -386,7 +358,6 @@ func TestStorageWriteRuntimeGlobalSingleIfNoneMatchExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -436,7 +407,6 @@ func TestStorageWriteRuntimeGlobalMultipleIfMatchNotExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -471,7 +441,6 @@ func TestStorageWritePipelineSingleGlobalNotAllowed(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -497,7 +466,6 @@ func TestStorageWritePipelineSingleOtherClientNotAllowed(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	data := []*server.StorageData{
 		&server.StorageData{
@@ -524,7 +492,6 @@ func TestStorageWritePipelineUserSingle(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 
@@ -558,7 +525,6 @@ func TestStorageWritePipelineUserMultiple(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 
@@ -620,7 +586,6 @@ func TestStorageWriteRuntimeGlobalMultipleSameKey(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -700,7 +665,6 @@ func TestStorageWritePipelineUserMultipleSameKey(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -771,7 +735,6 @@ func TestStorageWritePipelineIfMatchNotExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 
@@ -801,7 +764,6 @@ func TestStorageWritePipelineIfMatchExistsFail(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 
@@ -854,7 +816,6 @@ func TestStorageWritePipelineIfMatchExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -913,7 +874,6 @@ func TestStorageWritePipelineIfNoneMatchNotExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 
@@ -948,7 +908,6 @@ func TestStorageWritePipelineIfNoneMatchExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1002,7 +961,6 @@ func TestStorageWritePipelinePermissionFail(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1055,7 +1013,6 @@ func TestStorageFetchRuntimeGlobalPrivate(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -1109,7 +1066,6 @@ func TestStorageFetchRuntimeMixed(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -1168,7 +1124,6 @@ func TestStorageFetchRuntimeUserPrivate(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1225,7 +1180,6 @@ func TestStorageFetchPipelineGlobalPrivate(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -1272,7 +1226,6 @@ func TestStorageFetchPipelineUserPrivate(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1322,7 +1275,6 @@ func TestStorageFetchPipelineUserRead(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1379,7 +1331,6 @@ func TestStorageFetchPipelineUserPublic(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1436,7 +1387,6 @@ func TestStorageFetchPipelineUserOtherRead(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1486,7 +1436,6 @@ func TestStorageFetchPipelineUserOtherPublic(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1543,7 +1492,6 @@ func TestStorageFetchPipelineUserOtherPublicMixed(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -1621,7 +1569,6 @@ func TestStorageRemoveRuntimeGlobalPublic(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -1671,7 +1618,6 @@ func TestStorageRemoveRuntimeGlobalPrivate(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -1721,7 +1667,6 @@ func TestStorageRemoveRuntimeUserPublic(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1774,7 +1719,6 @@ func TestStorageRemoveRuntimeUserPrivate(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1827,7 +1771,6 @@ func TestStorageRemovePipelineGlobalRejected(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -1873,7 +1816,6 @@ func TestStorageRemovePipelineUserOtherRejected(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -1921,7 +1863,6 @@ func TestStorageRemovePipelineUserWrite(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -1969,7 +1910,6 @@ func TestStorageRemovePipelineUserDenied(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 	uid := uuid.NewV4()
@@ -2018,7 +1958,6 @@ func TestStorageRemoveRuntimeGlobalIfMatchNotExists(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	keys := []*server.StorageKey{
 		&server.StorageKey{
@@ -2041,7 +1980,6 @@ func TestStorageRemoveRuntimeGlobalIfMatchRejected(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -2088,7 +2026,6 @@ func TestStorageRemoveRuntimeGlobalIfMatch(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record := generateString()
 
@@ -2134,7 +2071,6 @@ func TestStorageRemoveRuntimeGlobalMultiple(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -2198,7 +2134,6 @@ func TestStorageRemoveRuntimeGlobalMultipleMixed(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -2250,7 +2185,6 @@ func TestStorageRemoveRuntimeGlobalMultipleMixedIfMatch(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -2316,7 +2250,6 @@ func TestStorageRemovePipelineUserMultipleMixedDenied(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -2386,7 +2319,6 @@ func TestStorageRemoveRuntimeUserMultipleMixed(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -2455,7 +2387,6 @@ func TestStorageRemoveRuntimeUserMultipleIfMatchFail(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -2557,7 +2488,6 @@ func TestStorageRemoveRuntimeUserMultipleIfMatch(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	record1 := generateString()
 	record2 := generateString()
@@ -2648,7 +2578,6 @@ func TestStorageListRuntimeUser(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 
@@ -2706,7 +2635,6 @@ func TestStorageListPipelineUserSelf(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 	collection := generateString()
@@ -2764,7 +2692,6 @@ func TestStorageListPipelineUserOther(t *testing.T) {
 		t.Error(err)
 	}
 	defer db.Close()
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
 
 	uid := uuid.NewV4()
 	collection := generateString()

--- a/tests/group_test.go
+++ b/tests/group_test.go
@@ -1,0 +1,148 @@
+// Copyright 2017 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"nakama/server"
+	"testing"
+
+	"github.com/satori/go.uuid"
+)
+
+func TestGroupCreateEmpty(t *testing.T) {
+	db, err := setupDB()
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+	_, err = server.GroupsCreate(logger, db, nil)
+	if err == nil {
+		t.Error("Expected error but was nil")
+	}
+}
+
+func TestGroupCreateMissingName(t *testing.T) {
+	db, err := setupDB()
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	_, err = server.GroupsCreate(logger, db, []*server.GroupCreateParam{{
+		Creator:     uuid.NewV4(),
+		Private:     true,
+		Lang:        "en",
+		Description: "desc",
+	}})
+	if err == nil {
+		t.Error("Expected error but was nil")
+	}
+}
+
+func TestGroupCreateMissingCreator(t *testing.T) {
+	db, err := setupDB()
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	_, err = server.GroupsCreate(logger, db, []*server.GroupCreateParam{{
+		Name:        "name1",
+		Private:     true,
+		Lang:        "en",
+		Description: "desc",
+	}})
+	if err == nil {
+		t.Error("Expected error but was nil")
+	}
+}
+
+func TestGroupCreate(t *testing.T) {
+	db, err := setupDB()
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	_, err = server.GroupsCreate(logger, db, []*server.GroupCreateParam{{
+		Name:        "name3",
+		Creator:     uuid.NewV4(),
+		Private:     true,
+		Lang:        "en",
+		Description: "desc",
+		Metadata:    []byte("{\"key\":\"value\"}"),
+	}})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGroupCreateMultipleSameName(t *testing.T) {
+	db, err := setupDB()
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	_, err = server.GroupsCreate(logger, db, []*server.GroupCreateParam{
+		{
+			Name:        "group",
+			Creator:     uuid.NewV4(),
+			Private:     true,
+			Lang:        "en",
+			Description: "desc",
+		},
+		{
+			Name:        "group",
+			Creator:     uuid.NewV4(),
+			Private:     true,
+			Lang:        "en",
+			Description: "desc",
+		},
+	})
+	if err == nil {
+		t.Error("Expected error but was nil")
+	}
+}
+
+func TestGroupCreateMultiple(t *testing.T) {
+	db, err := setupDB()
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	_, err = server.GroupsCreate(logger, db, []*server.GroupCreateParam{
+		{
+			Name:        "group1",
+			Creator:     uuid.NewV4(),
+			Private:     true,
+			Lang:        "en",
+			Description: "desc",
+			Metadata:    []byte("{\"key\":\"value\"}"),
+		},
+		{
+			Name:        "group2",
+			Creator:     uuid.NewV4(),
+			Private:     true,
+			Lang:        "en",
+			Description: "desc",
+			Metadata:    []byte("{\"key\":\"value\"}"),
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/tests/modules/e2e_runtime.lua
+++ b/tests/modules/e2e_runtime.lua
@@ -73,25 +73,29 @@ do
   assert(message == "\"WARN logger.\"")
 end
 
--- logger_error
-do
-  local message = nk.logger_error(("%q"):format("ERROR logger."))
-  assert(message == "\"ERROR logger.\"")
-end
-
--- user_fetch_id
+-- users_fetch_id
 do
   local user_ids = {"4c2ae592-b2a7-445e-98ec-697694478b1c"}
-  local users = nk.user_fetch_id(user_ids)
+  local users = nk.users_fetch_id(user_ids)
   assert(#users == 1)
   assert(user_ids[1] == users[1].Id)
 end
 
--- user_fetch_handle
+-- users_fetch_handle
 do
   local user_handles = {"02ebb2c8"}
-  local users = nk.user_fetch_handle(user_handles)
+  local users = nk.users_fetch_handle(user_handles)
   assert(user_handles[1] == users[1].Handle)
+end
+
+-- users_ban
+do
+  local user_ids = {"4c2ae592-b2a7-445e-98ec-697694478b1c"}
+  local status, res = pcall(nk.users_ban, user_ids)
+  if not status then
+    print(res)
+  end
+  assert(status == true)
 end
 
 --[[

--- a/tests/util.go
+++ b/tests/util.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+var (
+	logger, _ = zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel))
+)
+
+func setupDB() (*sql.DB, error) {
+	rawurl := fmt.Sprintf("postgresql://%s?sslmode=disable", "root@localhost:26257/nakama")
+	url, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("postgres", url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func generateString() string {
+	return strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+}


### PR DESCRIPTION
- Update Runtime modules to uses plural function names for batch operations. (`users_fetch_id` and `users_fetch_handle`.

- Ban users and create groups from within the Runtime environment.

- Also change `groupsCreate` message to run `TGroups` (rather than `TGroup`) since it's a batch operation. Therefore, removing `TGroup` message and reordering the proto messages once-again. **This requires a Client update.**