### PR TITLE
DB updates for constraint and content size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Runtime after hooks now include both the incoming and outgoing payloads.
+
+### Changed
+- Nakama will now log an error and refuse to start if the schema is outdated.
+- Drop unused leaderboard 'next' and 'previous' fields.
+- A user's 'last online at' field now contains a current UTC milliseconds timestamp if they are currently online.
+- Storage remove operations now ignore records that don't exist.
 
 ## [1.3.0] - 2017-11-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Drop unused leaderboard 'next' and 'previous' fields.
 - A user's 'last online at' field now contains a current UTC milliseconds timestamp if they are currently online.
 - Storage remove operations now ignore records that don't exist.
+- Fields that expect JSON content now allow up to 32kb of data.
 
 ## [1.3.0] - 2017-11-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
 ## [Unreleased]
-### Added
-- Runtime after hooks now include both the incoming and outgoing payloads.
-
 ### Changed
 - Nakama will now log an error and refuse to start if the schema is outdated.
 - Drop unused leaderboard 'next' and 'previous' fields.

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -62,12 +62,12 @@ func MigrationStartupCheck(logger *zap.Logger, db *sql.DB) {
 	}
 	records, err := migrate.GetMigrationRecords(db, dialect)
 	if err != nil {
-		logger.Fatal("Could not get migration records", zap.Error(err))
+		logger.Fatal("Could not get migration records, run `nakama migrate up`", zap.Error(err))
 	}
 
 	diff := len(migrations) - len(records)
 	if diff > 0 {
-		logger.Warn("DB schema outdated, run `nakama migrate up`", zap.Int("migrations", diff))
+		logger.Fatal("DB schema outdated, run `nakama migrate up`", zap.Int("migrations", diff))
 	}
 	if diff < 0 {
 		logger.Warn("DB schema newer, update Nakama", zap.Int64("migrations", int64(math.Abs(float64(diff)))))

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 	trackerService.AddDiffListener(presenceNotifier.HandleDiff)
 	notificationService := server.NewNotificationService(jsonLogger, db, trackerService, messageRouter, config.GetSocial().Notification)
 
-	runtimePool, err := server.NewRuntimePool(jsonLogger, multiLogger, db, config.GetRuntime(), notificationService)
+	runtimePool, err := server.NewRuntimePool(jsonLogger, multiLogger, db, config.GetRuntime(), trackerService, notificationService)
 	if err != nil {
 		multiLogger.Fatal("Failed initializing runtime modules.", zap.Error(err))
 	}

--- a/migrations/20170115200001_initial_schema.sql
+++ b/migrations/20170115200001_initial_schema.sql
@@ -37,8 +37,7 @@ CREATE TABLE IF NOT EXISTS users (
     created_at     BIGINT        CHECK (created_at > 0) NOT NULL,
     updated_at     BIGINT        CHECK (updated_at > 0) NOT NULL,
     verified_at    BIGINT        CHECK (verified_at >= 0) DEFAULT 0 NOT NULL,
-    disabled_at    BIGINT        CHECK (disabled_at >= 0) DEFAULT 0 NOT NULL,
-    last_online_at BIGINT        CHECK (last_online_at >= 0) DEFAULT 0 NOT NULL
+    disabled_at    BIGINT        CHECK (disabled_at >= 0) DEFAULT 0 NOT NULL
 );
 
 -- This table should be replaced with an array column in the users table

--- a/migrations/20170228205100_leaderboards.sql
+++ b/migrations/20170228205100_leaderboards.sql
@@ -17,16 +17,12 @@
 -- +migrate Up
 CREATE TABLE IF NOT EXISTS leaderboard (
     PRIMARY KEY (id),
-    FOREIGN KEY (next_id) REFERENCES leaderboard(id),
-    FOREIGN KEY (prev_id) REFERENCES leaderboard(id),
     id             BYTEA        NOT NULL,
     authoritative  BOOLEAN      DEFAULT FALSE,
     sort_order     SMALLINT     DEFAULT 1 NOT NULL, -- asc(0), desc(1)
     count          BIGINT       DEFAULT 0 CHECK (count >= 0) NOT NULL,
     reset_schedule VARCHAR(64), -- e.g. cron format: "* * * * * * *"
-    metadata       BYTEA        DEFAULT '{}' CHECK (length(metadata) < 16000) NOT NULL,
-    next_id        BYTEA        DEFAULT NULL::BYTEA CHECK (next_id <> id),
-    prev_id        BYTEA        DEFAULT NULL::BYTEA CHECK (prev_id <> id)
+    metadata       BYTEA        DEFAULT '{}' CHECK (length(metadata) < 16000) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS leaderboard_record (

--- a/migrations/20171212154402_last_online.sql
+++ b/migrations/20171212154402_last_online.sql
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 The Nakama Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- +migrate Up
+ALTER TABLE IF EXISTS leaderboard DROP CONSTRAINT IF EXISTS check_next_id_id;
+ALTER TABLE IF EXISTS leaderboard DROP CONSTRAINT IF EXISTS fk_next_id_ref_leaderboard;
+ALTER TABLE IF EXISTS leaderboard DROP CONSTRAINT IF EXISTS check_prev_id_id;
+ALTER TABLE IF EXISTS leaderboard DROP CONSTRAINT IF EXISTS fk_prev_id_ref_leaderboard;
+
+ALTER TABLE IF EXISTS leaderboard DROP COLUMN IF EXISTS next_id;
+ALTER TABLE IF EXISTS leaderboard DROP COLUMN IF EXISTS prev_id;
+
+ALTER TABLE IF EXISTS users DROP CONSTRAINT IF EXISTS check_last_online_at;
+
+ALTER TABLE IF EXISTS users DROP COLUMN IF EXISTS last_online_at;
+
+-- +migrate Down
+ALTER TABLE IF EXISTS leaderboard ADD COLUMN IF NOT EXISTS next_id BYTEA DEFAULT NULL::BYTEA;
+ALTER TABLE IF EXISTS leaderboard ADD COLUMN IF NOT EXISTS prev_id BYTEA DEFAULT NULL::BYTEA;
+
+ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS last_online_at BIGINT NOT NULL DEFAULT 0;
+
+CREATE INDEX ON leaderboard (next_id);
+CREATE INDEX ON leaderboard (prev_id);
+
+-- FIXME cannot create constraints until newly added columns are committed, but that causes issues with the migration.
+-- -- Commit so we can add constraints on the new columns.
+-- COMMIT;
+--
+-- ALTER TABLE IF EXISTS leaderboard ADD CONSTRAINT fk_next_id_ref_leaderboard FOREIGN KEY (next_id) REFERENCES leaderboard(id);
+-- ALTER TABLE IF EXISTS leaderboard ADD CONSTRAINT check_next_id_id CHECK (next_id <> id);
+-- ALTER TABLE IF EXISTS leaderboard ADD CONSTRAINT fk_prev_id_ref_leaderboard FOREIGN KEY (prev_id) REFERENCES leaderboard(id);
+-- ALTER TABLE IF EXISTS leaderboard ADD CONSTRAINT check_prev_id_id CHECK (prev_id <> id);
+
+-- ALTER TABLE IF EXISTS users ADD CONSTRAINT check_last_online_at CHECK (last_online_at >= 0);

--- a/migrations/20171212154402_last_online.sql
+++ b/migrations/20171212154402_last_online.sql
@@ -27,7 +27,37 @@ ALTER TABLE IF EXISTS users DROP CONSTRAINT IF EXISTS check_last_online_at;
 
 ALTER TABLE IF EXISTS users DROP COLUMN IF EXISTS last_online_at;
 
+ALTER TABLE IF EXISTS users DROP CONSTRAINT IF EXISTS check_metadata;
+ALTER TABLE IF EXISTS users ADD CONSTRAINT check_metadata CHECK (length(metadata) < 32000);
+
+ALTER TABLE IF EXISTS groups DROP CONSTRAINT IF EXISTS check_metadata;
+ALTER TABLE IF EXISTS groups ADD CONSTRAINT check_metadata CHECK (length(metadata) < 32000);
+
+ALTER TABLE IF EXISTS storage DROP CONSTRAINT IF EXISTS check_value;
+ALTER TABLE IF EXISTS storage ADD CONSTRAINT check_value CHECK (length(value) < 32000);
+
+ALTER TABLE IF EXISTS leaderboard_record DROP CONSTRAINT IF EXISTS check_metadata;
+ALTER TABLE IF EXISTS leaderboard_record ADD CONSTRAINT check_metadata CHECK (length(metadata) < 32000);
+
+ALTER TABLE IF EXISTS notification DROP CONSTRAINT IF EXISTS check_content;
+ALTER TABLE IF EXISTS notification ADD CONSTRAINT check_content CHECK (length(content) < 32000);
+
 -- +migrate Down
+ALTER TABLE IF EXISTS users DROP CONSTRAINT IF EXISTS check_metadata;
+ALTER TABLE IF EXISTS users ADD CONSTRAINT check_metadata CHECK (length(metadata) < 16000);
+
+ALTER TABLE IF EXISTS groups DROP CONSTRAINT IF EXISTS check_metadata;
+ALTER TABLE IF EXISTS groups ADD CONSTRAINT check_metadata CHECK (length(metadata) < 16000);
+
+ALTER TABLE IF EXISTS storage DROP CONSTRAINT IF EXISTS check_value;
+ALTER TABLE IF EXISTS storage ADD CONSTRAINT check_value CHECK (length(value) < 16000);
+
+ALTER TABLE IF EXISTS leaderboard_record DROP CONSTRAINT IF EXISTS check_metadata;
+ALTER TABLE IF EXISTS leaderboard_record ADD CONSTRAINT check_metadata CHECK (length(metadata) < 16000);
+
+ALTER TABLE IF EXISTS notification DROP CONSTRAINT IF EXISTS check_content;
+ALTER TABLE IF EXISTS notification ADD CONSTRAINT check_content CHECK (length(content) < 16000);
+
 ALTER TABLE IF EXISTS leaderboard ADD COLUMN IF NOT EXISTS next_id BYTEA DEFAULT NULL::BYTEA;
 ALTER TABLE IF EXISTS leaderboard ADD COLUMN IF NOT EXISTS prev_id BYTEA DEFAULT NULL::BYTEA;
 

--- a/pkg/multicode/client_instance.go
+++ b/pkg/multicode/client_instance.go
@@ -587,7 +587,7 @@ func (c *ClientInstance) flushReliablePacker(ts int64) {
 	if c.reliablePackerLength > 0 {
 		seq, fragments, fragmentLengths, err := c.reliableController.SendPacket(ts, c.reliablePacker, c.reliablePackerLength, RELIABLE_CHANNEL_ID)
 		if err != nil {
-			c.logger.Debug("error flushing reliable packer")
+			c.logger.Debug("error flushing reliable packer", zap.Error(err))
 			return
 		}
 

--- a/server/api.proto
+++ b/server/api.proto
@@ -1258,6 +1258,8 @@ message TStorageRemove {
  * Leaderboard is the core domain type representing a Leaderboard setup in the server.
  */
 message Leaderboard {
+  reserved 7, 8;
+
   string id = 1;
   /// Whether the user can submit records directly via the client or not
   bool authoritative = 2;
@@ -1265,8 +1267,6 @@ message Leaderboard {
   int64 count = 4;
   string reset_schedule = 5;
   string metadata = 6;
-  string next_id = 7;
-  string prev_id = 8;
 }
 
 /**

--- a/server/core_runtime_hooks.go
+++ b/server/core_runtime_hooks.go
@@ -50,7 +50,7 @@ func RuntimeBeforeHook(runtimePool *RuntimePool, jsonpbMarshaler *jsonpb.Marshal
 	return env, err
 }
 
-func RuntimeAfterHook(logger *zap.Logger, runtimePool *RuntimePool, jsonpbMarshaler *jsonpb.Marshaler, messageType string, envelope *Envelope, session session) {
+func RuntimeAfterHook(logger *zap.Logger, runtimePool *RuntimePool, jsonpbMarshaler *jsonpb.Marshaler, messageType string, outgoingEnvelope, incomingEnvelope *Envelope, session session) {
 	if !runtimePool.HasAfter(messageType) {
 		return
 	}
@@ -62,15 +62,25 @@ func RuntimeAfterHook(logger *zap.Logger, runtimePool *RuntimePool, jsonpbMarsha
 		return
 	}
 
-	strEnvelope, err := jsonpbMarshaler.MarshalToString(envelope)
+	strOutgoingEnvelope, err := jsonpbMarshaler.MarshalToString(outgoingEnvelope)
 	if err != nil {
-		logger.Error("Failed to convert proto message to protoJSON in After invocation", zap.String("message", messageType), zap.Error(err))
+		logger.Error("Failed to convert outgoing proto message to protoJSON in After invocation", zap.String("message", messageType), zap.Error(err))
+		return
+	}
+	strIncomingEnvelope, err := jsonpbMarshaler.MarshalToString(incomingEnvelope)
+	if err != nil {
+		logger.Error("Failed to convert incoming proto message to protoJSON in After invocation", zap.String("message", messageType), zap.Error(err))
 		return
 	}
 
-	var jsonEnvelope map[string]interface{}
-	if err = json.Unmarshal([]byte(strEnvelope), &jsonEnvelope); err != nil {
-		logger.Error("Failed to convert protoJSON message to Map in After invocation", zap.String("message", messageType), zap.Error(err))
+	var jsonOutgoingEnvelope map[string]interface{}
+	if err = json.Unmarshal([]byte(strOutgoingEnvelope), &jsonOutgoingEnvelope); err != nil {
+		logger.Error("Failed to convert outgoing protoJSON message to Map in After invocation", zap.String("message", messageType), zap.Error(err))
+		return
+	}
+	var jsonIncomingEnvelope map[string]interface{}
+	if err = json.Unmarshal([]byte(strIncomingEnvelope), &jsonIncomingEnvelope); err != nil {
+		logger.Error("Failed to convert incoming protoJSON message to Map in After invocation", zap.String("message", messageType), zap.Error(err))
 		return
 	}
 
@@ -83,7 +93,7 @@ func RuntimeAfterHook(logger *zap.Logger, runtimePool *RuntimePool, jsonpbMarsha
 		expiry = session.Expiry()
 	}
 
-	if fnErr := runtime.InvokeFunctionAfter(fn, userId, handle, expiry, jsonEnvelope); fnErr != nil {
+	if fnErr := runtime.InvokeFunctionAfter(fn, userId, handle, expiry, jsonOutgoingEnvelope, jsonIncomingEnvelope); fnErr != nil {
 		logger.Error("Runtime after function caused an error", zap.String("message", messageType), zap.Error(fnErr))
 	}
 	runtimePool.Put(runtime)
@@ -164,7 +174,7 @@ func RuntimeAfterHookAuthentication(logger *zap.Logger, runtimePool *RuntimePool
 		return
 	}
 
-	if fnErr := runtime.InvokeFunctionAfter(fn, userId, handle, expiry, jsonEnvelope); fnErr != nil {
+	if fnErr := runtime.InvokeFunctionAfter(fn, userId, handle, expiry, jsonEnvelope, nil); fnErr != nil {
 		logger.Error("Runtime after function caused an error", zap.String("message", messageType), zap.Error(fnErr))
 	}
 	runtimePool.Put(runtime)

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -205,7 +205,7 @@ func (p *pipeline) processRequest(logger *zap.Logger, session session, originalE
 		return
 	}
 
-	RuntimeAfterHook(logger, p.runtimePool, p.jsonpbMarshaler, messageType, envelope, originalEnvelope, session)
+	RuntimeAfterHook(logger, p.runtimePool, p.jsonpbMarshaler, messageType, envelope, session)
 }
 
 func ErrorMessageRuntimeException(collationID string, message string) *Envelope {

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -205,7 +205,7 @@ func (p *pipeline) processRequest(logger *zap.Logger, session session, originalE
 		return
 	}
 
-	RuntimeAfterHook(logger, p.runtimePool, p.jsonpbMarshaler, messageType, envelope, session)
+	RuntimeAfterHook(logger, p.runtimePool, p.jsonpbMarshaler, messageType, envelope, originalEnvelope, session)
 }
 
 func ErrorMessageRuntimeException(collationID string, message string) *Envelope {

--- a/server/pipeline_group.go
+++ b/server/pipeline_group.go
@@ -470,7 +470,7 @@ func (p *pipeline) groupUsersList(logger *zap.Logger, session session, envelope 
 		return
 	}
 
-	users, code, err := GroupUsersList(logger, p.db, session.UserID(), groupID)
+	users, code, err := GroupUsersList(logger, p.db, p.tracker, session.UserID(), groupID)
 	if err != nil {
 		session.Send(ErrorMessage(envelope.CollationId, code, err.Error()), true)
 		return

--- a/server/pipeline_leaderboard.go
+++ b/server/pipeline_leaderboard.go
@@ -52,7 +52,7 @@ func (p *pipeline) leaderboardsList(logger *zap.Logger, session session, envelop
 		return
 	}
 
-	query := "SELECT id, authoritative, sort_order, count, reset_schedule, metadata, next_id, prev_id FROM leaderboard"
+	query := "SELECT id, authoritative, sort_order, count, reset_schedule, metadata FROM leaderboard"
 	params := []interface{}{}
 
 	if len(incoming.Cursor) != 0 {
@@ -106,8 +106,6 @@ func (p *pipeline) leaderboardsList(logger *zap.Logger, session session, envelop
 	var count int64
 	var resetSchedule sql.NullString
 	var metadata []byte
-	var nextId sql.NullString
-	var prevId sql.NullString
 	for rows.Next() {
 		if int64(len(leaderboards)) >= limit {
 			cursorBuf := new(bytes.Buffer)
@@ -123,7 +121,7 @@ func (p *pipeline) leaderboardsList(logger *zap.Logger, session session, envelop
 			break
 		}
 
-		err = rows.Scan(&id, &authoritative, &sortOrder, &count, &resetSchedule, &metadata, &nextId, &prevId)
+		err = rows.Scan(&id, &authoritative, &sortOrder, &count, &resetSchedule, &metadata)
 		if err != nil {
 			logger.Error("Could not scan leaderboards list query results", zap.Error(err))
 			session.Send(ErrorMessageRuntimeException(envelope.CollationId, "Could not list leaderboards"), true)
@@ -137,8 +135,6 @@ func (p *pipeline) leaderboardsList(logger *zap.Logger, session session, envelop
 			Count:         count,
 			ResetSchedule: resetSchedule.String,
 			Metadata:      string(metadata),
-			NextId:        nextId.String,
-			PrevId:        prevId.String,
 		})
 	}
 	if err = rows.Err(); err != nil {

--- a/server/pipeline_user.go
+++ b/server/pipeline_user.go
@@ -42,7 +42,7 @@ func (p *pipeline) usersFetch(logger *zap.Logger, session session, envelope *Env
 		}
 	}
 
-	users, err := UsersFetchIdsHandles(logger, p.db, userIds, handles)
+	users, err := UsersFetchIdsHandles(logger, p.db, p.tracker, userIds, handles)
 	if err != nil {
 		logger.Warn("Could not retrieve users", zap.Error(err))
 		session.Send(ErrorMessageRuntimeException(envelope.CollationId, "Could not retrieve users"), true)

--- a/tests/core_storage_test.go
+++ b/tests/core_storage_test.go
@@ -1970,9 +1970,8 @@ func TestStorageRemoveRuntimeGlobalIfMatchNotExists(t *testing.T) {
 	}
 	code, err := server.StorageRemove(logger, db, "", keys)
 
-	assert.NotNil(t, err, "err was nil")
-	assert.Equal(t, server.STORAGE_REJECTED, code, "code did not match")
-	assert.Equal(t, "Storage remove rejected: not found, version check failed, or permission denied", err.Error(), "error message did not match")
+	assert.Nil(t, err, "err was nil")
+	assert.Equal(t, 0, int(code), "code did not match")
 }
 
 func TestStorageRemoveRuntimeGlobalIfMatchRejected(t *testing.T) {
@@ -2175,9 +2174,8 @@ func TestStorageRemoveRuntimeGlobalMultipleMixed(t *testing.T) {
 	}
 	code, err = server.StorageRemove(logger, db, "", keys)
 
-	assert.NotNil(t, err, "err was nil")
-	assert.Equal(t, server.STORAGE_REJECTED, code, "code did not match")
-	assert.Equal(t, "Storage remove rejected: not found, version check failed, or permission denied", err.Error(), "error message did not match")
+	assert.Nil(t, err, "err was nil")
+	assert.Equal(t, 0, int(code), "code did not match")
 }
 
 func TestStorageRemoveRuntimeGlobalMultipleMixedIfMatch(t *testing.T) {

--- a/tests/runtime_test.go
+++ b/tests/runtime_test.go
@@ -38,7 +38,7 @@ func newRuntimePool() (*server.RuntimePool, error) {
 	}
 	c := server.NewRuntimeConfig()
 	c.Path = filepath.Join(DATA_PATH, "modules")
-	return server.NewRuntimePool(logger, logger, db, c, nil)
+	return server.NewRuntimePool(logger, logger, db, c, nil, nil)
 }
 
 func writeStatsModule() {


### PR DESCRIPTION
- Nakama will now log an error and refuse to start if the schema is outdated.
- Drop unused leaderboard 'next' and 'previous' fields.
- A user's 'last online at' field now contains a current UTC milliseconds timestamp if they are currently online.
- Storage remove operations now ignore records that don't exist.
- Fields that expect JSON content now allow up to 32kb of data.