### PR TITLE
Fixed a offset-by-one bug in leaderboard record deleting

### DIFF
--- a/server/leaderboard_rank_cache.go
+++ b/server/leaderboard_rank_cache.go
@@ -16,10 +16,11 @@ package server
 
 import (
 	"database/sql"
-	"github.com/heroiclabs/nakama/api"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/heroiclabs/nakama/api"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
@@ -336,7 +337,7 @@ func (l *LocalLeaderboardRankCache) Delete(leaderboardId string, expiryUnix int6
 	}
 
 	// Shift ranks that were after the deleted record down by one rank number to fill the gap.
-	for i := int(rank) - 1; i < totalRanks; i++ {
+	for i := int(rank) - 1; i < totalRanks-1; i++ {
 		rankMap.Ranks[i].Rank--
 	}
 	// No need to sort, ranks are still in order.


### PR DESCRIPTION
For example, the old ranks are A:1, B:2, C:3, therefore totalRanks is 3.
When A is deleted, the remained are B:2, C:3 and the shifting should be from index 0 to index 1 which is (totalRanks-1) -1 instead of totalRanks-1.
When B is deleted, the remained are A:1, C:3 and the shifting should be from index 1 to index 1 which is (totalRanks-1) -1 instead of totalRanks-1.