### PR TITLE
Thread through client addr to Lua context

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -274,6 +274,8 @@ func apiInterceptorFunc(logger *zap.Logger, config Config, runtimePool *RuntimeP
 		if host, port, err := net.SplitHostPort(clientAddr); err == nil {
 			clientIP = host
 			clientPort = port
+		} else if addrErr, ok := err.(*net.AddrError); ok && addrErr.Err == "missing port in address" {
+			clientIP = clientAddr
 		} else {
 			logger.Debug("Could not extract client address from request.", zap.Error(err))
 		}

--- a/server/api.go
+++ b/server/api.go
@@ -28,6 +28,7 @@ import (
 
 	"compress/flate"
 	"compress/gzip"
+
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/jsonpb"
@@ -49,6 +50,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // enable gzip compression on server for grpc
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -256,8 +258,28 @@ func apiInterceptorFunc(logger *zap.Logger, config Config, runtimePool *RuntimeP
 		startNanos := time.Now().UTC().UnixNano()
 		span := trace.NewSpan(name, nil, trace.StartOptions{})
 
+		clientAddr := ""
+		clientIP := ""
+		clientPort := ""
+		md, _ := metadata.FromIncomingContext(ctx)
+		if ips := md.Get("x-forwarded-for"); len(ips) > 0 {
+			// look for gRPC-Gateway / LB header
+			clientAddr = strings.Split(ips[0], ",")[0]
+		} else if peerInfo, ok := peer.FromContext(ctx); ok {
+			// if missing, try to look up gRPC peer info
+			clientAddr = peerInfo.Addr.String()
+		}
+
+		clientAddr = strings.TrimSpace(clientAddr)
+		if host, port, err := net.SplitHostPort(clientAddr); err == nil {
+			clientIP = host
+			clientPort = port
+		} else {
+			logger.Debug("Could not extract client address from request.", zap.Error(err))
+		}
+
 		// Actual before hook function execution.
-		beforeHookResult, hookErr := invokeReqBeforeHook(logger, config, runtimePool, jsonpbMarshaler, jsonpbUnmarshaler, "", uid, username, expiry, info.FullMethod, req)
+		beforeHookResult, hookErr := invokeReqBeforeHook(logger, config, runtimePool, jsonpbMarshaler, jsonpbUnmarshaler, "", uid, username, expiry, clientIP, clientPort, info.FullMethod, req)
 
 		// Stats measurement end boundary.
 		span.End()
@@ -283,7 +305,7 @@ func apiInterceptorFunc(logger *zap.Logger, config Config, runtimePool *RuntimeP
 			span := trace.NewSpan(name, nil, trace.StartOptions{})
 
 			// Actual after hook function execution.
-			invokeReqAfterHook(logger, config, runtimePool, jsonpbMarshaler, "", uid, username, expiry, info.FullMethod, handlerResult)
+			invokeReqAfterHook(logger, config, runtimePool, jsonpbMarshaler, "", uid, username, expiry, info.FullMethod, clientIP, clientPort, handlerResult)
 
 			// Stats measurement end boundary.
 			span.End()

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -19,14 +19,15 @@ import (
 	"fmt"
 
 	"context"
+	"strings"
+	"time"
+
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/heroiclabs/nakama/rtapi"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
-	"strings"
-	"time"
 )
 
 type Pipeline struct {
@@ -147,7 +148,7 @@ func (p *Pipeline) ProcessRequest(logger *zap.Logger, session Session, envelope 
 		span := trace.NewSpan(name, nil, trace.StartOptions{})
 
 		// Actual before hook function execution.
-		hookResult, hookErr := invokeReqBeforeHook(logger, p.config, p.runtimePool, p.jsonpbMarshaler, p.jsonpbUnmarshaler, session.ID().String(), session.UserID(), session.Username(), session.Expiry(), messageName, envelope)
+		hookResult, hookErr := invokeReqBeforeHook(logger, p.config, p.runtimePool, p.jsonpbMarshaler, p.jsonpbUnmarshaler, session.ID().String(), session.UserID(), session.Username(), session.Expiry(), session.ClientIP(), session.ClientPort(), messageName, envelope)
 
 		// Stats measurement end boundary.
 		span.End()
@@ -202,7 +203,7 @@ func (p *Pipeline) ProcessRequest(logger *zap.Logger, session Session, envelope 
 		span := trace.NewSpan(name, nil, trace.StartOptions{})
 
 		// Actual after hook function execution.
-		invokeReqAfterHook(logger, p.config, p.runtimePool, p.jsonpbMarshaler, session.ID().String(), session.UserID(), session.Username(), session.Expiry(), messageName, envelope)
+		invokeReqAfterHook(logger, p.config, p.runtimePool, p.jsonpbMarshaler, session.ID().String(), session.UserID(), session.Username(), session.Expiry(), session.ClientIP(), session.ClientPort(), messageName, envelope)
 
 		// Stats measurement end boundary.
 		span.End()

--- a/server/pipeline_rpc.go
+++ b/server/pipeline_rpc.go
@@ -55,7 +55,7 @@ func (p *Pipeline) rpc(logger *zap.Logger, session Session, envelope *rtapi.Enve
 		return
 	}
 
-	result, fnErr, _ := runtime.InvokeFunction(ExecutionModeRPC, lf, nil, session.UserID().String(), session.Username(), session.Expiry(), session.ID().String(), rpcMessage.Payload)
+	result, fnErr, _ := runtime.InvokeFunction(ExecutionModeRPC, lf, nil, session.UserID().String(), session.Username(), session.Expiry(), session.ID().String(), session.ClientIP(), session.ClientPort(), rpcMessage.Payload)
 	p.runtimePool.Put(runtime)
 	if fnErr != nil {
 		logger.Error("Runtime RPC function caused an error", zap.String("id", rpcMessage.Id), zap.Error(fnErr))

--- a/server/runtime.go
+++ b/server/runtime.go
@@ -270,8 +270,8 @@ func (r *Runtime) GetCallback(e ExecutionMode, key string) *lua.LFunction {
 	return nil
 }
 
-func (r *Runtime) InvokeFunction(execMode ExecutionMode, fn *lua.LFunction, queryParams map[string][]string, uid string, username string, sessionExpiry int64, sid string, payload interface{}) (interface{}, error, codes.Code) {
-	ctx := NewLuaContext(r.vm, r.luaEnv, execMode, queryParams, uid, username, sessionExpiry, sid)
+func (r *Runtime) InvokeFunction(execMode ExecutionMode, fn *lua.LFunction, queryParams map[string][]string, uid string, username string, sessionExpiry int64, sid string, clientIP string, clientPort string, payload interface{}) (interface{}, error, codes.Code) {
+	ctx := NewLuaContext(r.vm, r.luaEnv, execMode, queryParams, sessionExpiry, uid, username, sid, clientIP, clientPort)
 	var lv lua.LValue
 	if payload != nil {
 		lv = ConvertValue(r.vm, payload)

--- a/server/runtime_hook.go
+++ b/server/runtime_hook.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func invokeReqBeforeHook(logger *zap.Logger, config Config, runtimePool *RuntimePool, jsonpbMarshaler *jsonpb.Marshaler, jsonpbUnmarshaler *jsonpb.Unmarshaler, sessionID string, uid uuid.UUID, username string, expiry int64, callbackID string, req interface{}) (interface{}, error) {
+func invokeReqBeforeHook(logger *zap.Logger, config Config, runtimePool *RuntimePool, jsonpbMarshaler *jsonpb.Marshaler, jsonpbUnmarshaler *jsonpb.Unmarshaler, sessionID string, uid uuid.UUID, username string, expiry int64, clientIP string, clientPort string, callbackID string, req interface{}) (interface{}, error) {
 	id := strings.ToLower(callbackID)
 	if !runtimePool.HasCallback(ExecutionModeBefore, id) {
 		return req, nil
@@ -65,7 +65,7 @@ func invokeReqBeforeHook(logger *zap.Logger, config Config, runtimePool *Runtime
 	if uid != uuid.Nil {
 		userID = uid.String()
 	}
-	result, fnErr, code := runtime.InvokeFunction(ExecutionModeBefore, lf, nil, userID, username, expiry, sessionID, reqMap)
+	result, fnErr, code := runtime.InvokeFunction(ExecutionModeBefore, lf, nil, userID, username, expiry, sessionID, clientIP, clientPort, reqMap)
 	runtimePool.Put(runtime)
 
 	if fnErr != nil {
@@ -105,7 +105,7 @@ func invokeReqBeforeHook(logger *zap.Logger, config Config, runtimePool *Runtime
 	return reqProto, nil
 }
 
-func invokeReqAfterHook(logger *zap.Logger, config Config, runtimePool *RuntimePool, jsonpbMarshaler *jsonpb.Marshaler, sessionID string, uid uuid.UUID, username string, expiry int64, callbackID string, req interface{}) {
+func invokeReqAfterHook(logger *zap.Logger, config Config, runtimePool *RuntimePool, jsonpbMarshaler *jsonpb.Marshaler, sessionID string, uid uuid.UUID, username string, expiry int64, clientIP string, clientPort string, callbackID string, req interface{}) {
 	id := strings.ToLower(callbackID)
 	if !runtimePool.HasCallback(ExecutionModeAfter, id) {
 		return
@@ -143,7 +143,7 @@ func invokeReqAfterHook(logger *zap.Logger, config Config, runtimePool *RuntimeP
 	if uid != uuid.Nil {
 		userID = uid.String()
 	}
-	_, fnErr, _ := runtime.InvokeFunction(ExecutionModeAfter, lf, nil, userID, username, expiry, sessionID, reqMap)
+	_, fnErr, _ := runtime.InvokeFunction(ExecutionModeAfter, lf, nil, userID, username, expiry, sessionID, clientIP, clientPort, reqMap)
 	runtimePool.Put(runtime)
 
 	if fnErr != nil {
@@ -176,7 +176,7 @@ func invokeMatchmakerMatchedHook(logger *zap.Logger, runtimePool *RuntimePool, e
 		return "", false
 	}
 
-	ctx := NewLuaContext(runtime.vm, runtime.luaEnv, ExecutionModeMatchmaker, nil, "", "", 0, "")
+	ctx := NewLuaContext(runtime.vm, runtime.luaEnv, ExecutionModeMatchmaker, nil, 0, "", "", "", "", "")
 
 	entriesTable := runtime.vm.CreateTable(len(entries), 0)
 	for i, entry := range entries {

--- a/server/runtime_lua_context.go
+++ b/server/runtime_lua_context.go
@@ -58,8 +58,8 @@ const (
 	__CTX_USERNAME         = "username"
 	__CTX_USER_SESSION_EXP = "user_session_exp"
 	__CTX_SESSION_ID       = "session_id"
-	__CTX_IP_ADDRESS       = "ip_address"
-	__CTX_PORT             = "port"
+	__CTX_CLIENT_IP        = "client_ip"
+	__CTX_CLIENT_PORT      = "client_port"
 	__CTX_MATCH_ID         = "match_id"
 	__CTX_MATCH_NODE       = "match_node"
 	__CTX_MATCH_LABEL      = "match_label"
@@ -102,11 +102,11 @@ func NewLuaContext(l *lua.LState, env *lua.LTable, mode ExecutionMode, queryPara
 	}
 
 	if clientIP != "" {
-		lt.RawSetString(__CTX_IP_ADDRESS, lua.LString(clientIP))
+		lt.RawSetString(__CTX_CLIENT_IP, lua.LString(clientIP))
 	}
 
 	if clientPort != "" {
-		lt.RawSetString(__CTX_PORT, lua.LString(clientPort))
+		lt.RawSetString(__CTX_CLIENT_PORT, lua.LString(clientPort))
 	}
 
 	return lt

--- a/server/runtime_lua_context.go
+++ b/server/runtime_lua_context.go
@@ -58,19 +58,29 @@ const (
 	__CTX_USERNAME         = "username"
 	__CTX_USER_SESSION_EXP = "user_session_exp"
 	__CTX_SESSION_ID       = "session_id"
+	__CTX_IP_ADDRESS       = "ip_address"
+	__CTX_PORT             = "port"
 	__CTX_MATCH_ID         = "match_id"
 	__CTX_MATCH_NODE       = "match_node"
 	__CTX_MATCH_LABEL      = "match_label"
 	__CTX_MATCH_TICK_RATE  = "match_tick_rate"
 )
 
-func NewLuaContext(l *lua.LState, env *lua.LTable, mode ExecutionMode, queryParams map[string][]string, uid string, username string, sessionExpiry int64, sid string) *lua.LTable {
+func NewLuaContext(l *lua.LState, env *lua.LTable, mode ExecutionMode, queryParams map[string][]string, sessionExpiry int64,
+	userID, username, sessionID, clientIP, clientPort string) *lua.LTable {
 	size := 3
-	if uid != "" {
+	if userID != "" {
 		size += 3
-		if sid != "" {
+		if sessionID != "" {
 			size++
 		}
+	}
+
+	if clientIP != "" {
+		size++
+	}
+	if clientPort != "" {
+		size++
 	}
 
 	lt := l.CreateTable(0, size)
@@ -82,13 +92,21 @@ func NewLuaContext(l *lua.LState, env *lua.LTable, mode ExecutionMode, queryPara
 		lt.RawSetString(__CTX_QUERY_PARAMS, ConvertValue(l, queryParams))
 	}
 
-	if uid != "" {
-		lt.RawSetString(__CTX_USER_ID, lua.LString(uid))
+	if userID != "" {
+		lt.RawSetString(__CTX_USER_ID, lua.LString(userID))
 		lt.RawSetString(__CTX_USERNAME, lua.LString(username))
 		lt.RawSetString(__CTX_USER_SESSION_EXP, lua.LNumber(sessionExpiry))
-		if sid != "" {
-			lt.RawSetString(__CTX_SESSION_ID, lua.LString(sid))
+		if sessionID != "" {
+			lt.RawSetString(__CTX_SESSION_ID, lua.LString(sessionID))
 		}
+	}
+
+	if clientIP != "" {
+		lt.RawSetString(__CTX_IP_ADDRESS, lua.LString(clientIP))
+	}
+
+	if clientPort != "" {
+		lt.RawSetString(__CTX_PORT, lua.LString(clientPort))
 	}
 
 	return lt

--- a/server/runtime_nakama_module.go
+++ b/server/runtime_nakama_module.go
@@ -41,6 +41,7 @@ import (
 	"crypto/sha256"
 
 	"crypto/md5"
+
 	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -327,7 +328,7 @@ func (n *NakamaModule) runOnce(l *lua.LState) int {
 			return
 		}
 
-		ctx := NewLuaContext(l, ConvertMap(l, n.config.GetRuntime().Environment), ExecutionModeRunOnce, nil, "", "", 0, "")
+		ctx := NewLuaContext(l, ConvertMap(l, n.config.GetRuntime().Environment), ExecutionModeRunOnce, nil, 0, "", "", "", "", "")
 
 		l.Push(LSentinel)
 		l.Push(fn)

--- a/server/session_registry.go
+++ b/server/session_registry.go
@@ -33,6 +33,8 @@ type Session interface {
 	Logger() *zap.Logger
 	ID() uuid.UUID
 	UserID() uuid.UUID
+	ClientIP() string
+	ClientPort() string
 
 	Username() string
 	SetUsername(string)

--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -77,7 +77,7 @@ func NewSessionWS(logger *zap.Logger, config Config, userID uuid.UUID, username 
 		username:   atomic.NewString(username),
 		expiry:     expiry,
 		clientIP:   clientIP,
-		clientPort: clientIP,
+		clientPort: clientPort,
 
 		jsonpbMarshaler:        jsonpbMarshaler,
 		jsonpbUnmarshaler:      jsonpbUnmarshaler,

--- a/server/socket_ws.go
+++ b/server/socket_ws.go
@@ -65,6 +65,8 @@ func NewSocketWsAcceptor(logger *zap.Logger, config Config, sessionRegistry *Ses
 		if host, port, err := net.SplitHostPort(clientAddr); err == nil {
 			clientIP = host
 			clientPort = port
+		} else if addrErr, ok := err.(*net.AddrError); ok && addrErr.Err == "missing port in address" {
+			clientIP = clientAddr
 		} else {
 			logger.Debug("Could not extract client address from request.", zap.Error(err))
 		}

--- a/tests/runtime_test.go
+++ b/tests/runtime_test.go
@@ -347,7 +347,7 @@ nakama.register_rpc(test.printWorld, "helloworld")
 	fn := r.GetCallback(server.ExecutionModeRPC, "helloworld")
 	payload := "Hello World"
 
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", payload)
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", payload)
 	if err != nil {
 		t.Error(err)
 	}
@@ -425,7 +425,7 @@ nakama.register_rpc(test, "test")
 	defer r.Stop()
 
 	fn := r.GetCallback(server.ExecutionModeRPC, "test")
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "")
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -454,7 +454,7 @@ nakama.register_rpc(test, "test")
 
 	payload := "{\"key\":\"value\"}"
 	fn := r.GetCallback(server.ExecutionModeRPC, "test")
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", payload)
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", payload)
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +483,7 @@ nakama.register_rpc(test, "test")
 
 	payload := "{\"key\":\"value\"}"
 	fn := r.GetCallback(server.ExecutionModeRPC, "test")
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", payload)
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", payload)
 	if err != nil {
 		t.Error(err)
 	}
@@ -512,7 +512,7 @@ nakama.register_rpc(test, "test")
 
 	payload := "{\"key\":\"value\"}"
 	fn := r.GetCallback(server.ExecutionModeRPC, "test")
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", payload)
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", payload)
 	if err != nil {
 		t.Error(err)
 	}
@@ -541,7 +541,7 @@ nakama.register_rpc(test, "test")
 
 	payload := "{\"key\":\"value\"}"
 	fn := r.GetCallback(server.ExecutionModeRPC, "test")
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", payload)
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", payload)
 	if err != nil {
 		t.Error(err)
 	}
@@ -596,7 +596,7 @@ nakama.register_rpc(test, "test")
 
 	payload := "{\"key\":\"value\"}"
 	fn := r.GetCallback(server.ExecutionModeRPC, "test")
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", payload)
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", payload)
 	if err != nil {
 		t.Error(err)
 	}
@@ -627,7 +627,7 @@ nakama.register_rpc(test, "test")
 	payload := "something_to_encrypt"
 	hash, _ := bcrypt.GenerateFromPassword([]byte(payload), bcrypt.DefaultCost)
 	fn := r.GetCallback(server.ExecutionModeRPC, "test")
-	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", string(hash))
+	m, err, _ := r.InvokeFunction(server.ExecutionModeRPC, fn, nil, "", "", 0, "", "", "", string(hash))
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
_Do not merge - this is untested_

This was a bit of nightmare trying to figure out which info is passed into the correct place to look up the client address info - especially for gRPC.

Turns out that if you only use `peer.FromContext` - it will give you gRPC server info which is masked to localhost if you use grpcGateway. So we need to look up both context metadata headers as well as peerInfo in case the client is HTTP/2. 

Moreover, GCP Loadbalancer has specific rules about X-Forwarded-For header. It appends the IP address in a certain manner. Long story short is that the first element of the X-Forwarded-For header is the real-ip as detected from GCP LB. 

Relevant bits of info:

https://github.com/grpc-ecosystem/grpc-gateway/pull/155/commits/17b6bbc279a5ebcb383abea8ace67f9ad6cf1331

https://cloud.google.com/load-balancing/docs/https/#components

https://husobee.github.io/golang/ip-address/2015/12/17/remote-ip-go.html