### PR TITLE
Support direct use of SSL on the HTTP auth/websocket

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -251,6 +251,8 @@ type SocketConfig struct {
 	WriteWaitMs         int    `yaml:"write_wait_ms" json:"write_wait_ms" usage:"Time in milliseconds to wait for an ack from the client when writing data."`
 	PongWaitMs          int    `yaml:"pong_wait_ms" json:"pong_wait_ms" usage:"Time in milliseconds to wait for a pong message from the client after sending a ping."`
 	PingPeriodMs        int    `yaml:"ping_period_ms" json:"ping_period_ms" usage:"Time in milliseconds to wait between client ping messages. This value must be less than the pong_wait_ms."`
+	SSLCertificate      string `yaml:"ssl_certificate" json:"ssl_certificate" usage:"Path to certificate file if you want the server to use SSL directly. Must also supply ssl_private_key"`
+	SSLPrivateKey       string `yaml:"ssl_private_key" json:"ssl_private_key" usage:"Path to private key file if you want the server to use SSL directly. Must also supply ssl_certificate"`
 }
 
 // NewTransportConfig creates a new TransportConfig struct
@@ -264,6 +266,8 @@ func NewSocketConfig() *SocketConfig {
 		WriteWaitMs:         5000,
 		PongWaitMs:          10000,
 		PingPeriodMs:        8000,
+		SSLCertificate:      "",
+		SSLPrivateKey:       "",
 	}
 }
 


### PR DESCRIPTION
Presently Nakama requires the use of a separate SSL terminator such as a load balancer. This adds additional complexity, resource usage and cost - if you set up Load Balancer on Google Cloud Platform to do the job, it actually costs more than a small instance to run. You can set up Nginx locally to do it, but this is another moving part which needs configuring & maintaining, uses system resources, and which can potentially fail.

Small devs using Nakama in limited scenarios may want to keep things small and simple, taking the risk of running a single node cheaply (they couldn't run multiple nodes without Enterprise anyway) while still protecting user data by using SSL (you can use self-signed certificates securely, see related PR for Unity client https://github.com/heroiclabs/nakama-unity/pull/60).

This PR allows you to configure an ssl cert/key combo for the Nakama server itself, meaning you can use the server directly instead of via an intermediary. This is clearly not as robust as using 3rd party proxy services to help with DDoS protection etc, but a dev running the server on a single node is already making the trade-off of resilience for simplicity / cost, so it's a valid usage scenario for some.

I'm prepared that this PR might not be accepted since it's not a recommended configuration, but @mofirouz encouraged me to submit it in case it's of use to someone anyway.

