### PR TITLE
DB version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Add User-Agent to the default list of accepted CORS request headers.
 - Improve how the dashboard component is stopped when server shuts down.
 - Improve dashboard CORS support by extending the list of allowed request headers.
+- Server startup output now contains database version string.
+- Migrate command output now contains database version string.
+- Doctor command output now contains database version string.
+
+### Changed
+- Internal operations exposed to the script runtime through function bindings now silently ignore unknown parameters.
 
 ## [1.2.0] - 2017-11-06
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,7 @@ dbsetup:
 	./${BUILDDIR}/dev/${BINNAME} migrate up
 
 .PHONY: dbreset
-dbreset:
-	./${BUILDDIR}/dev/${BINNAME} migrate down --limit 0
+dbreset: dbstop $(shell rm -rf /tmp/cockroach) dbstart
 
 .PHONY: dockerbuild
 dockerbuild:

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -126,6 +126,12 @@ func MigrateParse(args []string, logger *zap.Logger) {
 		logger.Fatal("Error pinging database", zap.Error(err))
 	}
 
+	var dbVersion string
+	if err = db.QueryRow("SELECT version()").Scan(&dbVersion); err != nil {
+		logger.Fatal("Error querying database version", zap.Error(err))
+	}
+	logger.Info("Database information", zap.String("version", dbVersion))
+
 	var exists bool
 	err = db.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", dbname).Scan(&exists)
 start:

--- a/server/dashboard_accepter.go
+++ b/server/dashboard_accepter.go
@@ -33,6 +33,7 @@ import (
 type dashboardService struct {
 	logger              *zap.Logger
 	version             string
+	dbVersion           string
 	config              Config
 	statsService        StatsService
 	httpServer          *http.Server
@@ -41,10 +42,11 @@ type dashboardService struct {
 }
 
 // NewDashboardService creates a new dashboardService
-func NewDashboardService(logger *zap.Logger, multiLogger *zap.Logger, version string, config Config, statsService StatsService) *dashboardService {
+func NewDashboardService(logger *zap.Logger, multiLogger *zap.Logger, version string, dbVersion string, config Config, statsService StatsService) *dashboardService {
 	service := &dashboardService{
 		logger:       logger,
 		version:      version,
+		dbVersion:    dbVersion,
 		config:       config,
 		statsService: statsService,
 		mux:          mux.NewRouter(),
@@ -106,11 +108,12 @@ func (s *dashboardService) infoHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
 	info := map[string]interface{}{
-		"version": s.version,
-		"go":      runtime.Version(),
-		"arch":    runtime.GOARCH,
-		"os":      runtime.GOOS,
-		"cpus":    runtime.NumCPU(),
+		"version":    s.version,
+		"db_version": s.dbVersion,
+		"go":         runtime.Version(),
+		"arch":       runtime.GOARCH,
+		"os":         runtime.GOOS,
+		"cpus":       runtime.NumCPU(),
 	}
 
 	infoBytes, _ := json.Marshal(info)

--- a/server/runtime_nakama_module.go
+++ b/server/runtime_nakama_module.go
@@ -762,9 +762,6 @@ func (n *NakamaModule) usersUpdate(l *lua.LState) int {
 					return
 				}
 				update.AvatarUrl = v.String()
-			default:
-				conversionError = "unrecognised update key, expects a valid set of user updates"
-				return
 			}
 		})
 
@@ -1222,9 +1219,6 @@ func (n *NakamaModule) storageUpdate(l *lua.LState) int {
 					return
 				}
 				update.Patch = patch
-			default:
-				conversionError = "unrecognised update key, expects a valid set of storage updates"
-				return
 			}
 		})
 
@@ -1796,9 +1790,6 @@ func (n *NakamaModule) groupsUpdate(l *lua.LState) int {
 				}
 
 				p.Metadata = string(metadataBytes)
-			default:
-				conversionError = fmt.Sprintf("unknown group field: %v", k.String())
-				return
 			}
 		})
 


### PR DESCRIPTION
- Server startup output now contains database version string.
- Migrate command output now contains database version string.
- Doctor command output now contains database version string.
- Internal operations exposed to the script runtime through function bindings now silently ignore unknown parameters.