### PR TITLE
added Dockerfile to build arm64v8-image and docker-compose to startup…

### DIFF
--- a/build/Dockerfile-arm64v8
+++ b/build/Dockerfile-arm64v8
@@ -1,0 +1,54 @@
+## Copyright 2018 The Nakama Authors
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http:##www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+# docker build "$PWD" --build-arg commit="$(git rev-parse --short HEAD)" --build-arg version=v2.6.0 -t heroiclabs/nakama:2.6.0-arm64v8 -f Dockerfile-arm64v8
+
+FROM arm64v8/golang:1.12.7-alpine3.10 as builder
+
+ARG commit
+ARG version
+
+ENV GOOS linux
+ENV GOARCH arm64
+ENV CGO_ENABLED 0 
+
+RUN apk --no-cache add ca-certificates gcc musl-dev git && \
+    git config --global advice.detachedHead false && \
+    git clone --no-checkout https://github.com/heroiclabs/nakama /go/src/github.com/heroiclabs/nakama
+
+WORKDIR /go/src/github.com/heroiclabs/nakama
+RUN git checkout  "$commit" && \
+    go build -o /go/build/nakama -gcflags "-trimpath $PWD" -asmflags "-trimpath $PWD" -ldflags "-s -w -X main.version=$version -X main.commitID=$commit"
+
+FROM arm64v8/alpine:3.10
+
+MAINTAINER Heroic Labs <support@heroiclabs.com>
+
+ARG version
+
+LABEL version=$version
+LABEL variant=nakama
+LABEL description="Distributed server for social and realtime games and apps."
+
+RUN mkdir -p /nakama/data/modules && \
+    apk --no-cache add ca-certificates curl iproute2 unzip rsync git tini
+
+WORKDIR /nakama/
+COPY --from=builder "/go/build/nakama" /nakama/
+EXPOSE 7349 7350 7351
+
+ENTRYPOINT ["/sbin/tini", "--", "/nakama/nakama"]
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:7350/ || exit 1

--- a/build/README.md
+++ b/build/README.md
@@ -60,16 +60,35 @@ With the release generated we can create the official container image.
 
    ```
    cd build
-   docker build "$PWD" --file ./Dockerfile --build-arg commit="$(git rev-parse --short HEAD 2>/dev/null)" --build-arg version=2.1.0 -t heroiclabs/nakama:2.1.0
+   docker build "$PWD" --file ./Dockerfile --build-arg commit="$(git rev-parse --short HEAD 2>/dev/null)" --build-arg version=2.6.0 -t heroiclabs/nakama:2.6.0
    ```
 
 2. Push the image to the container registry.
 
    ```
    docker tag <CONTAINERID> heroiclabs/nakama:latest
-   docker push heroiclabs/nakama:2.1.0
+   docker push heroiclabs/nakama:2.6.0
    docker push heroiclabs/nakama:latest
    ```
+
+## Build Nakama Image for arm64v8
+
+1. Build the container image
+
+   ```
+   cd build
+   docker build "$PWD" --build-arg commit="$(git rev-parse --short HEAD)" --build-arg version=v2.6.0 -t heroiclabs/nakama:2.6.0-arm64v8 -f Dockerfile-arm64v8
+   ```
+
+2. Push the image to the container registry
+
+   ```
+   docker tag <CONTAINERID> heroiclabs/nakama:latest-arm64v8
+   docker push heroiclabs/nakama:2.6.0-arm64v8
+   docker push heroiclabs/nakama:latest-arm64v8
+   ```
+
+
 
 ## Build Plugin Builder Image
 

--- a/docker-compose-postgres-arm64v8.yml
+++ b/docker-compose-postgres-arm64v8.yml
@@ -1,0 +1,54 @@
+#
+# make sure to create the nakama:latest-arm64v8 image.
+# for this follow the instructions in build/README.md
+#
+# alter the volume-paths(postgres and nakama) to point to a folder in on your host-system
+#
+#
+version: '3'
+services:
+  postgres:
+    container_name: postgres
+    image: arm64v8/postgres:9.6-alpine
+    environment:
+      - POSTGRES_DB="nakama"
+    volumes:
+      - /path/to/postgres/datafolder:/var/lib/postgresql/data
+    expose:
+      - "8080"
+      - "5432"
+    ports:
+      - "5432:5432"
+      - "8080:8080"
+  nakama:
+    container_name: nakama
+    image: heroiclabs/nakama:2.6.0-arm64v8 
+    entrypoint:
+      - "/bin/sh"
+      - "-ecx"
+      - > 
+          sleep 10 && 
+          /nakama/nakama migrate up --database.address postgres@postgres:5432/nakama &&
+          exec /nakama/nakama --name nakama1 --database.address postgres@postgres:5432/nakama --logger.level DEBUG --session.token_expiry_sec 7200
+    restart: always
+    links:
+      - "postgres:db"
+    depends_on:
+      - postgres
+    volumes:
+      - /path/to/nakama/datafolder:/nakama/data
+    expose:
+      - "7349"
+      - "7350"
+      - "7351"
+    ports:
+      - "7349:7349"
+      - "7350:7350"
+      - "7351:7351"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7350/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+volumes:
+  data:


### PR DESCRIPTION
As pointed out in the [forum](https://forum.heroiclabs.com/t/arm64v8-docker-image-available/147/4) I wanted to build a nakama-dockerimage for arm64v8. 
 
To achieve this I created two dedicated files:
1) build/Dockerfile-arm64v8 : to build the image like this:

```
docker build "$PWD" --build-arg commit="$(git rev-parse --short HEAD)" --build-arg version=v2.6.0 -t heroiclabs/nakama:2.6.0-arm64v8 -f Dockerfile-arm64v8
```
2)  docker-compose-postgres-arm64v8.yml: to startup nakama on arm64 accompanied with postgres
```
docker-compose -f docker-compose-postgres-arm64v8.yml up
```
