### PR TITLE
Fix for 8 char pwd error message.

### DIFF
--- a/server/api_authenticate.go
+++ b/server/api_authenticate.go
@@ -224,7 +224,7 @@ func (s *ApiServer) AuthenticateEmail(ctx context.Context, in *api.AuthenticateE
 	}
 
 	if len(email.Password) < 8 {
-		return nil, status.Error(codes.InvalidArgument, "Password must be longer than 8 characters.")
+		return nil, status.Error(codes.InvalidArgument, "Password must be at least 8 characters long.")
 	}
 
 	username := in.Username

--- a/server/api_link.go
+++ b/server/api_link.go
@@ -215,7 +215,7 @@ func (s *ApiServer) LinkEmail(ctx context.Context, in *api.AccountEmail) (*empty
 	} else if invalidCharsRegex.MatchString(in.Email) {
 		return nil, status.Error(codes.InvalidArgument, "Invalid email address, no spaces or control characters allowed.")
 	} else if len(in.Password) < 8 {
-		return nil, status.Error(codes.InvalidArgument, "Password must be longer than 8 characters.")
+		return nil, status.Error(codes.InvalidArgument, "Password must be at least 8 characters long")
 	} else if !emailRegex.MatchString(in.Email) {
 		return nil, status.Error(codes.InvalidArgument, "Invalid email address format.")
 	} else if len(in.Email) < 10 || len(in.Email) > 255 {


### PR DESCRIPTION
Message was "Password must be longer than 8 characters." when actually 8 character is the minimum.