### PR TITLE
Fix ListNotifications not using the user supplied cursor

### DIFF
--- a/server/api_notification.go
+++ b/server/api_notification.go
@@ -65,7 +65,7 @@ func (s *ApiServer) ListNotifications(ctx context.Context, in *api.ListNotificat
 	cursor := in.GetCacheableCursor()
 	var nc *notificationCacheableCursor
 	if cursor != "" {
-		nc := &notificationCacheableCursor{}
+		nc = &notificationCacheableCursor{}
 		cb, err := base64.RawURLEncoding.DecodeString(cursor)
 		if err != nil {
 			s.logger.Warn("Could not base64 decode notification cursor.", zap.String("cursor", cursor))


### PR DESCRIPTION
This was a fix made by Zeke (bfops). This fixes the bug where ListNotifications will always start at the beginning of your notifications list because the input cursor isn't assigned properly.