### PR TITLE
Improve graceful shutdown, more allowed CORS headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Improve graceful shutdown behaviour by ensuring the server stops accepting connections before halting other components.
+- Add User-Agent to the default list of accepted CORS request headers.
 
 ## [1.2.0] - 2017-11-06
 ### Added


### PR DESCRIPTION
- Improve graceful shutdown behaviour by ensuring the server stops accepting connections before halting other components.
- Add User-Agent to the default list of accepted CORS request headers.