### PR TITLE
Fix Apple Sign In issue

### DIFF
--- a/social/social.go
+++ b/social/social.go
@@ -675,9 +675,9 @@ func (c *Client) CheckAppleToken(ctx context.Context, bundleId string, idToken s
 		}
 
 		// Verify the audience matches the configured client ID.
-		if !claims.VerifyAudience(bundleId, true) {
+		/*if !claims.VerifyAudience(bundleId, true) {
 			return nil, fmt.Errorf("unexpected audience: %v", claims["aud"])
-		}
+		}*/
 
 		return cert.key, nil
 	})


### PR DESCRIPTION
Remove jwt aud field validation - the field is set to client_id for
web sign in as opposed to the bundle_id for app sign ins.

Resolves #618