### PR TITLE
Fix wrong http_key parameter

### DIFF
--- a/apigrpc/apigrpc.proto
+++ b/apigrpc/apigrpc.proto
@@ -68,8 +68,8 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       key: "HttpKeyAuth";
       value: {
         type: TYPE_API_KEY;
-        in: IN_HEADER;
-        name: "http_key";
+        in: IN_QUERY;
+        name: "httpKey";
       }
     }
   }

--- a/apigrpc/apigrpc.swagger.json
+++ b/apigrpc/apigrpc.swagger.json
@@ -4802,8 +4802,8 @@
     },
     "HttpKeyAuth": {
       "type": "apiKey",
-      "name": "http_key",
-      "in": "header"
+      "name": "httpKey",
+      "in": "query"
     }
   },
   "security": [

--- a/server/api.go
+++ b/server/api.go
@@ -149,7 +149,7 @@ func StartApiServer(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, p
 			q := r.URL.Query()
 			p := make(map[string][]string, len(q))
 			for k, vs := range q {
-				if k == "http_key" {
+				if k == "httpKey" {
 					// Skip Nakama's own query params, only process custom ones.
 					continue
 				}

--- a/server/api_rpc.go
+++ b/server/api_rpc.go
@@ -64,7 +64,7 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-	} else if httpKey := queryParams.Get("http_key"); httpKey != "" {
+	} else if httpKey := queryParams.Get("httpKey"); httpKey != "" {
 		if httpKey != s.config.GetRuntime().HTTPKey {
 			// HTTP key did not match.
 			w.Header().Set("content-type", "application/json")
@@ -171,7 +171,7 @@ func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	queryParams.Del("http_key")
+	queryParams.Del("httpKey")
 
 	uid := ""
 	if isTokenAuth {

--- a/server/runtime_test.go
+++ b/server/runtime_test.go
@@ -359,7 +359,7 @@ nakama.register_rpc(test.printWorld, "helloworld")`,
 
 	payload := "\"Hello World\""
 	client := &http.Client{}
-	request, _ := http.NewRequest("POST", "http://localhost:7350/v2/rpc/helloworld?http_key=defaulthttpkey", strings.NewReader(payload))
+	request, _ := http.NewRequest("POST", "http://localhost:7350/v2/rpc/helloworld?httpKey=defaulthttpkey", strings.NewReader(payload))
 	request.Header.Add("Content-Type", "Application/JSON")
 	res, err := client.Do(request)
 	if err != nil {


### PR DESCRIPTION
As already [said on Gitter](https://gitter.im/heroiclabs/nakama?at=611574639484630efa3556bc), this fixes the problem of some SDKs generating code based on the apigrpc.swagger.json file, like the [nakama-godot](https://github.com/heroiclabs/nakama-godot/blob/master/addons/com.heroiclabs.nakama/api/NakamaAPI.gd#L5172) addon