### PR TITLE
Increase schema column size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ### Added
 - New code runtime function to list leaderboard records for a given set of users.
 - New code runtime function to list leaderboard records around a given user.
-- New code runtime function to execute raw SQL queries. 
+- New code runtime function to execute raw SQL queries.
+- New code runtime function to run CRON expressions.
 
 ### Changed
 - Handle update now returns a bad input error code if handle is too long.
 - Improved handling of content type request headers in HTTP runtime script invocations.
+- Increase default maximum length of user handle from 20 to 128 characters.
+- Increase default maximum length of device and custom IDs from 64 to 128 characters.
+- Increase default maximum length of various name, location, timezone, and other free text fields to 255 characters.
+- Increase default maximum length of storage bucket, collection, and record from 70 to 128 characters.
+- Increase default maximum length of topic room names from 64 to 128 characters. 
+
+### Fixed
+- Realtime notification routing now correctly resolves connected users.
+- The server will now correctly log a reason when clients disconnect unexpectedly.
 
 ## [1.0.1] - 2017-08-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Increase default maximum length of device and custom IDs from 64 to 128 characters.
 - Increase default maximum length of various name, location, timezone, and other free text fields to 255 characters.
 - Increase default maximum length of storage bucket, collection, and record from 70 to 128 characters.
-- Increase default maximum length of topic room names from 64 to 128 characters. 
+- Increase default maximum length of topic room names from 64 to 128 characters.
 
 ### Fixed
 - Realtime notification routing now correctly resolves connected users.

--- a/migrations/20170115200001_initial_schema.sql
+++ b/migrations/20170115200001_initial_schema.sql
@@ -18,22 +18,22 @@
 CREATE TABLE IF NOT EXISTS users (
     PRIMARY KEY (id),
     id             BYTEA         NOT NULL,
-    handle         VARCHAR(20)   CONSTRAINT users_handle_key UNIQUE NOT NULL,
-    fullname       VARCHAR(70),
+    handle         VARCHAR(128)  CONSTRAINT users_handle_key UNIQUE NOT NULL,
+    fullname       VARCHAR(255),
     avatar_url     VARCHAR(255),
     -- https://tools.ietf.org/html/bcp47
     lang           VARCHAR(18)   DEFAULT 'en' NOT NULL,
-    location       VARCHAR(64),  -- e.g. "San Francisco, CA"
-    timezone       VARCHAR(64),  -- e.g. "Pacific Time (US & Canada)"
+    location       VARCHAR(255), -- e.g. "San Francisco, CA"
+    timezone       VARCHAR(255), -- e.g. "Pacific Time (US & Canada)"
     utc_offset_ms  SMALLINT      DEFAULT 0 NOT NULL,
     metadata       BYTEA         DEFAULT '{}' CHECK (length(metadata) < 16000) NOT NULL,
     email          VARCHAR(255)  UNIQUE,
     password       BYTEA         CHECK (length(password) < 32000),
-    facebook_id    VARCHAR(64)   UNIQUE,
-    google_id      VARCHAR(64)   UNIQUE,
-    gamecenter_id  VARCHAR(64)   UNIQUE,
-    steam_id       VARCHAR(64)   UNIQUE,
-    custom_id      VARCHAR(64)   UNIQUE,
+    facebook_id    VARCHAR(128)  UNIQUE,
+    google_id      VARCHAR(128)  UNIQUE,
+    gamecenter_id  VARCHAR(128)  UNIQUE,
+    steam_id       VARCHAR(128)  UNIQUE,
+    custom_id      VARCHAR(128)  UNIQUE,
     created_at     BIGINT        CHECK (created_at > 0) NOT NULL,
     updated_at     BIGINT        CHECK (updated_at > 0) NOT NULL,
     verified_at    BIGINT        CHECK (verified_at >= 0) DEFAULT 0 NOT NULL,
@@ -46,8 +46,8 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS user_device (
     PRIMARY KEY (id),
     FOREIGN KEY (user_id) REFERENCES users(id),
-    id      VARCHAR(64) NOT NULL,
-    user_id BYTEA       NOT NULL
+    id      VARCHAR(128) NOT NULL,
+    user_id BYTEA        NOT NULL
 );
 -- In cockroachdb a FK relationship will implicitly create an index on the
 -- column. As a result we don't need the separate index creation which breaks
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS groups (
     PRIMARY KEY (id),
     id            BYTEA         NOT NULL,
     creator_id    BYTEA         NOT NULL,
-    name          VARCHAR(70)   CONSTRAINT groups_name_key UNIQUE NOT NULL,
+    name          VARCHAR(255)  CONSTRAINT groups_name_key UNIQUE NOT NULL,
     description   VARCHAR(255),
     avatar_url    VARCHAR(255),
     -- https://tools.ietf.org/html/bcp47
@@ -111,37 +111,37 @@ CREATE INDEX IF NOT EXISTS source_id_destination_id_state_idx ON group_edge (sou
 
 CREATE TABLE IF NOT EXISTS message (
     PRIMARY KEY (topic, topic_type, message_id),
-    topic      BYTEA       CHECK (length(topic) <= 64) NOT NULL,
-    topic_type SMALLINT    NOT NULL, -- dm(0), room(1), group(2)
-    message_id BYTEA       NOT NULL,
-    user_id    BYTEA       NOT NULL,
-    created_at BIGINT      CHECK (created_at > 0) NOT NULL,
-    expires_at BIGINT      DEFAULT 0 CHECK (created_at >= 0) NOT NULL,
-    handle     VARCHAR(20) NOT NULL,
-    type       SMALLINT    NOT NULL, -- chat(0), group_join(1), group_add(2), group_leave(3), group_kick(4), group_promoted(5)
+    topic      BYTEA        CHECK (length(topic) <= 128) NOT NULL,
+    topic_type SMALLINT     NOT NULL, -- dm(0), room(1), group(2)
+    message_id BYTEA        NOT NULL,
+    user_id    BYTEA        NOT NULL,
+    created_at BIGINT       CHECK (created_at > 0) NOT NULL,
+    expires_at BIGINT       DEFAULT 0 CHECK (created_at >= 0) NOT NULL,
+    handle     VARCHAR(128) NOT NULL,
+    type       SMALLINT     NOT NULL, -- chat(0), group_join(1), group_add(2), group_leave(3), group_kick(4), group_promoted(5)
     -- FIXME replace with JSONB
-    data       BYTEA       DEFAULT '{}' CHECK (length(data) <= 1000) NOT NULL
+    data       BYTEA        DEFAULT '{}' CHECK (length(data) <= 1000) NOT NULL
 );
 CREATE INDEX IF NOT EXISTS topic_topic_type_created_at_idx ON message (topic, topic_type, created_at);
 CREATE INDEX IF NOT EXISTS topic_topic_type_created_at_message_id_user_id_idx ON message (topic, topic_type, created_at, message_id, user_id);
 
 CREATE TABLE IF NOT EXISTS storage (
     PRIMARY KEY (bucket, collection, user_id, record, deleted_at),
-    id         BYTEA       NOT NULL,
+    id         BYTEA        NOT NULL,
     user_id    BYTEA,
-    bucket     VARCHAR(70) NOT NULL,
-    collection VARCHAR(70) NOT NULL,
-    record     VARCHAR(70) NOT NULL,
+    bucket     VARCHAR(128) NOT NULL,
+    collection VARCHAR(128) NOT NULL,
+    record     VARCHAR(128) NOT NULL,
     -- FIXME replace with JSONB
-    value      BYTEA       DEFAULT '{}' CHECK (length(value) < 16000) NOT NULL,
-    version    BYTEA       NOT NULL,
-    read       SMALLINT    DEFAULT 1 CHECK (read >= 0) NOT NULL,
-    write      SMALLINT    DEFAULT 1 CHECK (write >= 0) NOT NULL,
-    created_at BIGINT      CHECK (created_at > 0) NOT NULL,
-    updated_at BIGINT      CHECK (updated_at > 0) NOT NULL,
+    value      BYTEA        DEFAULT '{}' CHECK (length(value) < 16000) NOT NULL,
+    version    BYTEA        NOT NULL,
+    read       SMALLINT     DEFAULT 1 CHECK (read >= 0) NOT NULL,
+    write      SMALLINT     DEFAULT 1 CHECK (write >= 0) NOT NULL,
+    created_at BIGINT       CHECK (created_at > 0) NOT NULL,
+    updated_at BIGINT       CHECK (updated_at > 0) NOT NULL,
     -- FIXME replace with TTL support
-    expires_at BIGINT      CHECK (expires_at >= 0) DEFAULT 0 NOT NULL,
-    deleted_at BIGINT      CHECK (deleted_at >= 0) DEFAULT 0 NOT NULL
+    expires_at BIGINT       CHECK (expires_at >= 0) DEFAULT 0 NOT NULL,
+    deleted_at BIGINT       CHECK (deleted_at >= 0) DEFAULT 0 NOT NULL
 );
 
 -- +migrate Down

--- a/migrations/20170228205100_leaderboards.sql
+++ b/migrations/20170228205100_leaderboards.sql
@@ -35,25 +35,25 @@ CREATE TABLE IF NOT EXISTS leaderboard_record (
     -- in the same transaction breaks. See issue cockroachdb/cockroach#13505.
     -- In this case we prefer the indexes over the constraint.
     -- FOREIGN KEY (leaderboard_id) REFERENCES leaderboard(id),
-    id                 BYTEA        UNIQUE NOT NULL,
-    leaderboard_id     BYTEA        NOT NULL,
-    owner_id           BYTEA        NOT NULL,
-    handle             VARCHAR(20)  NOT NULL,
-    lang               VARCHAR(18)  DEFAULT 'en' NOT NULL,
-    location           VARCHAR(64), -- e.g. "San Francisco, CA"
-    timezone           VARCHAR(64), -- e.g. "Pacific Time (US & Canada)"
-    rank_value         BIGINT       DEFAULT 0 CHECK (rank_value >= 0) NOT NULL,
-    score              BIGINT       DEFAULT 0 NOT NULL,
-    num_score          INT          DEFAULT 0 CHECK (num_score >= 0) NOT NULL,
+    id                 BYTEA         UNIQUE NOT NULL,
+    leaderboard_id     BYTEA         NOT NULL,
+    owner_id           BYTEA         NOT NULL,
+    handle             VARCHAR(128)  NOT NULL,
+    lang               VARCHAR(18)   DEFAULT 'en' NOT NULL,
+    location           VARCHAR(255), -- e.g. "San Francisco, CA"
+    timezone           VARCHAR(255), -- e.g. "Pacific Time (US & Canada)"
+    rank_value         BIGINT        DEFAULT 0 CHECK (rank_value >= 0) NOT NULL,
+    score              BIGINT        DEFAULT 0 NOT NULL,
+    num_score          INT           DEFAULT 0 CHECK (num_score >= 0) NOT NULL,
     -- FIXME replace with JSONB
-    metadata           BYTEA        DEFAULT '{}' CHECK (length(metadata) < 16000) NOT NULL,
-    ranked_at          INT          CHECK (ranked_at >= 0) DEFAULT 0 NOT NULL,
-    updated_at         INT          CHECK (updated_at > 0) NOT NULL,
+    metadata           BYTEA         DEFAULT '{}' CHECK (length(metadata) < 16000) NOT NULL,
+    ranked_at          BIGINT        CHECK (ranked_at >= 0) DEFAULT 0 NOT NULL,
+    updated_at         BIGINT        CHECK (updated_at > 0) NOT NULL,
     -- Used to enable proper order in revscan when sorting by score descending.
     -- Revscan is unaviodable here due to cockroachdb/cockroach#14241.
-    updated_at_inverse INT          CHECK (updated_at > 0) NOT NULL,
-    expires_at         INT          CHECK (expires_at >= 0) DEFAULT 0 NOT NULL,
-    banned_at          INT          CHECK (expires_at >= 0) DEFAULT 0 NOT NULL
+    updated_at_inverse BIGINT        CHECK (updated_at > 0) NOT NULL,
+    expires_at         BIGINT        CHECK (expires_at >= 0) DEFAULT 0 NOT NULL,
+    banned_at          BIGINT        CHECK (expires_at >= 0) DEFAULT 0 NOT NULL
 );
 CREATE INDEX IF NOT EXISTS owner_id_leaderboard_id_idx ON leaderboard_record (owner_id, leaderboard_id);
 CREATE INDEX IF NOT EXISTS leaderboard_id_expires_at_score_updated_at_inverse_id_idx ON leaderboard_record (leaderboard_id, expires_at, score, updated_at_inverse, id);

--- a/migrations/20170620104217_storage_list_purchase_notifications.sql
+++ b/migrations/20170620104217_storage_list_purchase_notifications.sql
@@ -37,8 +37,8 @@ CREATE TABLE IF NOT EXISTS purchase (
     PRIMARY KEY (user_id, provider, receipt_id), -- ad-hoc purchase lookup
     user_id         BYTEA        NOT NULL,
     provider        SMALLINT     NOT NULL, -- google(0), apple(1)
-    product_id      VARCHAR(255)  NOT NULL,
-    receipt_id      VARCHAR(255)  NOT NULL, -- the transaction ID
+    product_id      VARCHAR(255) NOT NULL,
+    receipt_id      VARCHAR(255) NOT NULL, -- the transaction ID
     receipt         BYTEA        NOT NULL,
     provider_resp   BYTEA        NOT NULL,
     created_at      BIGINT       CHECK (created_at > 0) NOT NULL

--- a/server/core_notification.go
+++ b/server/core_notification.go
@@ -97,7 +97,7 @@ func (n *NotificationService) NotificationSend(notifications []*NNotification) e
 	}
 
 	for userID, ns := range notificationsByUser {
-		presences := n.tracker.ListByTopicUser("notification", userID)
+		presences := n.tracker.ListByTopicUser("notifications", userID)
 		if len(presences) != 0 {
 			nots := convertNotifications(ns)
 			n.messageRouter.Send(n.logger, presences, nots)

--- a/server/core_self.go
+++ b/server/core_self.go
@@ -66,9 +66,9 @@ func SelfUpdate(logger *zap.Logger, db *sql.DB, updates []*SelfUpdateOp) (Error_
 		statements := make([]string, 0)
 		params := make([]interface{}, 0)
 		if update.Handle != "" {
-			if len(update.Handle) > 20 {
+			if len(update.Handle) > 128 {
 				code = BAD_INPUT
-				err = errors.New("Handle must be 1-20 characters long")
+				err = errors.New("Handle must be 1-128 characters long")
 				return code, err
 			}
 			statements = append(statements, "handle = $"+strconv.Itoa(index))

--- a/server/pipeline_link_unlink.go
+++ b/server/pipeline_link_unlink.go
@@ -55,8 +55,8 @@ func (p *pipeline) linkDevice(logger *zap.Logger, session *session, envelope *En
 	} else if invalidCharsRegex.MatchString(deviceID) {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Invalid device ID, no spaces or control characters allowed"))
 		return
-	} else if len(deviceID) < 10 || len(deviceID) > 64 {
-		session.Send(ErrorMessageBadInput(envelope.CollationId, "Invalid device ID, must be 10-64 bytes"))
+	} else if len(deviceID) < 10 || len(deviceID) > 128 {
+		session.Send(ErrorMessageBadInput(envelope.CollationId, "Invalid device ID, must be 10-128 bytes"))
 		return
 	}
 
@@ -342,8 +342,8 @@ func (p *pipeline) linkCustom(logger *zap.Logger, session *session, envelope *En
 	} else if invalidCharsRegex.MatchString(customID) {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Invalid custom ID, no spaces or control characters allowed"))
 		return
-	} else if len(customID) < 10 || len(customID) > 64 {
-		session.Send(ErrorMessageBadInput(envelope.CollationId, "Invalid custom ID, must be 10-64 bytes"))
+	} else if len(customID) < 10 || len(customID) > 128 {
+		session.Send(ErrorMessageBadInput(envelope.CollationId, "Invalid custom ID, must be 10-128 bytes"))
 		return
 	}
 

--- a/server/session.go
+++ b/server/session.go
@@ -83,7 +83,7 @@ func (s *session) Consume(processRequest func(logger *zap.Logger, session *sessi
 	for {
 		_, data, err := s.conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
+			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
 				s.logger.Warn("Error reading message from client", zap.Error(err))
 			}
 			break

--- a/server/session_auth.go
+++ b/server/session_auth.go
@@ -435,8 +435,8 @@ func (a *authenticationService) loginDevice(authReq *AuthenticateRequest) ([]byt
 		return nil, "", 0, "Device ID is required", BAD_INPUT
 	} else if invalidCharsRegex.MatchString(deviceID) {
 		return nil, "", 0, "Invalid device ID, no spaces or control characters allowed", BAD_INPUT
-	} else if len(deviceID) < 10 || len(deviceID) > 64 {
-		return nil, "", 0, "Invalid device ID, must be 10-64 bytes", BAD_INPUT
+	} else if len(deviceID) < 10 || len(deviceID) > 128 {
+		return nil, "", 0, "Invalid device ID, must be 10-128 bytes", BAD_INPUT
 	}
 
 	var userID []byte
@@ -631,8 +631,8 @@ func (a *authenticationService) loginCustom(authReq *AuthenticateRequest) ([]byt
 		return nil, "", 0, "Custom ID is required", BAD_INPUT
 	} else if invalidCharsRegex.MatchString(customID) {
 		return nil, "", 0, "Invalid custom ID, no spaces or control characters allowed", BAD_INPUT
-	} else if len(customID) < 10 || len(customID) > 64 {
-		return nil, "", 0, "Invalid custom ID, must be 10-64 bytes", BAD_INPUT
+	} else if len(customID) < 10 || len(customID) > 128 {
+		return nil, "", 0, "Invalid custom ID, must be 10-128 bytes", BAD_INPUT
 	}
 
 	var userID []byte
@@ -728,8 +728,8 @@ func (a *authenticationService) registerDevice(tx *sql.Tx, authReq *Authenticate
 		return nil, "", "", "Device ID is required", BAD_INPUT
 	} else if invalidCharsRegex.MatchString(deviceID) {
 		return nil, "", "", "Invalid device ID, no spaces or control characters allowed", BAD_INPUT
-	} else if len(deviceID) < 10 || len(deviceID) > 64 {
-		return nil, "", "", "Invalid device ID, must be 10-64 bytes", BAD_INPUT
+	} else if len(deviceID) < 10 || len(deviceID) > 128 {
+		return nil, "", "", "Invalid device ID, must be 10-128 bytes", BAD_INPUT
 	}
 
 	updatedAt := nowMs()
@@ -1030,8 +1030,8 @@ func (a *authenticationService) registerCustom(tx *sql.Tx, authReq *Authenticate
 		return nil, "", "", "Custom ID is required", BAD_INPUT
 	} else if invalidCharsRegex.MatchString(customID) {
 		return nil, "", "", "Invalid custom ID, no spaces or control characters allowed", BAD_INPUT
-	} else if len(customID) < 10 || len(customID) > 64 {
-		return nil, "", "", "Invalid custom ID, must be 10-64 bytes", BAD_INPUT
+	} else if len(customID) < 10 || len(customID) > 128 {
+		return nil, "", "", "Invalid custom ID, must be 10-128 bytes", BAD_INPUT
 	}
 
 	updatedAt := nowMs()

--- a/tests/modules/e2e_runtime.lua
+++ b/tests/modules/e2e_runtime.lua
@@ -343,6 +343,14 @@ do
   assert(objectDecode == '{"hello": "world"}', '"objectDecode" must equal {"hello": "world"}')
 end
 
+-- cron_next
+do
+  -- Normally use os.time() here.
+  local time = 1506433906
+  local next = nk.cron_next("1 * * * *", time)
+  assert(next == 1506434460)
+end
+
 -- sql_exec and sql_query
 do
   -- Table names cannot start with a number so we can't use our usual UUID here.


### PR DESCRIPTION
- Increase default maximum length of user handle from 20 to 128 characters.
- Increase default maximum length of device and custom IDs from 64 to 128 characters.
- Increase default maximum length of various name, location, timezone, and other free text fields to 255 characters.
- Increase default maximum length of storage bucket, collection, and record from 70 to 128 characters.
- Increase default maximum length of topic room names from 64 to 128 characters.
- New code runtime function to run CRON expressions.
- Realtime notification routing now correctly resolves connected users.
- The server will now correctly log a reason when clients disconnect unexpectedly.