### PR TITLE
use logger.Info instead of logger.Printf in sample go runtime code

### DIFF
--- a/sample_go_module/sample.go
+++ b/sample_go_module/sample.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"database/sql"
+
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama-common/runtime"
@@ -52,17 +53,17 @@ func InitModule(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runti
 }
 
 func rpcEcho(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
-	logger.Print("RUNNING IN GO")
+	logger.Info("RUNNING IN GO")
 	return payload, nil
 }
 
 func beforeChannelJoin(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, envelope *rtapi.Envelope) (*rtapi.Envelope, error) {
-	logger.Printf("Intercepted request to join channel '%v'", envelope.GetChannelJoin().Target)
+	logger.Info("Intercepted request to join channel '%v'", envelope.GetChannelJoin().Target)
 	return envelope, nil
 }
 
 func afterGetAccount(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.Account) error {
-	logger.Printf("Intercepted response to get account '%v'", in)
+	logger.Info("Intercepted response to get account '%v'", in)
 	return nil
 }
 
@@ -84,7 +85,7 @@ func (m *Match) MatchInit(ctx context.Context, logger runtime.Logger, db *sql.DB
 	}
 
 	if state.debug {
-		logger.Printf("match init, starting with debug: %v", state.debug)
+		logger.Info("match init, starting with debug: %v", state.debug)
 	}
 	tickRate := 1
 	label := "skill=100-150"
@@ -94,7 +95,7 @@ func (m *Match) MatchInit(ctx context.Context, logger runtime.Logger, db *sql.DB
 
 func (m *Match) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, presence runtime.Presence, metadata map[string]string) (interface{}, bool, string) {
 	if state.(*MatchState).debug {
-		logger.Printf("match join attempt username %v user_id %v session_id %v node %v with metadata %v", presence.GetUsername(), presence.GetUserId(), presence.GetSessionId(), presence.GetNodeId(), metadata)
+		logger.Info("match join attempt username %v user_id %v session_id %v node %v with metadata %v", presence.GetUsername(), presence.GetUserId(), presence.GetSessionId(), presence.GetNodeId(), metadata)
 	}
 
 	return state, true, ""
@@ -103,7 +104,7 @@ func (m *Match) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, db 
 func (m *Match) MatchJoin(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, presences []runtime.Presence) interface{} {
 	if state.(*MatchState).debug {
 		for _, presence := range presences {
-			logger.Printf("match join username %v user_id %v session_id %v node %v", presence.GetUsername(), presence.GetUserId(), presence.GetSessionId(), presence.GetNodeId())
+			logger.Info("match join username %v user_id %v session_id %v node %v", presence.GetUsername(), presence.GetUserId(), presence.GetSessionId(), presence.GetNodeId())
 		}
 	}
 
@@ -113,7 +114,7 @@ func (m *Match) MatchJoin(ctx context.Context, logger runtime.Logger, db *sql.DB
 func (m *Match) MatchLeave(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, presences []runtime.Presence) interface{} {
 	if state.(*MatchState).debug {
 		for _, presence := range presences {
-			logger.Printf("match leave username %v user_id %v session_id %v node %v", presence.GetUsername(), presence.GetUserId(), presence.GetSessionId(), presence.GetNodeId())
+			logger.Info("match leave username %v user_id %v session_id %v node %v", presence.GetUsername(), presence.GetUserId(), presence.GetSessionId(), presence.GetNodeId())
 		}
 	}
 
@@ -122,8 +123,8 @@ func (m *Match) MatchLeave(ctx context.Context, logger runtime.Logger, db *sql.D
 
 func (m *Match) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, messages []runtime.MatchData) interface{} {
 	if state.(*MatchState).debug {
-		logger.Printf("match loop match_id %v tick %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), tick)
-		logger.Printf("match loop match_id %v message count %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), len(messages))
+		logger.Info("match loop match_id %v tick %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), tick)
+		logger.Info("match loop match_id %v message count %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), len(messages))
 	}
 
 	if tick >= 10 {
@@ -134,17 +135,17 @@ func (m *Match) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql.DB
 
 func (m *Match) MatchTerminate(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, graceSeconds int) interface{} {
 	if state.(*MatchState).debug {
-		logger.Printf("match terminate match_id %v tick %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), tick)
-		logger.Printf("match terminate match_id %v grace seconds %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), graceSeconds)
+		logger.Info("match terminate match_id %v tick %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), tick)
+		logger.Info("match terminate match_id %v grace seconds %v", ctx.Value(runtime.RUNTIME_CTX_MATCH_ID), graceSeconds)
 	}
 
 	return state
 }
 
 func eventSessionStart(ctx context.Context, logger runtime.Logger, evt *api.Event) {
-	logger.Printf("session start %v %v", ctx, evt)
+	logger.Info("session start %v %v", ctx, evt)
 }
 
 func eventSessionEnd(ctx context.Context, logger runtime.Logger, evt *api.Event) {
-	logger.Printf("session end %v %v", ctx, evt)
+	logger.Info("session end %v %v", ctx, evt)
 }

--- a/sample_go_module/sample.go
+++ b/sample_go_module/sample.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Nakama Authors
+// Copyright 2020 The Nakama Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,11 @@ import (
 )
 
 func InitModule(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, initializer runtime.Initializer) error {
+
 	if err := initializer.RegisterRpc("go_echo_sample", rpcEcho); err != nil {
+		return err
+	}
+	if err := initializer.RegisterRpc("rpc_create_match", rpcCreateMatch); err != nil {
 		return err
 	}
 	if err := initializer.RegisterBeforeRt("ChannelJoin", beforeChannelJoin); err != nil {
@@ -49,12 +53,24 @@ func InitModule(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runti
 	}); err != nil {
 		return err
 	}
+
 	return nil
 }
 
 func rpcEcho(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
 	logger.Info("RUNNING IN GO")
 	return payload, nil
+}
+
+func rpcCreateMatch(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
+
+	matchID, err := nk.MatchCreate(ctx, "match", map[string]interface{}{})
+
+	if err != nil {
+		return "", err
+	}
+
+	return matchID, nil
 }
 
 func beforeChannelJoin(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, envelope *rtapi.Envelope) (*rtapi.Envelope, error) {


### PR DESCRIPTION
The sample code was not compiling due to `Printf` not existing on the logger. I just modified it to use `Info` instead.