### PR TITLE
Fix #401 Setting wrong headers on RPC responses

### DIFF
--- a/server/api_rpc.go
+++ b/server/api_rpc.go
@@ -201,9 +201,14 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		// "Unwrapped" response.
 		response = []byte(result)
 	}
-	if contentType := r.Header["Content-Type"]; unwrap && len(contentType) > 0 {
-		// Assume the request input content type is the same as the expected response.
-		w.Header().Set("content-type", contentType[0])
+	if unwrap {
+		if contentType := r.Header["Content-Type"]; len(contentType) > 0 {
+			// Assume the request input content type is the same as the expected response.
+			w.Header().Set("content-type", contentType[0])
+		} else {
+			// Don't know payload content-type.
+			w.Header().Set("content-type", "text/plain")
+		}
 	} else {
 		// Fall back to default response content type application/json.
 		w.Header().Set("content-type", "application/json")

--- a/server/api_rpc.go
+++ b/server/api_rpc.go
@@ -54,8 +54,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		userID, username, vars, expiry, tokenAuth = parseBearerAuth([]byte(s.config.GetSession().EncryptionKey), auth[0])
 		if !tokenAuth {
 			// Auth token not valid or expired.
-			w.WriteHeader(http.StatusUnauthorized)
 			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
 			_, err := w.Write(authTokenInvalidBytes)
 			if err != nil {
 				s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -65,8 +65,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 	} else if httpKey := queryParams.Get("http_key"); httpKey != "" {
 		if httpKey != s.config.GetRuntime().HTTPKey {
 			// HTTP key did not match.
-			w.WriteHeader(http.StatusUnauthorized)
 			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
 			_, err := w.Write(httpKeyInvalidBytes)
 			if err != nil {
 				s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -75,8 +75,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		// No authentication present.
-		w.WriteHeader(http.StatusUnauthorized)
 		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
 		_, err := w.Write(noAuthBytes)
 		if err != nil {
 			s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -97,8 +97,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 	maybeID, ok := mux.Vars(r)["id"]
 	if !ok || maybeID == "" {
 		// Missing RPC function ID.
-		w.WriteHeader(http.StatusBadRequest)
 		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
 		sentBytes, err = w.Write(rpcIDMustBeSetBytes)
 		if err != nil {
 			s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -111,8 +111,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 	fn := s.runtime.Rpc(id)
 	if fn == nil {
 		// No function registered for this ID.
-		w.WriteHeader(http.StatusNotFound)
 		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
 		sentBytes, err = w.Write(rpcFunctionNotFoundBytes)
 		if err != nil {
 			s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -131,8 +131,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			// Error reading request body.
-			w.WriteHeader(http.StatusInternalServerError)
 			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
 			sentBytes, err = w.Write(internalServerErrorBytes)
 			if err != nil {
 				s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -145,8 +145,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		if !unwrap {
 			err = json.Unmarshal(b, &payload)
 			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
 				w.Header().Set("content-type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
 				sentBytes, err = w.Write(badJSONBytes)
 				if err != nil {
 					s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -171,8 +171,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 	result, fnErr, code := fn(r.Context(), queryParams, uid, username, vars, expiry, "", clientIP, clientPort, payload)
 	if fnErr != nil {
 		response, _ := json.Marshal(map[string]interface{}{"error": fnErr, "message": fnErr.Error(), "code": code})
-		w.WriteHeader(runtime.HTTPStatusFromCode(code))
 		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(runtime.HTTPStatusFromCode(code))
 		sentBytes, err = w.Write(response)
 		if err != nil {
 			s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -189,8 +189,8 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			// Failed to encode the wrapped response.
 			s.logger.Error("Error marshaling wrapped response to client", zap.Error(err))
-			w.WriteHeader(http.StatusInternalServerError)
 			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
 			sentBytes, err = w.Write(internalServerErrorBytes)
 			if err != nil {
 				s.logger.Debug("Error writing response to client", zap.Error(err))
@@ -201,7 +201,6 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		// "Unwrapped" response.
 		response = []byte(result)
 	}
-	w.WriteHeader(http.StatusOK)
 	if contentType := r.Header["Content-Type"]; unwrap && len(contentType) > 0 {
 		// Assume the request input content type is the same as the expected response.
 		w.Header().Set("content-type", contentType[0])
@@ -209,6 +208,7 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		// Fall back to default response content type application/json.
 		w.Header().Set("content-type", "application/json")
 	}
+	w.WriteHeader(http.StatusOK)
 	sentBytes, err = w.Write(response)
 	if err != nil {
 		s.logger.Debug("Error writing response to client", zap.Error(err))


### PR DESCRIPTION
Fixes https://github.com/heroiclabs/nakama/issues/401. For the purposes of documenting the existing behavior, fixed by this patch:

The "Accept" header does not influence server responses when querying RPC funcitons. This is due to the fact that RPC functions transform payloads internally and do not communicate desired response headers to nakama. Therefore, nakama disregards the "Accept" values in this case.

Additionally, there's the `unwrap` query parameter that determines whether the server should return a JSON-wrapped payload (default, when `unwrap` is not set) or the raw string that the RPC function returned (when `unwrap=true`).

Thus, "Content-Type" is determined as follows:

- An error message is always an "application/json"
```
{"error":"error_text","message":"message_text","code":3}
```
- If `unwrap` is unset (default), the response is always an "application/json"
```
{"payload":"payload_string"}
```
- if `unwrap` is set, outgoing "Content-Type" is set to the value provided in the incoming "Content-Type", or to "text/plain" if not specified.
```
payload_string
```

To have the server compress a response, just specify the "Accept-Encoding: gzip" header in your request. Same "Content-Type" determination rules apply.