### PR TITLE
Fix for database credentials visible in logs

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -136,7 +136,7 @@ func Parse(args []string, tmpLogger *zap.Logger) {
 		dbname = parsedURL.Path[1:]
 	}
 
-	logger.Info("Database connection", zap.String("dsn", ms.dbAddress))
+	logger.Info("Database connection", zap.String("dsn", parsedURL.Redacted()))
 
 	parsedURL.Path = ""
 	db, err := sql.Open("pgx", parsedURL.String())


### PR DESCRIPTION
Issue logged in #461 indicating passwords being output to logs during startup.

This PR uses [URL.Redacted()](https://golang.org/pkg/net/url/#URL.Redacted) to display the DSN when logged.

During migrations, DSNs are output using the alternate format.

During startup, a copy is made, then the copy is redacted and used for log output.