### PR TITLE
Fix racy timers for websocket pinging

### DIFF
--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -166,7 +166,7 @@ func (s *sessionWS) Consume(processRequest func(logger *zap.Logger, session Sess
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
 				// Ignore underlying connection being shut down while read is waiting for data.
 				if e, ok := err.(*net.OpError); !ok || e.Err.Error() != "use of closed network connection" {
-					s.logger.Debug("Error reading message from client", zap.Error(err))
+					s.logger.Warn("Error reading message from client", zap.Error(err))
 				}
 			}
 			break


### PR DESCRIPTION
According to [Go docs](https://golang.org/pkg/time/#Timer.Reset), it should not be done concurrent to other receives from the Timer's channel. This will cause panics for high server loads.

Additionally, it's better to use defer func to ensure Unlock() is called before exiting pingNow(), IMHO.