### PR TITLE
Fix for unmarhalling steam id

### DIFF
--- a/social/social.go
+++ b/social/social.go
@@ -92,7 +92,7 @@ type GoogleProfile struct {
 
 // SteamProfile is an abbreviated version of a Steam profile.
 type SteamProfile struct {
-	SteamID uint64 `json:"steamid"`
+	SteamID uint64 `json:"steamid,string"`
 }
 
 // SteamError contains a possible error response from the Steam Web API.


### PR DESCRIPTION
```
{"level":"info","ts":"2019-01-07T00:15:23.637+0100","msg":"Could not authenticate Steam profile.","error":"json: cannot unmarshal string into Go struct field SteamProfile.steamid of type uint64"}
```