### PR TITLE
Switch prometheus metrics to use labels instead of a prefix

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -29,7 +29,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
-	"strings"
 )
 
 var (
@@ -170,13 +169,15 @@ func (m *Metrics) initStackdriver(logger, startupLogger *zap.Logger, config Conf
 }
 
 func (m *Metrics) initPrometheus(logger, startupLogger *zap.Logger, config Config) {
-	prefix := strings.Replace(config.GetName(), "-", "_", -1)
+	labels := make(map[string]string)
+	labels["node_name"] = config.GetName()
+
 	if config.GetMetrics().Namespace != "" {
-		prefix += "_" + strings.Replace(config.GetMetrics().Namespace, "-", "_", -1)
+		labels["namespace"] = config.GetMetrics().Namespace
 	}
 
 	exporter, err := ocprometheus.NewExporter(ocprometheus.Options{
-		Namespace: prefix,
+		ConstLabels: labels,
 		OnError: func(err error) {
 			logger.Error("Could not upload data to Prometheus", zap.Error(err))
 		},


### PR DESCRIPTION
Prometheus has the concept of labels, which allow you to add sub fields to a metric name.  This makes it easy to generate queries for a metric across a number of labels.  In the case of nakama, this will allow for the building of single dashboard, which can render metrics across any number of nodes.

With this change, the metric nakama_b26f_local_nakama_socket_ws_server_elapsed_time_bucket{le="0.0"} would become nakama_socket_ws_server_elapsed_time_bucket{le="0.0", node_name="nakama_b26f", namespace="local"}