### PR TITLE
Track tool dependencies in modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ To build the codebase and generate all sources follow these steps.
 1. Install the toolchain.
 
    ```shell
-   go install \
-       "github.com/golang/protobuf/protoc-gen-go" \
-       "google.golang.org/grpc/cmd/protoc-gen-go-grpc" \
-       "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway" \
-       "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
+  go install \
+    github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway \
+    github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \
+    google.golang.org/protobuf/cmd/protoc-gen-go \
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc
    ```
 
 2. If you've made changes to the embedded Console.

--- a/go.sum
+++ b/go.sum
@@ -185,12 +185,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.1/go.mod h1:oVMjMN64nzEcepv1kdZKg
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/heroiclabs/nakama-common v0.0.0-20210310182534-5118454ac852 h1:CQ1sqllnrpnDySXVxB8H0GKVG9ht/TjziZOnAixUzR0=
-github.com/heroiclabs/nakama-common v0.0.0-20210310182534-5118454ac852/go.mod h1:li7bMQwOYA0NjT3DM4NKQBNruULPa2hrqdiSaaTwui4=
 github.com/heroiclabs/nakama-common v0.0.0-20210324184331-c33a19836925 h1:ga9O6p73ddcCbLZ48IBJBq06SOtBB7X8GM/Sku0WxTY=
 github.com/heroiclabs/nakama-common v0.0.0-20210324184331-c33a19836925/go.mod h1:li7bMQwOYA0NjT3DM4NKQBNruULPa2hrqdiSaaTwui4=
-github.com/heroiclabs/nakama-common v1.12.1 h1:3ZB9CW5iCF/bWipFeULEBzZz/j/QYPGjbs7HyRUITu8=
-github.com/heroiclabs/nakama-common v1.12.1/go.mod h1:li7bMQwOYA0NjT3DM4NKQBNruULPa2hrqdiSaaTwui4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,10 @@
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
+)

--- a/vendor/google.golang.org/protobuf/cmd/protoc-gen-go/main.go
+++ b/vendor/google.golang.org/protobuf/cmd/protoc-gen-go/main.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The protoc-gen-go binary is a protoc plugin to generate Go code for
+// both proto2 and proto3 versions of the protocol buffer language.
+//
+// For more information about the usage of this plugin, see:
+//	https://developers.google.com/protocol-buffers/docs/reference/go-generated
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	gengo "google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo"
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/internal/version"
+)
+
+func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Fprintf(os.Stderr, "%v %v\n", filepath.Base(os.Args[0]), version.String())
+		os.Exit(0)
+	}
+
+	var (
+		flags        flag.FlagSet
+		plugins      = flags.String("plugins", "", "deprecated option")
+		importPrefix = flags.String("import_prefix", "", "deprecated option")
+	)
+	protogen.Options{
+		ParamFunc: flags.Set,
+	}.Run(func(gen *protogen.Plugin) error {
+		if *plugins != "" {
+			return errors.New("protoc-gen-go: plugins are not supported; use 'protoc --go-grpc_out=...' to generate gRPC")
+		}
+		if *importPrefix != "" {
+			return errors.New("protoc-gen-go: import_prefix is not supported")
+		}
+		for _, f := range gen.Files {
+			if f.Generate {
+				gengo.GenerateFile(gen, f)
+			}
+		}
+		gen.SupportedFeatures = gengo.SupportedFeatures
+		return nil
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -331,6 +331,7 @@ google.golang.org/grpc/tap
 google.golang.org/grpc/cmd/protoc-gen-go-grpc
 # google.golang.org/protobuf v1.25.0
 ## explicit
+google.golang.org/protobuf/cmd/protoc-gen-go
 google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo
 google.golang.org/protobuf/compiler/protogen
 google.golang.org/protobuf/encoding/protojson


### PR DESCRIPTION
Although I won't elaborate here, I've added the installation binaries for GRPC to go modules, and updated the documentation to reflect the current installation pattern (updated from their README)

- https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
- https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md
- https://github.com/grpc-ecosystem/grpc-gateway#installation