### PR TITLE
Let config argument to be passed in any order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Use Lua table for Metadata field when updating a user.
 - Updated configuration variable names. Most importantly `DB` is now changed to `database.address`.
 - Moved all `nakamax` functions into `nakama`. 
+- Invalid config file, or invalid command line config option results in server from starting.
 
 ## [1.0.0-rc.1] - 2017-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Use Lua table for Metadata field when updating a user.
 - Updated configuration variable names. Most importantly `DB` is now changed to `database.address`.
 - Moved all `nakamax` functions into `nakama`. 
-- Invalid config file, or invalid command line config option results in server from starting.
+- Invalid config file, or invalid command line config option prevents server from starting.
 
 ## [1.0.0-rc.1] - 2017-07-18
 ### Added

--- a/server/config.go
+++ b/server/config.go
@@ -215,7 +215,7 @@ func NewSessionConfig() *SessionConfig {
 // SocketConfig is configuration relevant to the transport socket and protocol
 type SocketConfig struct {
 	ServerKey           string `yaml:"server_key" json:"server_key" usage:"Server key to use to establish a connection to the server."`
-	Port                int    `yaml:"port" json:"port" usage:"The port for accepting connections from the client, listening on all interfaces. Unless explicitly defined, other ports will be chosen sequentially from here upwards."`
+	Port                int    `yaml:"port" json:"port" usage:"The port for accepting connections from the client, listening on all interfaces."`
 	MaxMessageSizeBytes int64  `yaml:"max_message_size_bytes" json:"max_message_size_bytes" usage:"Maximum amount of data in bytes allowed to be read from the client socket per message."`
 	WriteWaitMs         int    `yaml:"write_wait_ms" json:"write_wait_ms" usage:"Time in milliseconds to wait for an ack from the client when writing data."`
 	PongWaitMs          int    `yaml:"pong_wait_ms" json:"pong_wait_ms" usage:"Time in milliseconds to wait for a pong message from the client after sending a ping."`

--- a/server/config.go
+++ b/server/config.go
@@ -43,26 +43,7 @@ type Config interface {
 }
 
 func ParseArgs(logger *zap.Logger, args []string) Config {
-	//config := NewConfig()
-	//
-	//if len(args) > 1 {
-	//	switch args[1] {
-	//	case "--config":
-	//		configPath := args[2]
-	//		data, err := ioutil.ReadFile(configPath)
-	//		if err != nil {
-	//			logger.Error("Could not read config file, using defaults", zap.Error(err))
-	//		} else {
-	//			err = yaml.Unmarshal(data, config)
-	//			if err != nil {
-	//				logger.Error("Could not parse config file, using defaults", zap.Error(err))
-	//			} else {
-	//				config.Config = configPath
-	//			}
-	//		}
-	//	}
-	//}
-
+	// parse args to get path to a config file if passed in
 	configFilePath := NewConfig()
 	configFileFlagSet := flag.NewFlagSet("nakama", flag.ExitOnError)
 	configFileFlagMaker := flags.NewFlagMakerFlagSet(&flags.FlagMakingOptions{
@@ -76,6 +57,7 @@ func ParseArgs(logger *zap.Logger, args []string) Config {
 		logger.Fatal("Could not parse command line arguments", zap.Error(err))
 	}
 
+	// parse config file if path is set
 	mainConfig := NewConfig()
 	if configFilePath.Config != "" {
 		data, err := ioutil.ReadFile(configFilePath.Config)
@@ -91,6 +73,7 @@ func ParseArgs(logger *zap.Logger, args []string) Config {
 		}
 	}
 
+	// override config with those passed from command-line
 	mainFlagSet := flag.NewFlagSet("nakama", flag.ExitOnError)
 	mainFlagMaker := flags.NewFlagMakerFlagSet(&flags.FlagMakingOptions{
 		UseLowerCase: true,

--- a/tests/config_test.yml
+++ b/tests/config_test.yml
@@ -1,9 +1,12 @@
 name: nakama-test
 database:
   address:
-    - test@localhost:26257
+    - root@localhost:26257
 log:
   verbose: true
   stdout: false
 runtime:
   http_key: testkey
+purchase:
+  apple:
+    password: helloworld


### PR DESCRIPTION
- Invalid config file, or invalid command line config option results in server from starting. (FATAL error).
- Config file can be passed in any order, no longer requiring the `--config` param to be the first item.