### PR TITLE
Return third party auth ids from friends graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - Fix some issues around listing tournaments.
 - Fix an issue that would prevent the insertion of a record in a tournament with no scheduled reset and end time.
 - Ensure the devconsole applies user password updates even if no other fields change.
+- Fix third-party authentication ids not getting returned if queried through the friends graph.
 
 ## [2.14.1] - 2020-11-02
 ### Added


### PR DESCRIPTION
Our third party authentication provider ids weren't being included in our User objects if the user was requested via the ListFriends method. This fixes that.

Tested this against the following test:

https://github.com/heroiclabs/nakama-js/blob/master/packages/nakama-js-test/client-friend.test.ts#L129