### PR TITLE
Misc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
-### Changed
+### Added
 - New storage partial update feature.
+
+### Changed
 - Use Lua table for Content field when creating new notifications.
 - Use Lua table for Metadata field for new groups.
 - Use Lua table for Metadata field when updating a user.
@@ -13,6 +15,8 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Moved all `nakamax` functions into `nakama`.
 - Invalid config file, or invalid command line config option prevents server from starting.
 - Matchmake token expiry increased from 15 seconds to 30 seconds.
+- Script runtime `os.date()` function now returns correct day of year.
+- Script runtime contexts passed to function hooks now use `PascalCase` naming for fields. For example `context.user_id` must now be `context.UserId`.
 
 ## [1.0.0-rc.1] - 2017-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Added
 - New storage partial update feature.
+- Log warning messages at startup when using insecure default parameter values.
 
 ### Changed
 - Use Lua table for Content field when creating new notifications.

--- a/glide.lock
+++ b/glide.lock
@@ -51,7 +51,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/yuin/gopher-lua
-  version: b402f3114ec730d8bddb074a6c137309f561aa78
+  version: 2243d714d6c94951d8ccca8c851836ff47d401c9
   subpackages:
   - ast
   - parse

--- a/server/config.go
+++ b/server/config.go
@@ -91,6 +91,17 @@ func ParseArgs(logger *zap.Logger, args []string) Config {
 		mainConfig.GetRuntime().Path = filepath.Join(mainConfig.GetDataDir(), "modules")
 	}
 
+	// Log warnings for insecure default parameter values.
+	if mainConfig.GetSocket().ServerKey == "defaultkey" {
+		logger.Warn("WARNING: insecure default parameter value, change this for production!", zap.String("param", "socket.server_key"))
+	}
+	if mainConfig.GetSession().EncryptionKey == "defaultencryptionkey" {
+		logger.Warn("WARNING: insecure default parameter value, change this for production!", zap.String("param", "session.encryption_key"))
+	}
+	if mainConfig.GetRuntime().HTTPKey == "defaultkey" {
+		logger.Warn("WARNING: insecure default parameter value, change this for production!", zap.String("param", "runtime.http_key"))
+	}
+
 	return mainConfig
 }
 

--- a/server/dashboard_accepter.go
+++ b/server/dashboard_accepter.go
@@ -57,7 +57,8 @@ func NewDashboardService(logger *zap.Logger, multiLogger *zap.Logger, version st
 	service.mux.HandleFunc("/v0/cluster/stats", service.statusHandler).Methods("GET")
 	service.mux.HandleFunc("/v0/config", service.configHandler).Methods("GET")
 	service.mux.HandleFunc("/v0/info", service.infoHandler).Methods("GET")
-	service.mux.PathPrefix("/").Handler(http.FileServer(service.dashboardFilesystem)).Methods("GET") //needs to be last
+	// TODO coming soon
+	// service.mux.PathPrefix("/").Handler(http.FileServer(service.dashboardFilesystem)).Methods("GET") // Needs to be last.
 
 	go func() {
 		bindAddr := fmt.Sprintf(":%d", config.GetDashboard().Port)

--- a/server/dashboard_accepter.go
+++ b/server/dashboard_accepter.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"nakama/build/generated/dashboard"
-	"os"
 	"runtime"
 
 	"github.com/elazarl/go-bindata-assetfs"
@@ -68,11 +67,11 @@ func NewDashboardService(logger *zap.Logger, multiLogger *zap.Logger, version st
 			multiLogger.Fatal("Dashboard listener failed", zap.Error(err))
 		}
 	}()
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "127.0.0.1"
-	}
-	multiLogger.Info("Dashboard", zap.String("address", fmt.Sprintf("http://%s:%d", hostname, config.GetDashboard().Port)))
+	// hostname, err := os.Hostname()
+	// if err != nil {
+	// 	 hostname = "127.0.0.1"
+	// }
+	// multiLogger.Info("Dashboard", zap.String("address", fmt.Sprintf("http://%s:%d", hostname, config.GetDashboard().Port)))
 
 	return service
 }

--- a/server/runtime_lua_context.go
+++ b/server/runtime_lua_context.go
@@ -52,11 +52,11 @@ func (e ExecutionMode) String() string {
 }
 
 const (
-	__CTX_ENV              = "env"
-	__CTX_MODE             = "execution_mode"
-	__CTX_USER_ID          = "user_id"
-	__CTX_USER_HANDLE      = "user_handle"
-	__CTX_USER_SESSION_EXP = "user_session_exp"
+	__CTX_ENV              = "Env"
+	__CTX_MODE             = "ExecutionMode"
+	__CTX_USER_ID          = "UserId"
+	__CTX_USER_HANDLE      = "UserHandle"
+	__CTX_USER_SESSION_EXP = "UserSessionExp"
 )
 
 func NewLuaContext(l *lua.LState, env *lua.LTable, mode ExecutionMode, uid uuid.UUID, handle string, sessionExpiry int64) *lua.LTable {

--- a/server/runtime_nakama_module.go
+++ b/server/runtime_nakama_module.go
@@ -970,6 +970,7 @@ func (n *NakamaModule) storageUpdate(l *lua.LState) int {
 
 		// Initialise fields where default values for their types are not the logical defaults needed.
 		update := &StorageKeyUpdate{
+			Key:             &StorageKey{},
 			PermissionRead:  int64(1),
 			PermissionWrite: int64(1),
 		}

--- a/server/runtime_oslib.go
+++ b/server/runtime_oslib.go
@@ -94,8 +94,8 @@ func osDate(L *lua.LState) int {
 			ret.RawSetString("min", lua.LNumber(t.Minute()))
 			ret.RawSetString("sec", lua.LNumber(t.Second()))
 			ret.RawSetString("wday", lua.LNumber(t.Weekday()))
-			// TODO yday & dst
-			ret.RawSetString("yday", lua.LNumber(0))
+			ret.RawSetString("yday", lua.LNumber(t.YearDay()))
+			// TODO dst
 			ret.RawSetString("isdst", lua.LFalse)
 			L.Push(ret)
 			return 1

--- a/tests/core_storage_test.go
+++ b/tests/core_storage_test.go
@@ -2757,7 +2757,7 @@ func TestStorageUpdateRuntimeNewRecord(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -2818,7 +2818,7 @@ func TestStorageUpdateRuntimeExistingRecord(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -2866,7 +2866,7 @@ func TestStorageUpdatePipelineNewRecord(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -2933,7 +2933,7 @@ func TestStorageUpdatePipelineExistingRecord(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -3000,7 +3000,7 @@ func TestStorageUpdatePipelineExistingRecordPermissionDenied(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -3034,7 +3034,7 @@ func TestStorageUpdateRuntimeBadPatch(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -3065,7 +3065,7 @@ func TestStorageUpdateRuntimeNewRecordIfNoneMatch(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -3125,7 +3125,7 @@ func TestStorageUpdateRuntimeExistingRecordIfNoneMatch(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -3157,7 +3157,7 @@ func TestStorageUpdateRuntimeNewRecordIfMatch(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -3203,7 +3203,7 @@ func TestStorageUpdateRuntimeExistingRecordIfMatch(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",
@@ -3263,7 +3263,7 @@ func TestStorageUpdateRuntimeExistingRecordIfMatchBadVersion(t *testing.T) {
 
 	updates := []*server.StorageKeyUpdate{
 		&server.StorageKeyUpdate{
-			Key: server.StorageKey{
+			Key: &server.StorageKey{
 				Bucket:     "testbucket",
 				Collection: collection,
 				Record:     "record",

--- a/tests/modules/notification.lua
+++ b/tests/modules/notification.lua
@@ -18,7 +18,7 @@ local nk = require("nakama")
 
 function notification_send(ctx, payload)
   notifications = {
-    { Subject="test_notification",Content='{["hello"] = "world"}',UserId=ctx["user_id"],Code=101,Persistent=true },
+    { Subject="test_notification",Content='{["hello"] = "world"}',UserId=ctx["UserId"],Code=101,Persistent=true },
   }
 
   local status, res = pcall(nk.notifications_send_id, notifications)

--- a/tests/runtime_test.go
+++ b/tests/runtime_test.go
@@ -289,7 +289,7 @@ test={}
 -- Get the mean value of a table
 function test.printWorld(ctx, payload)
 	print("Hello World")
-	print(ctx.execution_mode)
+	print(ctx.ExecutionMode)
 	return payload
 end
 
@@ -330,7 +330,7 @@ test={}
 -- Get the mean value of a table
 function test.printWorld(ctx, payload)
 	print("Hello World")
-	print(ctx.execution_mode)
+	print(ctx.ExecutionMode)
 	return payload
 end
 
@@ -369,7 +369,7 @@ test={}
 -- Get the mean value of a table
 function test.printWorld(ctx, payload)
 	print("Hello World")
-	print(ctx.execution_mode)
+	print(ctx.ExecutionMode)
 	return payload
 end
 


### PR DESCRIPTION
* Script runtime `os.date()` function now returns correct day of year.
* Script runtime contexts passed to function hooks now use `PascalCase` naming for fields. For example `context.user_id` must now be `context.UserId`.
* Disable access to internal dashboard.