### PR TITLE
fix off-by-one error in indexing leaderboard records around owner

### DIFF
--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -639,12 +639,12 @@ func getLeaderboardRecordsHaystack(ctx context.Context, logger *zap.Logger, db *
 	numRecords := len(records)
 
 	if start < 0 {
-		// if we hit the top of the record slice before reaching the limit
-		// then move down the bottom boundary of the slice by the number of records blocked by the top.
+		// if we hit the front of the record slice before reaching the limit
+		// then move back the back boundary of the slice by the number of records blocked by the front.
 		end -= start
 	} else if end > numRecords {
-		// if we hit the bottom of the record slice before reaching the limit
-		// then move up the top boundary of the slice by the number of records blocked by the bottom.
+		// if we hit the back of the record slice before reaching the limit
+		// then move up the front boundary of the slice by the number of records blocked by the back.
 		start -= end - numRecords
 	}
 

--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -628,32 +628,14 @@ func getLeaderboardRecordsHaystack(ctx context.Context, logger *zap.Logger, db *
 	records := append(firstRecords, ownerRecord)
 	records = append(records, secondRecords...)
 
-	// owner index minus half the limit
-	// if an even number of records, favor the owner record
-	// being in the front half of records
-	start := len(firstRecords) - int((limit-1)/2)
-
-	// start plus two (owner index & end of slice is exclusive) plus back "half" of records
-	end := start + int(limit/2) + 2
-
 	numRecords := len(records)
-
-	if start < 0 {
-		// if we hit the front of the record slice before reaching the limit
-		// then move back the back boundary of the slice by the number of records blocked by the front.
-		end -= start
-	} else if end > numRecords {
-		// if we hit the back of the record slice before reaching the limit
-		// then move up the front boundary of the slice by the number of records blocked by the back.
-		start -= end - numRecords
-	}
-
-	if start < 0 {
+	start := numRecords - int(limit)
+	if len(firstRecords) < limit/2 {
 		start = 0
 	}
-
+	end := start + int(limit)
 	if end > numRecords {
-		end = len(records)
+		end = numRecords
 	}
 
 	records = records[start:end]


### PR DESCRIPTION
After the [following issue](
https://github.com/heroiclabs/nakama-unity/issues/112) was filed against the Unity client I wrote the following test suite:

https://github.com/heroiclabs/nakama-dotnet/commit/5d0228603331a185f7837076c7c0326ba72446f6

In short, if you have ranks 1 through 10, the owner is rank 2, and you request 4 records, the server will return ranks 2, 3, 4,  and 5.

If I am interpreting the term "aroundOwner" correctly, the server should instead return ranks 1, 2, 3, and 4.

Fixes: #607, https://github.com/heroiclabs/nakama-unity/issues/112

In terms of the leaderboard rank cache, I am assuming that during a rolling reboot the cache gets invalidated, in which case it would get repopulated with the correct entries at some appropriate time.
