### PR TITLE
fix list matches behavior with no querystring

### DIFF
--- a/server/match_registry.go
+++ b/server/match_registry.go
@@ -441,7 +441,7 @@ func (r *LocalMatchRegistry) ListMatches(ctx context.Context, limit int, authori
 		}
 
 		// Apply the label filter to the set of known match labels.
-		indexQuery := bluge.NewMatchQuery(label.Value)
+		indexQuery := bluge.NewTermQuery(label.Value)
 		indexQuery.SetField("label_string")
 		searchReq := bluge.NewTopNSearch(count, indexQuery)
 		searchReq.SortBy([]string{"-create_time"})

--- a/server/match_registry_test.go
+++ b/server/match_registry_test.go
@@ -83,7 +83,9 @@ func TestMatchRegistryAuthoritativeMatchAndListMatches(t *testing.T) {
 	defer matchRegistry.Stop(0)
 
 	_, err = matchRegistry.CreateMatch(context.Background(), consoleLogger,
-		runtimeMatchCreateFunc, "match", map[string]interface{}{})
+		runtimeMatchCreateFunc, "match", map[string]interface{}{
+			"label": "label",
+		})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +93,42 @@ func TestMatchRegistryAuthoritativeMatchAndListMatches(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	matches, err := matchRegistry.ListMatches(context.Background(), 2, wrapperspb.Bool(true),
-		wrapperspb.String("label"), wrapperspb.Int32(0), wrapperspb.Int32(5), wrapperspb.String(""))
+		wrapperspb.String("label"), wrapperspb.Int32(0), wrapperspb.Int32(5), nil)
+	if len(matches) != 1 {
+		t.Fatalf("expected one match, got %d", len(matches))
+	}
+	matchZero := matches[0]
+	if matchZero.MatchId == "" {
+		t.Fatalf("expected non-empty  match id, was empty")
+	}
+	if !matchZero.Authoritative {
+		t.Fatalf("expected authoritative match, got non-authoritative")
+	}
+}
+
+// should create authoritative match, list matches with particular label
+// the label is chosen to be something which might tokenize into multiple
+// terms, if a tokenizer is incorrectly applied
+func TestMatchRegistryAuthoritativeMatchAndListMatchesWithTokenizableLabel(t *testing.T) {
+	consoleLogger := loggerForTest(t)
+	matchRegistry, runtimeMatchCreateFunc, err := createTestMatchRegistry(t, consoleLogger)
+	if err != nil {
+		t.Fatalf("error creating test match registry: %v", err)
+	}
+	defer matchRegistry.Stop(0)
+
+	_, err = matchRegistry.CreateMatch(context.Background(), consoleLogger,
+		runtimeMatchCreateFunc, "match", map[string]interface{}{
+			"label": "label-part2",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	matches, err := matchRegistry.ListMatches(context.Background(), 2, wrapperspb.Bool(true),
+		wrapperspb.String("label-part2"), wrapperspb.Int32(0), wrapperspb.Int32(5), nil)
 	if len(matches) != 1 {
 		t.Fatalf("expected one match, got %d", len(matches))
 	}


### PR DESCRIPTION
An issue was reported in which matching on the label string
was not returning expected matches.  This was diagnosed to relate
to the use of a MatchQuery clause.  When using TermQuery the
correct results were returned.

Further analysis revealed that the existing unit tests were not
covering this path.  The
TestMatchRegistryAuthoritativeMatchAndListMatches test was
intended to cover this path, but did not due to passing an
empty string instead of a nil query string.  This commit updates
this test to correctly exercise this code path.

Further, a new test case has been added.  This test matches
TestMatchRegistryAuthoritativeMatchAndListMatches but also uses
a label string which is able to be tokenized (if a Match query
is used and a tokenizer is incorrectly applied).  This test
case reproduces the original issue, where a label that can
be tokenized results in the MatchQuery returning incorrect
results.

The original bug has been addressed by switching to using a
TermQuery.