### PR TITLE
Support database strings with "sslmode" specified, also other query params

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func main() {
 
 func dbConnect(multiLogger *zap.Logger, dsns []string) (*sql.DB, string) {
 	// TODO config database pooling
-	var rawurl = fmt.Sprintf("postgresql://%s", dsns[0])
+	rawurl := fmt.Sprintf("postgresql://%s", dsns[0])
 	url, err := url.Parse(rawurl)
 	if err != nil {
 		multiLogger.Fatal("Bad connection URL", zap.Error(err))

--- a/main.go
+++ b/main.go
@@ -151,10 +151,15 @@ func main() {
 
 func dbConnect(multiLogger *zap.Logger, dsns []string) (*sql.DB, string) {
 	// TODO config database pooling
-	rawurl := fmt.Sprintf("postgresql://%s?sslmode=disable", dsns[0])
+	var rawurl = fmt.Sprintf("postgresql://%s", dsns[0])
 	url, err := url.Parse(rawurl)
 	if err != nil {
 		multiLogger.Fatal("Bad connection URL", zap.Error(err))
+	}
+	query := url.Query()
+	if len(query.Get("sslmode")) == 0 {
+		query.Set("sslmode", "disable")
+		url.RawQuery = query.Encode()
 	}
 
 	if len(url.Path) < 1 {


### PR DESCRIPTION
The docs at https://heroiclabs.com/docs/install-start-server/#database-connection suggest that you can use Nakama against a secured instance of Cockroach (started without `--insecure`) by adding query params, but this doesn't work because `?sslmode=disable` is always appended to any string you give it, which breaks not only a custom setting of `sslmode`, but also any other query param you might have added, since it uses `?` instead of `&`.

This update doesn't add `sslmode` if it's already there, and if it's not, appends the option safely using URL methods so it works with any other query params that are there.