### PR TITLE
Configure whether or not to add the Lua stacktrace in the API response

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -765,6 +765,7 @@ type RuntimeConfig struct {
 	EventQueueWorkers  int               `yaml:"event_queue_workers" json:"event_queue_workers" usage:"Number of workers to use for concurrent processing of events. Default 8."`
 	ReadOnlyGlobals    bool              `yaml:"read_only_globals" json:"read_only_globals" usage:"When enabled marks all Lua runtime global tables as read-only to reduce memory footprint. Default true."` // Kept for backwards compatibility
 	LuaReadOnlyGlobals bool              `yaml:"lua_read_only_globals" json:"lua_read_only_globals" usage:"When enabled marks all Lua runtime global tables as read-only to reduce memory footprint. Default true."`
+	LuaApiStackTrace   bool              `yaml:"lua_api_stacktrace" json:"lua_api_stacktrace" usage:"Add the Lua stacktrace in the API response"`
 	JsEntrypoint       string            `yaml:"js_entrypoint" json:"js_entrypoint" usage:"Specifies the location of the bundled JavaScript runtime source code."`
 }
 
@@ -825,6 +826,7 @@ func NewRuntimeConfig() *RuntimeConfig {
 		EventQueueWorkers:  8,
 		ReadOnlyGlobals:    true,
 		LuaReadOnlyGlobals: true,
+		LuaApiStackTrace:   true,
 	}
 }
 

--- a/server/runtime_lua.go
+++ b/server/runtime_lua.go
@@ -1232,7 +1232,7 @@ func (rp *RuntimeProviderLua) Rpc(ctx context.Context, id string, queryParams ma
 			code = 13
 		}
 
-		if apiErr, ok := fnErr.(*lua.ApiError); ok && !rp.logger.Core().Enabled(zapcore.InfoLevel) {
+		if apiErr, ok := fnErr.(*lua.ApiError); ok && !rp.config.GetRuntime().LuaApiStackTrace {
 			msg := apiErr.Object.String()
 			if strings.HasPrefix(msg, lf.Proto.SourceName) {
 				msg = msg[len(lf.Proto.SourceName):]


### PR DESCRIPTION
Add a parameter to the config to choose whether or not to add the Lua stacktrace in the API response, instead of checking the log level. For example we want to use the DEBUG log level but we don't want to leak the stacktrace to someone trying to do bad things.