### PR TITLE
Add TournamentRecordsList and FriendList to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - Event contexts now contain user information for external events.
 - Expose more metrics for socket activity.
 - New [Docker release](https://hub.docker.com/repository/docker/heroiclabs/nakama-dsym) of the server with debug symbols enabled.
+- Added `TournamentRecordsList` and `ListFriends` functions to the Go Runtime.
+- Added `friends_list` and `tournament_records_list` functions to the Lua Runtime.
 
 ### Fixed
 - Add missing 'rank' field from the Lua runtime `tournament_records_haystack` function results.
+- Add missing cursor return values from the Go runtime `GroupUsersList` and `UsersGroupList` functions.
 
 ## [2.14.0] - 2020-10-03
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/grpc-gateway v1.13.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.0-beta.5
-	github.com/heroiclabs/nakama-common v1.8.0
+	github.com/heroiclabs/nakama-common v1.8.1-0.20201023170947-267661dc1574
 	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgx v3.5.0+incompatible
 	github.com/jmhodges/levigo v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.0-beta.5/go.mod h1:fR9dOEfEyRM7lt
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/heroiclabs/nakama-common v1.8.0 h1:GrRmXS9R7rquVPTzD9c9oJlwJWVUtm8IJiq/x/+vHQg=
-github.com/heroiclabs/nakama-common v1.8.0/go.mod h1:C+clZj5bSOYz4UYS7nlAVncqiLxenaTaUGx7heC9H7M=
+github.com/heroiclabs/nakama-common v1.8.1-0.20201023170947-267661dc1574 h1:jIjYnNvgICEv1cLFpiMAcK+fLceTfm3Dd5Wnlb5LlDs=
+github.com/heroiclabs/nakama-common v1.8.1-0.20201023170947-267661dc1574/go.mod h1:C+clZj5bSOYz4UYS7nlAVncqiLxenaTaUGx7heC9H7M=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -263,7 +263,7 @@ func LeaderboardRecordsList(ctx context.Context, logger *zap.Logger, db *sql.DB,
 		for rows.Next() {
 			err = rows.Scan(&dbOwnerID, &dbUsername, &dbScore, &dbSubscore, &dbNumScore, &dbMaxNumScore, &dbMetadata, &dbCreateTime, &dbUpdateTime)
 			if err != nil {
-				_ = rows.Close()
+				rows.Close()
 				logger.Error("Error parsing read leaderboard records", zap.Error(err))
 				return nil, err
 			}

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -2009,58 +2009,58 @@ func (n *RuntimeGoNakamaModule) GroupUsersKick(ctx context.Context, groupID stri
 	return KickGroupUsers(ctx, n.logger, n.db, n.router, uuid.Nil, group, users)
 }
 
-func (n *RuntimeGoNakamaModule) GroupUsersList(ctx context.Context, id string, limit int, state *int, cursor string) ([]*api.GroupUserList_GroupUser, error) {
+func (n *RuntimeGoNakamaModule) GroupUsersList(ctx context.Context, id string, limit int, state *int, cursor string) ([]*api.GroupUserList_GroupUser, string, error) {
 	groupID, err := uuid.FromString(id)
 	if err != nil {
-		return nil, errors.New("expects group ID to be a valid identifier")
+		return nil, "", errors.New("expects group ID to be a valid identifier")
 	}
 
 	if limit < 1 || limit > 100 {
-		return nil, errors.New("expects limit to be 1-100")
+		return nil, "", errors.New("expects limit to be 1-100")
 	}
 
 	var stateWrapper *wrappers.Int32Value
 	if state != nil {
 		stateValue := *state
 		if stateValue < 0 || stateValue > 4 {
-			return nil, errors.New("expects state to be 0-4")
+			return nil, "", errors.New("expects state to be 0-4")
 		}
 		stateWrapper = &wrappers.Int32Value{Value: int32(stateValue)}
 	}
 
 	users, err := ListGroupUsers(ctx, n.logger, n.db, n.tracker, groupID, limit, stateWrapper, cursor)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return users.GroupUsers, nil
+	return users.GroupUsers, users.Cursor, nil
 }
 
-func (n *RuntimeGoNakamaModule) UserGroupsList(ctx context.Context, userID string, limit int, state *int, cursor string) ([]*api.UserGroupList_UserGroup, error) {
+func (n *RuntimeGoNakamaModule) UserGroupsList(ctx context.Context, userID string, limit int, state *int, cursor string) ([]*api.UserGroupList_UserGroup, string, error) {
 	uid, err := uuid.FromString(userID)
 	if err != nil {
-		return nil, errors.New("expects user ID to be a valid identifier")
+		return nil, "", errors.New("expects user ID to be a valid identifier")
 	}
 
 	if limit < 1 || limit > 100 {
-		return nil, errors.New("expects limit to be 1-100")
+		return nil, "", errors.New("expects limit to be 1-100")
 	}
 
 	var stateWrapper *wrappers.Int32Value
 	if state != nil {
 		stateValue := *state
 		if stateValue < 0 || stateValue > 4 {
-			return nil, errors.New("expects state to be 0-4")
+			return nil, "", errors.New("expects state to be 0-4")
 		}
 		stateWrapper = &wrappers.Int32Value{Value: int32(stateValue)}
 	}
 
 	groups, err := ListUserGroups(ctx, n.logger, n.db, uid, limit, stateWrapper, cursor)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return groups.UserGroups, nil
+	return groups.UserGroups, groups.Cursor, nil
 }
 
 func (n *RuntimeGoNakamaModule) Event(ctx context.Context, evt *api.Event) error {
@@ -2079,6 +2079,33 @@ func (n *RuntimeGoNakamaModule) Event(ctx context.Context, evt *api.Event) error
 	}
 
 	return nil
+}
+
+func (n *RuntimeGoNakamaModule) FriendsList(ctx context.Context, userID string, limit int, state *int, cursor string) ([]*api.Friend, string, error) {
+	uid, err := uuid.FromString(userID)
+	if err != nil {
+		return nil, "", errors.New("expects user ID to be a valid identifier")
+	}
+
+	if limit < 1 || limit > 100 {
+		return nil, "", errors.New("expects limit to be 1-100")
+	}
+
+	var stateWrapper *wrappers.Int32Value
+	if state != nil {
+		stateValue := *state
+		if stateValue < 0 || stateValue > 3 {
+			return nil, "", errors.New("expects state to be 0-3")
+		}
+		stateWrapper = &wrappers.Int32Value{Value: int32(stateValue)}
+	}
+
+	friends, err := ListFriends(ctx, n.logger, n.db, n.tracker, uid, limit, stateWrapper, cursor)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return friends.Friends, friends.Cursor, nil
 }
 
 func (n *RuntimeGoNakamaModule) SetEventFn(fn RuntimeEventCustomFunction) {

--- a/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
+++ b/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
@@ -879,6 +879,7 @@ type NakamaModule interface {
 	TournamentJoin(ctx context.Context, id, ownerID, username string) error
 	TournamentsGetId(ctx context.Context, tournamentIDs []string) ([]*api.Tournament, error)
 	TournamentList(ctx context.Context, categoryStart, categoryEnd, startTime, endTime, limit int, cursor string) (*api.TournamentList, error)
+	TournamentRecordsList(ctx context.Context, tournamentId string, ownerIDs []string, limit int, cursor string, overrideExpiry int64) ([]*api.LeaderboardRecord, []*api.LeaderboardRecord, string, string, error)
 	TournamentRecordWrite(ctx context.Context, id, ownerID, username string, score, subscore int64, metadata map[string]interface{}) (*api.LeaderboardRecord, error)
 	TournamentRecordsHaystack(ctx context.Context, id, ownerID string, limit int, expiry int64) ([]*api.LeaderboardRecord, error)
 
@@ -887,8 +888,10 @@ type NakamaModule interface {
 	GroupUpdate(ctx context.Context, id, name, creatorID, langTag, description, avatarUrl string, open bool, metadata map[string]interface{}, maxCount int) error
 	GroupDelete(ctx context.Context, id string) error
 	GroupUsersKick(ctx context.Context, groupID string, userIDs []string) error
-	GroupUsersList(ctx context.Context, id string, limit int, state *int, cursor string) ([]*api.GroupUserList_GroupUser, error)
-	UserGroupsList(ctx context.Context, userID string, limit int, state *int, cursor string) ([]*api.UserGroupList_UserGroup, error)
+	GroupUsersList(ctx context.Context, id string, limit int, state *int, cursor string) ([]*api.GroupUserList_GroupUser, string, error)
+	UserGroupsList(ctx context.Context, userID string, limit int, state *int, cursor string) ([]*api.UserGroupList_UserGroup, string, error)
+
+	FriendsList(ctx context.Context, userID string, limit int, state *int, cursor string) ([]*api.Friend, string, error)
 
 	Event(ctx context.Context, evt *api.Event) error
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -113,7 +113,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopena
 github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options
 github.com/grpc-ecosystem/grpc-gateway/v2/runtime
 github.com/grpc-ecosystem/grpc-gateway/v2/utilities
-# github.com/heroiclabs/nakama-common v1.8.0
+# github.com/heroiclabs/nakama-common v1.8.1-0.20201023170947-267661dc1574
 github.com/heroiclabs/nakama-common/api
 github.com/heroiclabs/nakama-common/rtapi
 github.com/heroiclabs/nakama-common/runtime


### PR DESCRIPTION
`ListTournamentRecords` logic moved from api to core so it can be reused.
Expose `ListTournamentRecords` to Go and Lua runtimes.
Add FriendsList function to Go and Lua runtimes.

Fixes #326 #470