### PR TITLE
Add type info to wallet update error message

### DIFF
--- a/server/core_wallet.go
+++ b/server/core_wallet.go
@@ -247,7 +247,7 @@ func applyWalletUpdate(wallet map[string]interface{}, changeset map[string]inter
 				}
 			} else {
 				// Existing value is not a map or float.
-				return nil, errors.Errorf("unknown existing wallet value type at path '%v'", currentPath)
+				return nil, errors.Errorf("unknown existing wallet value type at path '%v'. Expecting map or float64", currentPath)
 			}
 		} else {
 			// No existing value for this field.
@@ -265,7 +265,7 @@ func applyWalletUpdate(wallet map[string]interface{}, changeset map[string]inter
 				wallet[k] = changesetValue
 			} else {
 				// Incoming value is not a map or float.
-				return nil, errors.Errorf("unknown update changeset value type at path '%v'", currentPath)
+				return nil, errors.Errorf("unknown update changeset value type at path '%v'. Expecting map or float64", currentPath)
 			}
 		}
 	}


### PR DESCRIPTION
Creating a `nk.WalletUpdate` request like:
```
	var changeset = map[string]interface{}{
		"coins": 100,
	}
	err := nk.WalletUpdate(ctx, userID, changeset, nil)
	if err != nil {
		logger.Printf("failed to update user wallet: %v", err)
		return "", errors.New("unable to update wallet")
	}
```
results in a very confusing & unhelpful error message:
> failed to update user wallet: unknown update changeset value type at path 'coins'

Afaik there's no documentation to find what types are expected, the only source of that information is grep-ing through Nakama source. I've added the expected types to the error message to clear up this confusion.

Does this seem reasonable? Is there some documentation that users are expected to have read before reaching this stage that would have explained the types that are expected in this request (that I may have overlooked)?