### PR TITLE
Update protoc-gen-angular go.mod

### DIFF
--- a/console/protoc-gen-angular/README.md
+++ b/console/protoc-gen-angular/README.md
@@ -14,6 +14,12 @@ Install the `protoc-gen-angular` binary by running:
 ```shell
 go build && go install
 ```
+
+Otherwise you can install it using go mod as such:
+```shell
+go get github.com/heroiclabs/nakama/console/protoc-gen-angular
+```
+
 #### Options
 Options are passed to the `protoc` flag in the following way: `--angular_out=service_name=foo,filename=bar.ts:.`.
 

--- a/console/protoc-gen-angular/go.mod
+++ b/console/protoc-gen-angular/go.mod
@@ -1,4 +1,4 @@
-module protoc-gen-angular
+module github.com/heroiclabs/nakama/console/protoc-gen-angular
 
 go 1.13
 


### PR DESCRIPTION
Allow the angular generator protoc plugin to be installed using go get.