### PR TITLE
Allow sending arbitrary messages instead of StreamData to stream in Go runtime

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -309,6 +309,7 @@ type NakamaModule interface {
 	StreamCount(mode uint8, subject, descriptor, label string) (int, error)
 	StreamClose(mode uint8, subject, descriptor, label string) error
 	StreamSend(mode uint8, subject, descriptor, label, data string) error
+	StreamSendRaw(mode uint8, subject, descriptor, label string, msg *rtapi.Envelope) error
 
 	MatchCreate(ctx context.Context, module string, params map[string]interface{}) (string, error)
 	MatchList(ctx context.Context, limit int, authoritative bool, label string, minSize, maxSize int, query string) ([]*api.Match, error)

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -627,6 +627,33 @@ func (n *RuntimeGoNakamaModule) StreamSend(mode uint8, subject, descriptor, labe
 	return nil
 }
 
+func (n *RuntimeGoNakamaModule) StreamSendRaw(mode uint8, subject, descriptor, label string, msg *rtapi.Envelope) error {
+	stream := PresenceStream{
+		Mode:  mode,
+		Label: label,
+	}
+	var err error
+	if subject != "" {
+		stream.Subject, err = uuid.FromString(subject)
+		if err != nil {
+			return errors.New("stream subject must be a valid identifier")
+		}
+	}
+	if descriptor != "" {
+		stream.Descriptor, err = uuid.FromString(descriptor)
+		if err != nil {
+			return errors.New("stream descriptor must be a valid identifier")
+		}
+	}
+	if msg == nil {
+		return errors.New("expects a valid message")
+	}
+
+	n.router.SendToStream(n.logger, stream, msg)
+
+	return nil
+}
+
 func (n *RuntimeGoNakamaModule) MatchCreate(ctx context.Context, module string, params map[string]interface{}) (string, error) {
 	if module == "" {
 		return "", errors.New("expects module name")


### PR DESCRIPTION
It's a small step to the vision described in [the Streams doc](https://heroiclabs.com/docs/advanced-streams/#built-in-streams). Sometimes, we need to change the behaviors of built-in streams.