### PR TITLE
add empty bodies to post methods in apigrpc.proto

### DIFF
--- a/apigrpc/apigrpc.proto
+++ b/apigrpc/apigrpc.proto
@@ -529,7 +529,8 @@ service Nakama {
   // Promote a set of users in a group to the next role up.
   rpc PromoteGroupUsers (api.PromoteGroupUsersRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/v2/group/{group_id}/promote"
+      post: "/v2/group/{group_id}/promote",
+      body: "*"
     };
   }
 

--- a/apigrpc/apigrpc.proto
+++ b/apigrpc/apigrpc.proto
@@ -97,7 +97,7 @@ service Nakama {
   // Add users to a group.
   rpc AddGroupUsers (api.AddGroupUsersRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/v2/group/{group_id}/add";
+      post: "/v2/group/{group_id}/add",
       body: "*"
     };
   }

--- a/apigrpc/apigrpc.proto
+++ b/apigrpc/apigrpc.proto
@@ -88,12 +88,18 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 service Nakama {
   // Add friends by ID or username to a user's account.
   rpc AddFriends (api.AddFriendsRequest) returns (google.protobuf.Empty) {
-    option (google.api.http).post = "/v2/friend";
+    option (google.api.http) = {
+      post: "/v2/friend",
+      body: "*"
+    };
   }
 
   // Add users to a group.
   rpc AddGroupUsers (api.AddGroupUsersRequest) returns (google.protobuf.Empty) {
-    option (google.api.http).post = "/v2/group/{group_id}/add";
+    option (google.api.http) = {
+      post: "/v2/group/{group_id}/add";
+      body: "*"
+    };
   }
 
   // Refresh a user's session using a refresh token retrieved from a previous authentication request.
@@ -266,13 +272,17 @@ service Nakama {
 
   // Ban a set of users from a group.
   rpc BanGroupUsers (api.BanGroupUsersRequest) returns (google.protobuf.Empty) {
-    option (google.api.http).post = "/v2/group/{group_id}/ban";
+    option (google.api.http) = {
+      post = "/v2/group/{group_id}/ban",
+      body: "*"
+    };
   }
 
   // Block one or more users by ID or username.
   rpc BlockFriends (api.BlockFriendsRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/v2/friend/block"
+      post: "/v2/friend/block",
+      body: "*"
     };
   }
 
@@ -363,7 +373,10 @@ service Nakama {
 
   // Kick a set of users from a group.
   rpc KickGroupUsers (api.KickGroupUsersRequest) returns (google.protobuf.Empty) {
-    option (google.api.http).post = "/v2/group/{group_id}/kick";
+    option (google.api.http) = {
+      post: "/v2/group/{group_id}/kick",
+      body: "*"
+    };
   }
 
   // Leave a group the user is a member of.
@@ -515,12 +528,17 @@ service Nakama {
 
   // Promote a set of users in a group to the next role up.
   rpc PromoteGroupUsers (api.PromoteGroupUsersRequest) returns (google.protobuf.Empty) {
-    option (google.api.http).post = "/v2/group/{group_id}/promote";
+    option (google.api.http) = {
+      post: "/v2/group/{group_id}/promote"
+    };
   }
 
   // Demote a set of users in a group to the next role down.
   rpc DemoteGroupUsers (api.DemoteGroupUsersRequest) returns (google.protobuf.Empty) {
-    option (google.api.http).post = "/v2/group/{group_id}/demote";
+    option (google.api.http) = {
+      post: "/v2/group/{group_id}/demote",
+      body: "*"
+    };
   }
 
   // Get storage objects.


### PR DESCRIPTION
This is a slight workaround for https://github.com/grpc-ecosystem/grpc-gateway/issues/2093 so that we don't need to manually patch apigrpc.swagger.json after generating it.

One other thing I noticed -- it seems like the `protoc` invocation when running `go generate...` is dependent on my local protobuf installation. This was unexpected given the tool dependencies listed in https://github.com/heroiclabs/nakama/blob/master/build/tools.go.

Should we look at including the `protoc` tool itself in the tool dependencies?