### PR TITLE
google-profile-update-vg

### DIFF
--- a/server/api_link.go
+++ b/server/api_link.go
@@ -444,14 +444,14 @@ func (s *ApiServer) LinkGoogle(ctx context.Context, in *api.AccountGoogle) (*emp
 
 	res, err := s.db.ExecContext(ctx, `
 UPDATE users
-SET google_id = $2, update_time = now()
+SET google_id = $2, display_name = $3, avatar_url = $4, update_time = now()
 WHERE (id = $1)
 AND (NOT EXISTS
     (SELECT id
      FROM users
      WHERE google_id = $2 AND NOT id = $1))`,
 		userID,
-		googleProfile.Sub)
+		googleProfile.Sub, googleProfile.Name, googleProfile.Picture)
 
 	if err != nil {
 		s.logger.Error("Could not link Google ID.", zap.Error(err), zap.Any("input", in))


### PR DESCRIPTION
The existing code pulls the profile details, i.e. DisplayName and AvatarUrl from the googleProfile but doesn't save it in the db. Thus the player's updated profile is not reflected in the game. This pull request fixes that.

Please note the following:

1. Changes have been made to api_link (when a Google Account is linked to an existing account) and core_authenticate (when a new Google Account is created, or changes are made to an existing Google Account)
2. The error in updating DisplayName and AvatarUrl have been suppressed, since this is not an error which should interrupt the code execution. The update will be retried automatically at the time of the next login.

Notes for testing:
At times changes to Google Profile take time to reflect, thus the changes to the Google Account may not show up immediately.