### PR TITLE
Add node status icons to the console dashboard

### DIFF
--- a/console/ui/src/app/status/status.component.html
+++ b/console/ui/src/app/status/status.component.html
@@ -17,7 +17,15 @@
   </thead>
   <tbody *ngIf="statusData">
     <tr class="clickable" *ngFor="let nodeData of statusData.nodes">
-      <td>{{nodeData.name}}</td>
+      <td>
+        <ng-container [ngSwitch]="nodeData.health">
+          <img *ngSwitchCase="0" class="mr-2" src="/static/svg/green-tick.svg" alt="" width="15" height="" ngbTooltip="Ok">
+          <img *ngSwitchCase="1" class="mr-2" src="/static/svg/red-triangle.svg" alt="" width="15" height="" ngbTooltip="Error">
+          <img *ngSwitchCase="2" class="mr-2" src="/static/blue-spinner.svg" alt="" width="15" height="" ngbTooltip="Connecting">
+          <img *ngSwitchCase="3" class="mr-2" src="/static/red-spinner.svg" alt="" width="15" height="" ngbTooltip="Disconnecting">
+        </ng-container>
+        <span>{{nodeData.name}}</span>
+      </td>
       <td>{{nodeData.session_count}} <span [hidden]="!showDelta" class="text-muted small">({{getMaxSessionCount() - nodeData.session_count}} delta)</span></td>
       <td>{{nodeData.presence_count}} <span [hidden]="!showDelta" class="text-muted small">({{getMaxPresenceCount() - nodeData.presence_count}} delta)</span></td>
       <td>{{nodeData.match_count}} <span [hidden]="!showDelta" class="text-muted small">({{getMaxMatchCount() - nodeData.match_count}} delta)</span></td>

--- a/console/ui/src/static/blue-spinner.svg
+++ b/console/ui/src/static/blue-spinner.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0" width="128px" height="128px" viewBox="0 0 128 128" xml:space="preserve">
+  <g>
+    <path d="M75.4 126.63a11.43 11.43 0 0 1-2.1-22.65 40.9 40.9 0 0 0 30.5-30.6 11.4 11.4 0 1 1 22.27 4.87h.02a63.77 63.77 0 0 1-47.8 48.05v-.02a11.38 11.38 0 0 1-2.93.37z" fill="#31CAFF" fill-opacity="1" />
+    <animateTransform attributeName="transform" type="rotate" from="0 64 64" to="360 64 64" dur="1000ms" repeatCount="indefinite"></animateTransform>
+  </g>
+</svg>

--- a/console/ui/src/static/red-spinner.svg
+++ b/console/ui/src/static/red-spinner.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0" width="128px" height="128px" viewBox="0 0 128 128" xml:space="preserve">
+  <g>
+    <path d="M75.4 126.63a11.43 11.43 0 0 1-2.1-22.65 40.9 40.9 0 0 0 30.5-30.6 11.4 11.4 0 1 1 22.27 4.87h.02a63.77 63.77 0 0 1-47.8 48.05v-.02a11.38 11.38 0 0 1-2.93.37z" fill="#FE756A" fill-opacity="1" />
+    <animateTransform attributeName="transform" type="rotate" from="0 64 64" to="360 64 64" dur="1000ms" repeatCount="indefinite"></animateTransform>
+  </g>
+</svg>


### PR DESCRIPTION
This PR adds the node status as a icon with a tooltip describing the status (the 1/4 filled circle is actually a loop animation)

![Screenshot 2021-10-11 at 17 00 21](https://user-images.githubusercontent.com/6062267/136820814-f0d2b8d7-bfd8-4e0e-a97e-afd0678db338.png)
![Screenshot 2021-10-11 at 17 00 07](https://user-images.githubusercontent.com/6062267/136820818-66d2fa62-c48c-4084-adba-43f3f627d70d.png)
![Screenshot 2021-10-11 at 16 59 51](https://user-images.githubusercontent.com/6062267/136820819-7c131cc9-7823-4a2f-b125-7ecc4d40959a.png)
![Screenshot 2021-10-11 at 16 59 33](https://user-images.githubusercontent.com/6062267/136820821-241d8fde-bd6a-4910-a996-16bbe591b1e5.png)

with tooltip
![Screenshot 2021-10-11 at 17 02 28](https://user-images.githubusercontent.com/6062267/136821033-4780e0d7-c07e-4c0c-a531-a3a3db875186.png)

