### PR TITLE
fix time conversion for time based metrics

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -522,7 +522,7 @@ func traceApiBefore(ctx context.Context, logger *zap.Logger, fullMethodName stri
 	err = fn(clientIP, clientPort)
 
 	span.End()
-	stats.Record(statsCtx, MetricsAPITimeSpentMsec.M(float64(time.Now().UTC().UnixNano()-startNanos)/1000), MetricsAPICount.M(1))
+	stats.Record(statsCtx, MetricsAPITimeSpentMsec.M(float64(time.Now().UTC().UnixNano()-startNanos)/1e6), MetricsAPICount.M(1))
 
 	return err
 }
@@ -543,5 +543,5 @@ func traceApiAfter(ctx context.Context, logger *zap.Logger, fullMethodName strin
 	fn(clientIP, clientPort)
 
 	span.End()
-	stats.Record(statsCtx, MetricsAPITimeSpentMsec.M(float64(time.Now().UTC().UnixNano()-startNanos)/1000), MetricsAPICount.M(1))
+	stats.Record(statsCtx, MetricsAPITimeSpentMsec.M(float64(time.Now().UTC().UnixNano()-startNanos)/1e6), MetricsAPICount.M(1))
 }

--- a/server/socket_ws.go
+++ b/server/socket_ws.go
@@ -101,6 +101,6 @@ func NewSocketWsAcceptor(logger *zap.Logger, config Config, sessionRegistry Sess
 
 		// Mark the end of the session.
 		span.End()
-		stats.Record(SocketWsStatsCtx, MetricsSocketWsTimeSpentMsec.M(float64(time.Now().UTC().UnixNano()-startNanos)/1000), MetricsSocketWsCloseCount.M(1))
+		stats.Record(SocketWsStatsCtx, MetricsSocketWsTimeSpentMsec.M(float64(time.Now().UTC().UnixNano()-startNanos)/1e6), MetricsSocketWsCloseCount.M(1))
 	}
 }


### PR DESCRIPTION
**Background**
- Conversion rate from nanoseconds to milliseconds is 1e6 not 1k
- https://www.convertunits.com/from/nanosecond/to/millisecond

**Change**
- Updated in  api (MetricsAPITimeSpentMsec) and websocket (MetricsSocketWsTimeSpentMsec)
- MetricsRtapiTimeSpentMsec does not seem be to used anymore, so there are no updates for it