### PR TITLE
:bug: extract directory from logger filename in config, then try to c…

### DIFF
--- a/server/logger.go
+++ b/server/logger.go
@@ -17,6 +17,7 @@ package server
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"strings"
@@ -104,9 +105,13 @@ func NewRotatingJSONFileLogger(consoleLogger *zap.Logger, config Config, level z
 		consoleLogger.Fatal("Rotating log file is enabled but log file name is empty")
 		return nil
 	}
-	if err := os.MkdirAll(fileName, 0755); err != nil {
-		consoleLogger.Fatal("Could not create log directory", zap.Error(err))
-		return nil
+
+	logDir := filepath.Dir(fileName)
+	if _, err := os.Stat(logDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(logDir, 0755); err != nil {
+			consoleLogger.Fatal("Could not create log directory", zap.Error(err))
+			return nil
+		}
 	}
 
 	jsonEncoder := newJSONEncoder(format)


### PR DESCRIPTION
Should not treat logger filename in config as a directory. First, extract the logger directory. Then, try to create logger directory if it does not exist.