### PR TITLE
Add advanced matchmaker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ### [Unreleased]
+### Added
+- Advanced Matchmaking with custom filters and user properties.
+
 ### Changed
 - Script runtime RPC and HTTP hook errors now return more detail when verbose logging is enabled.
 

--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cockroachdb:
-    image: cockroachdb/cockroach:v1.0.3
+    image: cockroachdb/cockroach:v1.0.6
     command: start --insecure --store=attrs=ssd,path=/var/lib/cockroach/
     restart: always
     volumes:

--- a/server/api.proto
+++ b/server/api.proto
@@ -888,17 +888,17 @@ message TopicPresence {
 }
 
 /**
- * PropertyMap is a core domain type respresenting a single user property
+ * PropertyPair is a core domain type respresenting a single user property
  */
 message PropertyPair {
-  /// List of string user property
-  message StringList {
+  /// Set of string user property
+  message StringSet {
     repeated string values = 1;
   }
 
   string key = 1;
   oneof value {
-    StringList stringList = 2;
+    StringSet stringSet = 2;
     bool boolValue = 3;
     int64 intValue = 4;
   }

--- a/server/api.proto
+++ b/server/api.proto
@@ -888,13 +888,58 @@ message TopicPresence {
 }
 
 /**
+ * PropertyMap is a core domain type respresenting a single user property
+ */
+message PropertyPair {
+  /// List of string user property
+  message StringList {
+    repeated string values = 1;
+  }
+
+  string key = 1;
+  oneof value {
+    StringList stringList = 2;
+    bool boolValue = 3;
+    int64 intValue = 4;
+  }
+}
+
+/**
+ * MatchmakeFilter is a core domain type respresenting a filter to use for matchmaking.
+ */
+message MatchmakeFilter {
+  /// String term filters
+  message TermFilter {
+    repeated string terms = 1;
+    bool matchAllTerms = 2;
+  }
+
+  /// Numeric range filter
+  message RangeFilter {
+    int64 lower_bound = 1; // inclusive lower_bound
+    int64 upper_bound = 2; // inclusive upper_bound
+  }
+
+  string name = 1;
+  oneof value {
+    TermFilter term = 2;
+    RangeFilter range = 3;
+    bool check = 4;
+  }
+}
+
+/**
  * TMatchmakeAdd is used to add the current user to the matchmaking pool.
  *
  * @returns TMatchmakeTicket
  */
 message TMatchmakeAdd {
   /// Match user with other users looking for a match with the the following number of users.
-  int64 requiredCount = 1;
+  int64 required_count = 1;
+  /// List of filters that need to match.
+  repeated MatchmakeFilter filters = 2; // "AND"
+  /// List of properties for the current user.
+  repeated PropertyPair properties = 3;
 }
 
 /**
@@ -915,12 +960,20 @@ message TMatchmakeRemove {
  * MatchmakeMatched is the core domain type representing a found match via matchmaking.
  */
 message MatchmakeMatched {
+  /// Matched user presence and properties
+  message UserProperty {
+    bytes user_id = 1;
+    repeated PropertyPair properties = 2;
+    repeated MatchmakeFilter filters = 3;
+  }
+
   /// Matchmaking ticket. Use this to invalidate ticket cache on the client.
   bytes ticket = 1;
-  /// Matchmaking token. Use this to accept the match. This is a onetime token which is only valid for 15seconds.
+  /// Matchmaking token. Use this to accept the match. This is a onetime token which is only valid for a limited time.
   bytes token = 2;
   repeated UserPresence presences = 3;
   UserPresence self = 4;
+  repeated UserProperty properties = 5;
 }
 
 /**

--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -247,6 +247,7 @@ func (m *MatchmakerService) intersection(a, b []string) []string {
 		for j := range b {
 			if a[i] == b[j] {
 				o = append(o, a[i])
+				break
 			}
 		}
 	}

--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -16,15 +16,60 @@ package server
 
 import (
 	"errors"
-	"github.com/satori/go.uuid"
 	"sync"
+
+	"github.com/satori/go.uuid"
 )
 
 type Matchmaker interface {
-	Add(sessionID uuid.UUID, userID uuid.UUID, meta PresenceMeta, requiredCount int64) (uuid.UUID, map[MatchmakerKey]*MatchmakerProfile)
+	Add(sessionID uuid.UUID, userID uuid.UUID, requestProfile *MatchmakerProfile) (uuid.UUID, map[MatchmakerKey]*MatchmakerProfile, []*MatchmakerAcceptedProperty)
 	Remove(sessionID uuid.UUID, userID uuid.UUID, ticket uuid.UUID) error
 	RemoveAll(sessionID uuid.UUID)
 	UpdateAll(sessionID uuid.UUID, meta PresenceMeta)
+}
+
+type Filter int
+
+const (
+	BOOL Filter = iota
+	RANGE
+	TERM
+)
+
+type MatchmakerFilter interface {
+	Type() Filter
+}
+
+type MatchmakerTermFilter struct {
+	Terms    []string
+	AllTerms bool // set to False for Any Term
+}
+
+func (*MatchmakerTermFilter) Type() Filter {
+	return TERM
+}
+
+type MatchmakerRangeFilter struct {
+	LowerBound int64
+	UpperBound int64
+}
+
+func (*MatchmakerRangeFilter) Type() Filter {
+	return RANGE
+}
+
+type MatchmakerBoolFilter struct {
+	Value bool
+}
+
+func (*MatchmakerBoolFilter) Type() Filter {
+	return BOOL
+}
+
+type MatchmakerAcceptedProperty struct {
+	UserID     uuid.UUID
+	Properties map[string]interface{}
+	Filters    map[string]MatchmakerFilter
 }
 
 type MatchmakerKey struct {
@@ -35,7 +80,9 @@ type MatchmakerKey struct {
 
 type MatchmakerProfile struct {
 	Meta          PresenceMeta
-	RequiredCount int64
+	RequiredCount int
+	Properties    map[string]interface{}
+	Filters       map[string]MatchmakerFilter
 }
 
 type MatchmakerService struct {
@@ -51,36 +98,159 @@ func NewMatchmakerService(name string) *MatchmakerService {
 	}
 }
 
-func (m *MatchmakerService) Add(sessionID uuid.UUID, userID uuid.UUID, meta PresenceMeta, requiredCount int64) (uuid.UUID, map[MatchmakerKey]*MatchmakerProfile) {
+func (m *MatchmakerService) Add(sessionID uuid.UUID, userID uuid.UUID, incomingProfile *MatchmakerProfile) (uuid.UUID, map[MatchmakerKey]*MatchmakerProfile, []*MatchmakerAcceptedProperty) {
 	ticket := uuid.NewV4()
-	selected := make(map[MatchmakerKey]*MatchmakerProfile, requiredCount-1)
-	qmk := MatchmakerKey{ID: PresenceID{SessionID: sessionID, Node: m.name}, UserID: userID, Ticket: ticket}
-	qmp := &MatchmakerProfile{Meta: meta, RequiredCount: requiredCount}
+	candidates := make(map[MatchmakerKey]*MatchmakerProfile, incomingProfile.RequiredCount-1)
+	requestKey := MatchmakerKey{ID: PresenceID{SessionID: sessionID, Node: m.name}, UserID: userID, Ticket: ticket}
 
 	m.Lock()
-	for mk, mp := range m.values {
-		if mk.ID.SessionID != sessionID && mk.UserID != userID && mp.RequiredCount == requiredCount {
-			selected[mk] = mp
-			if int64(len(selected)) == requiredCount-1 {
-				break
+	defer m.Unlock()
+
+	// find list of suitable candidates
+	for key, profile := range m.values {
+		// if queued users match the current user, then skip
+		if key.ID.SessionID == sessionID || key.UserID == userID {
+			continue
+		}
+
+		// compatible with the request's filter
+		if !m.checkFilter(incomingProfile, profile) {
+			continue
+		}
+
+		// compatible with the profile's filter
+		if !m.checkFilter(profile, incomingProfile) {
+			continue
+		}
+
+		candidates[key] = profile
+	}
+
+	// cross match all previously selected profiles
+	// to see if they are compatible with each other as well
+	matches := m.crossmatchCandidates(candidates, incomingProfile.RequiredCount-1)
+
+	// not enough profiles, bail out early
+	if len(matches) < int(incomingProfile.RequiredCount-1) {
+		m.values[requestKey] = incomingProfile
+		return ticket, nil, nil
+	}
+
+	// remove the matched profiles from the queue
+	for mk, _ := range matches {
+		delete(m.values, mk)
+	}
+
+	// add the incoming profile to the final list
+	matches[requestKey] = incomingProfile
+
+	return ticket, matches, m.calculateAcceptedProperties(matches)
+}
+
+func (m *MatchmakerService) crossmatchCandidates(candidates map[MatchmakerKey]*MatchmakerProfile, requiredCount int) map[MatchmakerKey]*MatchmakerProfile {
+	if requiredCount == 0 {
+		return map[MatchmakerKey]*MatchmakerProfile{}
+	}
+
+	if requiredCount > len(candidates) {
+		return nil
+	}
+
+	keys := make([]MatchmakerKey, 0)
+	values := make([]*MatchmakerProfile, 0)
+	for key, value := range candidates {
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+
+	for i := 0; i < len(keys); i++ {
+		s := values[i]
+		tempCandidates := make(map[MatchmakerKey]*MatchmakerProfile, 0)
+		for j := i + 1; j < len(keys); j++ {
+			p := values[j]
+			if m.checkFilter(s, p) && m.checkFilter(p, s) {
+				tempCandidates[keys[j]] = p
+			}
+		}
+
+		findCandidateResult := m.crossmatchCandidates(tempCandidates, requiredCount-1)
+		if findCandidateResult != nil {
+			findCandidateResult[keys[i]] = s
+			return findCandidateResult
+		}
+	}
+	return nil
+}
+
+func (m *MatchmakerService) checkFilter(requestProfile, queuedProfile *MatchmakerProfile) bool {
+	if queuedProfile.RequiredCount != requestProfile.RequiredCount {
+		return false
+	}
+
+	for filterName, filter := range requestProfile.Filters {
+		propertyValue := queuedProfile.Properties[filterName]
+		if propertyValue == nil {
+			return false
+		}
+
+		if filter.Type() == TERM {
+			termFilter := filter.(*MatchmakerTermFilter)
+			propertyTermList, ok := propertyValue.([]string)
+			if !ok {
+				return false
+			}
+
+			matchingTerms := m.intersection(termFilter.Terms, propertyTermList)
+			if len(matchingTerms) == 0 {
+				return false
+			}
+
+			if termFilter.AllTerms && len(matchingTerms) != len(termFilter.Terms) {
+				return false
+			}
+		} else if filter.Type() == RANGE {
+			rangeFilter := filter.(*MatchmakerRangeFilter)
+			propertyInt, ok := propertyValue.(int64)
+
+			if !ok || propertyInt < rangeFilter.LowerBound || propertyInt > rangeFilter.UpperBound {
+				return false
+			}
+		} else if filter.Type() == BOOL {
+			boolFilter := filter.(*MatchmakerBoolFilter)
+			propertyBool, ok := propertyValue.(bool)
+			if !ok || boolFilter.Value != propertyBool {
+				return false
 			}
 		}
 	}
-	if int64(len(selected)) == requiredCount-1 {
-		for mk, _ := range selected {
-			delete(m.values, mk)
-		}
-		selected[qmk] = qmp
-	} else {
-		m.values[qmk] = qmp
-	}
-	m.Unlock()
 
-	if int64(len(selected)) != requiredCount {
-		return ticket, nil
-	} else {
-		return ticket, selected
+	return true
+}
+
+func (m *MatchmakerService) calculateAcceptedProperties(matched map[MatchmakerKey]*MatchmakerProfile) []*MatchmakerAcceptedProperty {
+	props := make([]*MatchmakerAcceptedProperty, 0)
+	for key, profile := range matched {
+		prop := &MatchmakerAcceptedProperty{
+			UserID:     key.UserID,
+			Properties: profile.Properties,
+			Filters:    profile.Filters,
+		}
+		props = append(props, prop)
 	}
+
+	return props
+}
+
+func (m *MatchmakerService) intersection(a, b []string) []string {
+	o := make([]string, 0)
+	for i := range a {
+		for j := range b {
+			if a[i] == b[j] {
+				o = append(o, a[i])
+			}
+		}
+	}
+	return o
 }
 
 func (m *MatchmakerService) Remove(sessionID uuid.UUID, userID uuid.UUID, ticket uuid.UUID) error {

--- a/server/pipeline_matchmake.go
+++ b/server/pipeline_matchmake.go
@@ -38,7 +38,7 @@ func (p *pipeline) matchmakeAdd(logger *zap.Logger, session *session, envelope *
 		case *PropertyPair_IntValue:
 			properties[pair.Key] = v.IntValue
 		case *PropertyPair_StringSet_:
-			properties[pair.Key] = v.StringSet.Values
+			properties[pair.Key] = uniqueList(v.StringSet.Values)
 		}
 	}
 
@@ -50,7 +50,7 @@ func (p *pipeline) matchmakeAdd(logger *zap.Logger, session *session, envelope *
 		case *MatchmakeFilter_Range:
 			filters[filter.Name] = &MatchmakerRangeFilter{v.Range.LowerBound, v.Range.UpperBound}
 		case *MatchmakeFilter_Term:
-			filters[filter.Name] = &MatchmakerTermFilter{v.Term.Terms, v.Term.MatchAllTerms}
+			filters[filter.Name] = &MatchmakerTermFilter{uniqueList(v.Term.Terms), v.Term.MatchAllTerms}
 		}
 	}
 

--- a/server/pipeline_matchmake.go
+++ b/server/pipeline_matchmake.go
@@ -38,7 +38,7 @@ func (p *pipeline) matchmakeAdd(logger *zap.Logger, session *session, envelope *
 		case *PropertyPair_IntValue:
 			properties[pair.Key] = v.IntValue
 		case *PropertyPair_StringSet_:
-			properties[pair.Key] = uniqueList(v.StringSet.Values)
+			properties[pair.Key] = v.StringSet.Values
 		}
 	}
 

--- a/server/pipeline_matchmake.go
+++ b/server/pipeline_matchmake.go
@@ -15,20 +15,52 @@
 package server
 
 import (
+	"time"
+
 	"github.com/dgrijalva/jwt-go"
 	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
-	"time"
 )
 
 func (p *pipeline) matchmakeAdd(logger *zap.Logger, session *session, envelope *Envelope) {
-	requiredCount := envelope.GetMatchmakeAdd().RequiredCount
+	matchmakeAdd := envelope.GetMatchmakeAdd()
+	requiredCount := matchmakeAdd.RequiredCount
 	if requiredCount < 2 {
 		session.Send(ErrorMessageBadInput(envelope.CollationId, "Required count must be >= 2"))
 		return
 	}
 
-	ticket, selected := p.matchmaker.Add(session.id, session.userID, PresenceMeta{Handle: session.handle.Load()}, requiredCount)
+	properties := make(map[string]interface{}, 0)
+	for _, pair := range matchmakeAdd.Properties {
+		switch v := pair.Value.(type) {
+		case *PropertyPair_BoolValue:
+			properties[pair.Key] = v.BoolValue
+		case *PropertyPair_IntValue:
+			properties[pair.Key] = v.IntValue
+		case *PropertyPair_StringList_:
+			properties[pair.Key] = v.StringList.Values
+		}
+	}
+
+	filters := make(map[string]MatchmakerFilter)
+	for _, filter := range matchmakeAdd.Filters {
+		switch v := filter.Value.(type) {
+		case *MatchmakeFilter_Check:
+			filters[filter.Name] = &MatchmakerBoolFilter{v.Check}
+		case *MatchmakeFilter_Range:
+			filters[filter.Name] = &MatchmakerRangeFilter{v.Range.LowerBound, v.Range.UpperBound}
+		case *MatchmakeFilter_Term:
+			filters[filter.Name] = &MatchmakerTermFilter{v.Term.Terms, v.Term.MatchAllTerms}
+		}
+	}
+
+	matchmakerProfile := &MatchmakerProfile{
+		Meta:          PresenceMeta{Handle: session.handle.Load()},
+		RequiredCount: int(requiredCount),
+		Properties:    properties,
+		Filters:       filters,
+	}
+	ticket, selected, props := p.matchmaker.Add(session.id, session.userID, matchmakerProfile)
 
 	session.Send(&Envelope{CollationId: envelope.CollationId, Payload: &Envelope_MatchmakeTicket{MatchmakeTicket: &TMatchmakeTicket{
 		Ticket: ticket.Bytes(),
@@ -55,10 +87,56 @@ func (p *pipeline) matchmakeAdd(logger *zap.Logger, session *session, envelope *
 		}
 		idx++
 	}
+
+	protoProps := make([]*MatchmakeMatched_UserProperty, 0)
+	for _, prop := range props {
+		protoProp := &MatchmakeMatched_UserProperty{
+			UserId:     prop.UserID.Bytes(),
+			Properties: make([]*PropertyPair, 0),
+			Filters:    make([]*MatchmakeFilter, 0),
+		}
+		protoProps = append(protoProps, protoProp)
+
+		for userPropertyKey, userPropertyValue := range prop.Properties {
+			pair := &PropertyPair{Key: userPropertyKey}
+			protoProp.Properties = append(protoProp.Properties, pair)
+			switch v := userPropertyValue.(type) {
+			case int64:
+				pair.Value = &PropertyPair_IntValue{v}
+			case bool:
+				pair.Value = &PropertyPair_BoolValue{v}
+			case []string:
+				pair.Value = &PropertyPair_StringList_{&PropertyPair_StringList{v}}
+			}
+		}
+
+		for userFilterKey, userFilterValue := range prop.Filters {
+			filter := &MatchmakeFilter{Name: userFilterKey}
+			protoProp.Filters = append(protoProp.Filters, filter)
+			switch userFilterValue.Type() {
+			case TERM:
+				f := userFilterValue.(*MatchmakerTermFilter)
+				filter.Value = &MatchmakeFilter_Term{&MatchmakeFilter_TermFilter{f.Terms, f.AllTerms}}
+			case RANGE:
+				f := userFilterValue.(*MatchmakerRangeFilter)
+				filter.Value = &MatchmakeFilter_Range{&MatchmakeFilter_RangeFilter{f.LowerBound, f.UpperBound}}
+			case BOOL:
+				f := userFilterValue.(*MatchmakerBoolFilter)
+				filter.Value = &MatchmakeFilter_Check{f.Value}
+			}
+		}
+
+		logger.Info("propProp", zap.Any("pp", protoProp))
+		logger.Info("propProp-Prop", zap.Any("pp", len(protoProp.Properties)))
+		logger.Info("propProp-Filter", zap.Any("pp", len(protoProp.Filters)))
+		logger.Info("propProps-length", zap.Any("length", len(protoProps)))
+	}
+
 	outgoing := &Envelope{Payload: &Envelope_MatchmakeMatched{MatchmakeMatched: &MatchmakeMatched{
 		// Ticket: ..., // Set individually below for each recipient.
-		Token:     []byte(signedToken),
-		Presences: ps,
+		Token:      []byte(signedToken),
+		Presences:  ps,
+		Properties: protoProps,
 		// Self:   ..., // Set individually below for each recipient.
 	}}}
 	for mk, mp := range selected {
@@ -76,6 +154,7 @@ func (p *pipeline) matchmakeAdd(logger *zap.Logger, session *session, envelope *
 			SessionId: mk.ID.SessionID.Bytes(),
 			Handle:    mp.Meta.Handle,
 		}
+
 		p.messageRouter.Send(logger, to, outgoing)
 	}
 }

--- a/tests/matchmaker_test.go
+++ b/tests/matchmaker_test.go
@@ -1,0 +1,497 @@
+// Copyright 2017 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"nakama/server"
+	"testing"
+
+	"sort"
+
+	"github.com/satori/go.uuid"
+)
+
+var matchmaker server.Matchmaker
+
+func newMatchmaker() {
+	matchmaker = server.NewMatchmakerService("test_node")
+}
+
+func add(props map[string]interface{}, filters map[string]server.MatchmakerFilter) (uuid.UUID, map[server.MatchmakerKey]*server.MatchmakerProfile, []*server.MatchmakerAcceptedProperty) {
+	userID := uuid.NewV4()
+	profile := &server.MatchmakerProfile{
+		Meta:          server.PresenceMeta{userID.String()},
+		RequiredCount: 2,
+		Properties:    props,
+		Filters:       filters,
+	}
+	_, m, p := matchmaker.Add(uuid.NewV4(), userID, profile)
+	return userID, m, p
+}
+
+// Two users, both having the same required count and no other filters
+func TestMatchmakeOnlyRequiredCount(t *testing.T) {
+	newMatchmaker()
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, nil)
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Somehow found matches with a new matchmaker!")
+	}
+
+	_, matched, matchedCriteria = add(map[string]interface{}{
+		"rank":  int64(12),
+		"modes": []string{"tdm"},
+	}, nil)
+	if matched == nil || matchedCriteria == nil {
+		t.Fatal("Matchmaking failed with nil result")
+	}
+
+	if len(matched) != 2 {
+		t.Fatal("Matchmaking did not matched expected result")
+	}
+}
+
+// Two users, both having the same required count
+// and both with range filters that match each other
+func TestMatchmakeRange(t *testing.T) {
+	newMatchmaker()
+
+	profile1id, _, _ := add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{8, 12},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(12),
+		"modes": []string{"tdm"},
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{10, 14},
+	})
+
+	if matched == nil || matchedCriteria == nil {
+		t.Fatal("Matchmaking failed with nil result")
+	}
+
+	if len(matched) != 2 {
+		t.Fatal("Matchmaking did not matched expected result")
+	}
+
+	// make sure data is sorted
+	sort.Slice(matchedCriteria, func(i, j int) bool { return matchedCriteria[i].UserID.String() == profile1id.String() })
+
+	p := matchedCriteria[0].Properties
+	if p["rank"] != int64(10) {
+		t.Fatal("Profile 1 rank does not match")
+	}
+
+	p = matchedCriteria[1].Properties
+	if p["rank"] != int64(12) {
+		t.Fatal("Profile 2 rank does not match")
+	}
+}
+
+// Two users, both having the same required count
+// and both with ANY terms filters that match each other
+func TestMatchmakeAnyTerms(t *testing.T) {
+	newMatchmaker()
+
+	profile1id, _, _ := add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, false},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(12),
+		"modes": []string{"tdm"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm"}, false},
+	})
+
+	if matched == nil || matchedCriteria == nil {
+		t.Fatal("Matchmaking failed with nil result")
+	}
+
+	if len(matched) != 2 {
+		t.Fatal("Matchmaking did not matched expected result")
+	}
+
+	// make sure data is sorted
+	sort.Slice(matchedCriteria, func(i, j int) bool { return matchedCriteria[i].UserID.String() == profile1id.String() })
+
+	p := matchedCriteria[0].Properties
+	pt := p["modes"].([]string)
+	if len(pt) != 2 {
+		t.Fatal("Profile 1 modes does not match")
+	}
+
+	p = matchedCriteria[1].Properties
+	pt = p["modes"].([]string)
+	if pt[0] != "tdm" || len(pt) != 1 {
+		t.Fatal("Profile 2 modes does not match")
+	}
+}
+
+// Two users, both having the same required count
+// and both with ALL terms filters that DON'T match each other
+func TestMatchmakeAllTerms1(t *testing.T) {
+	newMatchmaker()
+
+	add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, true},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(12),
+		"modes": []string{"tdm"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm"}, false},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+}
+
+// Two users, both having the same required count
+// and both with terms filters that DO match each other
+// reversed term filters
+func TestMatchmakeAllTerms2(t *testing.T) {
+	newMatchmaker()
+
+	profile1id, _, _ := add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, false},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(12),
+		"modes": []string{"tdm"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm"}, true},
+	})
+
+	if matched == nil || matchedCriteria == nil {
+		t.Fatal("Matchmaking failed with nil result")
+	}
+
+	if len(matched) != 2 {
+		t.Fatal("Matchmaking did not matched expected result")
+	}
+
+	// make sure data is sorted
+	sort.Slice(matchedCriteria, func(i, j int) bool { return matchedCriteria[i].UserID.String() == profile1id.String() })
+
+	p := matchedCriteria[0].Properties
+	pt := p["modes"].([]string)
+	if len(pt) != 2 {
+		t.Fatal("Profile 1 modes does not match")
+	}
+
+	p = matchedCriteria[1].Properties
+	pt = p["modes"].([]string)
+	if pt[0] != "tdm" || len(pt) != 1 {
+		t.Fatal("Profile 2 modes does not match")
+	}
+}
+
+func TestMatchmakeBoolFalse(t *testing.T) {
+	newMatchmaker()
+
+	add(map[string]interface{}{
+		"rank":   int64(10),
+		"modes":  []string{"tdm", "s-d"},
+		"ranked": true,
+	}, map[string]server.MatchmakerFilter{
+		"ranked": &server.MatchmakerBoolFilter{true},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":   int64(12),
+		"modes":  []string{"tdm"},
+		"ranked": false,
+	}, map[string]server.MatchmakerFilter{
+		"ranked": &server.MatchmakerBoolFilter{false},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+}
+
+func TestMatchmakeUnmatchingRange(t *testing.T) {
+	newMatchmaker()
+
+	add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{8, 12},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(5),
+		"modes": []string{"tdm"},
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{10, 14},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+}
+
+func TestMatchmakeUnmatchingAllTerms(t *testing.T) {
+	newMatchmaker()
+
+	add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, true},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(5),
+		"modes": []string{"tdm", "s-d", "ffa"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d", "ffa"}, true},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+
+	newMatchmaker()
+
+	add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d", "ffa"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d", "ffa"}, true},
+	})
+
+	_, matched, matchedCriteria = add(map[string]interface{}{
+		"rank":  int64(5),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, true},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+
+	newMatchmaker()
+
+	add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, false},
+	})
+
+	_, matched, matchedCriteria = add(map[string]interface{}{
+		"rank":  int64(5),
+		"modes": []string{"tdm", "s-d", "ffa"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d", "ffa"}, true},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+}
+
+func TestMatchmakeUnmatchingMissingProperties(t *testing.T) {
+	// missing rank property
+	newMatchmaker()
+	add(map[string]interface{}{
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{8, 12},
+	})
+
+	_, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(5),
+		"modes": []string{"tdm"},
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{10, 14},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+
+	// missing modes
+	newMatchmaker()
+	add(map[string]interface{}{
+		"rank": int64(10),
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d", "ffa"}, true},
+	})
+
+	_, matched, matchedCriteria = add(map[string]interface{}{
+		"rank":  int64(5),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, true},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+
+	// missing modes - reversed
+	newMatchmaker()
+	add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm", "s-d", "ffa"},
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d", "ffa"}, true},
+	})
+
+	_, matched, matchedCriteria = add(map[string]interface{}{
+		"rank": int64(5),
+	}, map[string]server.MatchmakerFilter{
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, true},
+	})
+
+	if matched != nil || matchedCriteria != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+}
+
+func TestMatchmakeMultipleProfile(t *testing.T) {
+	newMatchmaker()
+	profile1, _, _ := add(map[string]interface{}{
+		"rank":  int64(10),
+		"modes": []string{"tdm"},
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{10, 14},
+		// not matching on "modes"
+	})
+
+	_, matched, _ := add(map[string]interface{}{
+		"rank": int64(8),
+	}, map[string]server.MatchmakerFilter{
+		"rank": &server.MatchmakerRangeFilter{10, 14},
+	})
+	if matched != nil {
+		t.Fatal("Expected Matchmaking to fail but found with unexpected results")
+	}
+
+	profile3, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":  int64(11),
+		"modes": []string{"tdm", "s-d"},
+	}, map[string]server.MatchmakerFilter{
+		"rank":  &server.MatchmakerRangeFilter{8, 12},
+		"modes": &server.MatchmakerTermFilter{[]string{"tdm", "s-d"}, false},
+	})
+
+	if matched == nil || matchedCriteria == nil {
+		t.Fatal("Matchmaking failed with nil result")
+	}
+
+	if len(matched) != 2 {
+		t.Fatal("Matchmaking did not matched expected result")
+	}
+
+	// make sure data is sorted
+	sort.Slice(matchedCriteria, func(i, j int) bool { return matchedCriteria[i].UserID.String() == profile1.String() })
+
+	if matchedCriteria[1].UserID.String() == profile1.String() || matchedCriteria[0].UserID.String() == profile3.String() {
+		t.Fatal("Matchmaking did not matched expected result - wrong matches")
+	}
+
+	p := matchedCriteria[0].Properties
+	pt := p["modes"].([]string)
+	if pt[0] != "tdm" || len(pt) != 1 {
+		t.Fatal("Profile 1 modes does not match")
+	}
+
+	if p["rank"].(int64) != 10 {
+		t.Fatal("Profile 1 rank does not match")
+	}
+
+	p = matchedCriteria[1].Properties
+	pt = p["modes"].([]string)
+	if len(pt) != 2 {
+		t.Fatal("Profile 2 modes does not match")
+	}
+
+	if p["rank"].(int64) != 11 {
+		t.Fatal("Profile 2 rank does not match")
+	}
+}
+
+func TestMatchmakeMultiFilter(t *testing.T) {
+	newMatchmaker()
+	profile1, _, _ := add(map[string]interface{}{
+		"rank":      int64(10),
+		"modes":     []string{"tdm", "ffa"},
+		"divisions": []string{"silver1"},
+	}, map[string]server.MatchmakerFilter{
+		"rank":      &server.MatchmakerRangeFilter{10, 15},
+		"modes":     &server.MatchmakerTermFilter{[]string{"tdm", "ffa"}, false},
+		"divisions": &server.MatchmakerTermFilter{[]string{"bronze3", "silver1", "silver2"}, false},
+	})
+
+	profile2, matched, matchedCriteria := add(map[string]interface{}{
+		"rank":      int64(10),
+		"modes":     []string{"tdm", "ffa"},
+		"divisions": []string{"bronze3"},
+	}, map[string]server.MatchmakerFilter{
+		"rank":      &server.MatchmakerRangeFilter{8, 12},
+		"modes":     &server.MatchmakerTermFilter{[]string{"tdm", "ffa"}, false},
+		"divisions": &server.MatchmakerTermFilter{[]string{"bronze2", "bronze3", "silver1"}, false},
+	})
+
+	if matched == nil || matchedCriteria == nil {
+		t.Fatal("Matchmaking failed with nil result")
+	}
+
+	if len(matched) != 2 {
+		t.Fatal("Matchmaking did not matched expected result")
+	}
+
+	// make sure data is sorted
+	sort.Slice(matchedCriteria, func(i, j int) bool { return matchedCriteria[i].UserID.String() == profile1.String() })
+
+	if matchedCriteria[1].UserID.String() == profile1.String() || matchedCriteria[0].UserID.String() == profile2.String() {
+		t.Fatal("Matchmaking did not matched expected result - wrong matches")
+	}
+
+	p := matchedCriteria[0].Properties
+	if p["rank"].(int64) != int64(10) {
+		t.Fatal("Profile 1 rank does not match")
+	}
+
+	p = matchedCriteria[1].Properties
+	if p["rank"].(int64) != int64(10) {
+		t.Fatal("Profile 2 rank does not match")
+	}
+}


### PR DESCRIPTION
- Update docker-compose to Cockroach 1.0.6

Using advanced matchmaker, you can:
- Setup single/multi-term filters, and setup how those filters should be matched (any of the terms, or all the terms must match)
- Matchmake based on a range
- Matchmake based on a boolean condition.
- You can setup as many filter as you like on a matchmaking request.

Alongside filters, you can supply user properties. Filters are matched against user properties, so the same filter-name and property-name must match before the filter is evaluated against that user.

You can supply extra user properties for metadata information. All user properties and all filters are redistributed back to each client when matches are found.

This answers #11 and #87.