### PR TITLE
Upgrade DO marketplace app for Nakama 2.6.0

### DIFF
--- a/build/do-marketplace/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/build/do-marketplace/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -4,6 +4,10 @@
 ufw limit ssh
 ufw allow https
 ufw allow http
+ufw allow 7350
+ufw allow 7351
+ufw allow 7349
+ufw allow 7348
 ufw --force enable
 
 # Start Cockroach

--- a/build/do-marketplace/marketplace-image.json
+++ b/build/do-marketplace/marketplace-image.json
@@ -2,8 +2,8 @@
   "variables": {
     "token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "marketplace-snapshot-{{timestamp}}",
-    "nakama_url": "https://github.com/heroiclabs/nakama/releases/download/v2.5.1/nakama-2.5.1-linux-amd64.tar.gz",
-    "cockroach_url": "https://binaries.cockroachdb.com/cockroach-v2.1.6.linux-amd64.tgz"
+    "nakama_url": "https://github.com/heroiclabs/nakama/releases/download/v2.6.0/nakama-2.6.0-linux-amd64.tar.gz",
+    "cockroach_url": "https://binaries.cockroachdb.com/cockroach-v19.1.3.linux-amd64.tgz"
   },
   "builders": [
     {
@@ -46,7 +46,8 @@
       "type": "shell",
       "inline": [
         "apt-get -qqy update",
-        "apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' upgrade"
+        "apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' upgrade",
+        "apt-get -qqy dist-upgrade"
       ]
     },
     {

--- a/build/do-marketplace/scripts/01-test
+++ b/build/do-marketplace/scripts/01-test
@@ -19,6 +19,7 @@ systemctl status nakama.service
 
 echo "Stopping all"
 systemctl stop nakama.service
+sleep 30
 cockroach quit --insecure
 
 echo "Complete"


### PR DESCRIPTION
This PR also bundles in some assorted image changes:

- ufw rules for all of the Nakama ports
- A `dist-upgrade` to catch some recent Ubuntu 18-04 security updates
- Minor changes to the test to accommodate what seems to be a slower node initialisation under Cockroachdb 19.1.3

The image generated from this PR has been submitted to the DigitalOcean Marketplace team. 