### PR TITLE
#595 use path.Join for go embed filesystems instead of filepath.Join

### DIFF
--- a/console/ui.go
+++ b/console/ui.go
@@ -18,7 +18,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
-	"path/filepath"
+	"path"
 )
 
 //go:embed ui/dist/*
@@ -28,7 +28,7 @@ var UIFS = &uiFS{}
 type uiFS struct{}
 
 func (fs *uiFS) Open(name string) (fs.File, error) {
-	return embedFS.Open(filepath.Join("ui", "dist", name))
+	return embedFS.Open(path.Join("ui", "dist", name))
 }
 
 var UI = http.FileServer(http.FS(UIFS))

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -23,7 +23,7 @@ import (
 	"math"
 	"net/url"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -66,15 +66,15 @@ func StartupCheck(logger *zap.Logger, db *sql.DB) {
 	migrate.SetIgnoreUnknown(true)
 
 	ms := &migrate.AssetMigrationSource{
-		Asset: func(path string) ([]byte, error) {
-			f, err := sqlMigrateFS.Open(filepath.Join("sql", path))
+		Asset: func(_path string) ([]byte, error) {
+			f, err := sqlMigrateFS.Open(path.Join("sql", _path))
 			if err != nil {
 				return nil, err
 			}
 			return ioutil.ReadAll(f)
 		},
-		AssetDir: func(path string) ([]string, error) {
-			entries, err := sqlMigrateFS.ReadDir(filepath.Join("sql", path))
+		AssetDir: func(_path string) ([]string, error) {
+			entries, err := sqlMigrateFS.ReadDir(path.Join("sql", _path))
 			if err != nil {
 				return nil, err
 			}
@@ -113,15 +113,15 @@ func Parse(args []string, tmpLogger *zap.Logger) {
 	migrate.SetIgnoreUnknown(true)
 	ms := &migrationService{
 		migrations: &migrate.AssetMigrationSource{
-			Asset: func(path string) ([]byte, error) {
-				f, err := sqlMigrateFS.Open(filepath.Join("sql", path))
+			Asset: func(_path string) ([]byte, error) {
+				f, err := sqlMigrateFS.Open(path.Join("sql", _path))
 				if err != nil {
 					return nil, err
 				}
 				return ioutil.ReadAll(f)
 			},
-			AssetDir: func(path string) ([]string, error) {
-				entries, err := sqlMigrateFS.ReadDir(filepath.Join("sql", path))
+			AssetDir: func(_path string) ([]string, error) {
+				entries, err := sqlMigrateFS.ReadDir(path.Join("sql", _path))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
…because embed fs always uses forward slash separators