### PR TITLE
basic GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# https://github.com/marketplace/actions/setup-go-environment#usage
+name: CI
+
+on:
+  push:
+    branches:
+    - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ '1.17', '1.16' ]
+    name: Go ${{ matrix.go }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Build
+        run: go build
+      - name: Test
+        run: go test

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![GitHub release](https://img.shields.io/github/release/heroiclabs/nakama.svg)](https://heroiclabs.com/docs/nakama-download/)
 [![Forum](https://img.shields.io/badge/forum-online-success.svg)](https://forum.heroiclabs.com)
 [![License](https://img.shields.io/github/license/heroiclabs/nakama.svg)](https://github.com/heroiclabs/nakama/blob/master/LICENSE)
+[![Build status](https://github.com/heroiclabs/nakama/actions/workflows/ci.yml/badge.svg)](https://github.com/heroiclabs/nakama/actions/workflows/ci.yml)
 
 > Distributed server for social and realtime games and apps.
 


### PR DESCRIPTION
Appears to succeed: https://github.com/peterbecich/nakama/actions/runs/1179907797

Should these https://github.com/heroiclabs/nakama/blob/a84aa39232703d34c3cc3dc6110c053457270378/.github/workflows/ci.yml#L23-L26
be `go build -trimpath -mod=vendor` and `go test -trimpath -mod=vendor` ?