### PR TITLE
match listing support query boost

### DIFF
--- a/server/match_common.go
+++ b/server/match_common.go
@@ -23,6 +23,8 @@ import (
 	"github.com/blugelabs/bluge"
 	"github.com/blugelabs/bluge/analysis/analyzer"
 	"github.com/blugelabs/bluge/search"
+	"github.com/blugelabs/bluge/search/similarity"
+	segment "github.com/blugelabs/bluge_segment_api"
 	queryStr "github.com/blugelabs/query_string"
 	"go.uber.org/zap"
 )
@@ -242,4 +244,21 @@ var blugeKeywordAnalyzer = analyzer.NewKeywordAnalyzer()
 func ParseQueryString(query string) (bluge.Query, error) {
 	opt := queryStr.DefaultOptions().WithDefaultAnalyzer(blugeKeywordAnalyzer)
 	return queryStr.ParseQueryString(query, opt)
+}
+
+type constantSimilarity struct{}
+
+func (c constantSimilarity) ComputeNorm(_ int) float32 {
+	return 0
+}
+
+func (c constantSimilarity) Scorer(boost float64, _ segment.CollectionStats, _ segment.TermStats) search.Scorer {
+	return similarity.ConstantScorer(boost)
+}
+
+func BlugeInMemoryConfig() bluge.Config {
+	cfg := bluge.InMemoryOnlyConfig()
+	cfg.DefaultSimilarity = constantSimilarity{}
+	cfg.DefaultSearchAnalyzer = blugeKeywordAnalyzer
+	return cfg
 }

--- a/server/match_registry.go
+++ b/server/match_registry.go
@@ -146,7 +146,7 @@ type LocalMatchRegistry struct {
 
 func NewLocalMatchRegistry(logger, startupLogger *zap.Logger, config Config, sessionRegistry SessionRegistry, tracker Tracker, router MessageRouter, metrics Metrics, node string) MatchRegistry {
 
-	cfg := bluge.InMemoryOnlyConfig()
+	cfg := BlugeInMemoryConfig()
 	indexWriter, err := bluge.OpenWriter(cfg)
 	if err != nil {
 		startupLogger.Fatal("Failed to create match registry index", zap.Error(err))

--- a/server/match_registry.go
+++ b/server/match_registry.go
@@ -410,7 +410,7 @@ func (r *LocalMatchRegistry) ListMatches(ctx context.Context, limit int, authori
 		}
 
 		searchReq := bluge.NewTopNSearch(count, q)
-		searchReq.SortBy([]string{"-create_time"})
+		searchReq.SortBy([]string{"-_score", "-create_time"})
 
 		labelResultsItr, err := indexReader.Search(ctx, searchReq)
 		if err != nil {

--- a/server/match_registry_test.go
+++ b/server/match_registry_test.go
@@ -218,9 +218,9 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingAndBoost(t *te
 		labelMatches map[int]string
 	}{
 		{
-			// query should find all matches, with sitting count 4 in first 2 positions
-			// and sitting count 2 in next 2 positions
-			// we can only match on the sitting_count, not the entire string, because order
+			// query should find all matches, with baz 4 in first 2 positions
+			// and baz 2 in next 2 positions
+			// we can only match on the baz value, not the entire string, because order
 			// is not imposed over the option a/b
 			name:  "exact numeric boost",
 			query: "+label.foo:5 +label.bar:1 label.baz:4^10 label.baz:2^5",
@@ -234,8 +234,8 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingAndBoost(t *te
 		},
 		{
 			// this variant introduces a required text match (bm25 scoring)
-			// query should find only option a, with sitting count 4 in first position
-			// and sitting count 2 in next position
+			// query should find only option a, with baz 4 in first position
+			// and baz 2 in next position
 			name:  "exact numeric boost with required text match",
 			query: "+label.foo:5 +label.bar:1 +label.option:a label.baz:4^10 label.baz:2^5",
 			total: 5,
@@ -246,8 +246,8 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingAndBoost(t *te
 		},
 		{
 			// this variant makes the text match (bm25 scoring) optional
-			// query should find all matches, with sitting count 4 in first 2 positions
-			// and sitting count 2 in next 2 positions
+			// query should find all matches, with baz 4 in first 2 positions
+			// and baz 2 in next 2 positions
 			name:  "exact numeric boost with optional text match",
 			query: "+label.foo:5 +label.bar:1 label.option:a label.baz:4^10 label.baz:2^5",
 			total: 10,

--- a/server/match_registry_test.go
+++ b/server/match_registry_test.go
@@ -186,16 +186,16 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingAndBoost(t *te
 	defer matchRegistry.Stop(0)
 
 	matchLabels := []string{
-		`{"size": 5, "speed": 1, "option": "a", "sitting_count": 4}`,
-		`{"size": 5, "speed": 1, "option": "b", "sitting_count": 4}`,
-		`{"size": 5, "speed": 1, "option": "a", "sitting_count": 3}`,
-		`{"size": 5, "speed": 1, "option": "b", "sitting_count": 3}`,
-		`{"size": 5, "speed": 1, "option": "a", "sitting_count": 2}`,
-		`{"size": 5, "speed": 1, "option": "b", "sitting_count": 2}`,
-		`{"size": 5, "speed": 1, "option": "a", "sitting_count": 1}`,
-		`{"size": 5, "speed": 1, "option": "b", "sitting_count": 1}`,
-		`{"size": 5, "speed": 1, "option": "a", "sitting_count": 0}`,
-		`{"size": 5, "speed": 1, "option": "b", "sitting_count": 0}`,
+		`{"foo": 5, "bar": 1, "option": "a", "baz": 4}`,
+		`{"foo": 5, "bar": 1, "option": "b", "baz": 4}`,
+		`{"foo": 5, "bar": 1, "option": "a", "baz": 3}`,
+		`{"foo": 5, "bar": 1, "option": "b", "baz": 3}`,
+		`{"foo": 5, "bar": 1, "option": "a", "baz": 2}`,
+		`{"foo": 5, "bar": 1, "option": "b", "baz": 2}`,
+		`{"foo": 5, "bar": 1, "option": "a", "baz": 1}`,
+		`{"foo": 5, "bar": 1, "option": "b", "baz": 1}`,
+		`{"foo": 5, "bar": 1, "option": "a", "baz": 0}`,
+		`{"foo": 5, "bar": 1, "option": "b", "baz": 0}`,
 	}
 
 	// create all matches
@@ -223,13 +223,13 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingAndBoost(t *te
 			// we can only match on the sitting_count, not the entire string, because order
 			// is not imposed over the option a/b
 			name:  "exact numeric boost",
-			query: "+label.size:5 +label.speed:1 label.sitting_count:4^10 label.sitting_count:2^5",
+			query: "+label.foo:5 +label.bar:1 label.baz:4^10 label.baz:2^5",
 			total: 10,
 			labelMatches: map[int]string{
-				0: `"sitting_count": 4`,
-				1: `"sitting_count": 4`,
-				2: `"sitting_count": 2`,
-				3: `"sitting_count": 2`,
+				0: `"baz": 4`,
+				1: `"baz": 4`,
+				2: `"baz": 2`,
+				3: `"baz": 2`,
 			},
 		},
 		{
@@ -237,7 +237,7 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingAndBoost(t *te
 			// query should find only option a, with sitting count 4 in first position
 			// and sitting count 2 in next position
 			name:  "exact numeric boost with required text match",
-			query: "+label.size:5 +label.speed:1 +label.option:a label.sitting_count:4^10 label.sitting_count:2^5",
+			query: "+label.foo:5 +label.bar:1 +label.option:a label.baz:4^10 label.baz:2^5",
 			total: 5,
 			labelMatches: map[int]string{
 				0: matchLabels[0],
@@ -249,7 +249,7 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingAndBoost(t *te
 			// query should find all matches, with sitting count 4 in first 2 positions
 			// and sitting count 2 in next 2 positions
 			name:  "exact numeric boost with optional text match",
-			query: "+label.size:5 +label.speed:1 label.option:a label.sitting_count:4^10 label.sitting_count:2^5",
+			query: "+label.foo:5 +label.bar:1 label.option:a label.baz:4^10 label.baz:2^5",
 			total: 10,
 			labelMatches: map[int]string{
 				0: matchLabels[0],

--- a/server/matchmaker_test.go
+++ b/server/matchmaker_test.go
@@ -849,14 +849,14 @@ func TestMatchmakerAddMultipleAndSomeMatchWithBoost(t *testing.T) {
 			SessionID: sessionID,
 		},
 	}, sessionID.String(), "",
-		"properties.level:<10^10 properties.a6:bar +properties.id:"+testID.String(),
+		"properties.n1:<10^10 properties.a6:bar +properties.id:"+testID.String(),
 		2, 2,
 		map[string]string{
 			"id": testID.String(),
 			"a6": "bar",
 		},
 		map[string]float64{
-			"level": 5,
+			"n1": 5,
 		})
 	if err != nil {
 		t.Fatalf("error matchmaker add: %v", err)
@@ -875,14 +875,14 @@ func TestMatchmakerAddMultipleAndSomeMatchWithBoost(t *testing.T) {
 			SessionID: sessionID2,
 		},
 	}, sessionID2.String(), "",
-		"properties.level:>10^10 properties.a6:bar +properties.id:"+testID.String(),
+		"properties.n1:>10^10 properties.a6:bar +properties.id:"+testID.String(),
 		2, 2,
 		map[string]string{
 			"id": testID.String(),
 			"a6": "bar",
 		},
 		map[string]float64{
-			"level": 15,
+			"n1": 15,
 		})
 	if err != nil {
 		t.Fatalf("error matchmaker add: %v", err)
@@ -901,14 +901,14 @@ func TestMatchmakerAddMultipleAndSomeMatchWithBoost(t *testing.T) {
 			SessionID: sessionID3,
 		},
 	}, sessionID3.String(), "",
-		"properties.level:<10^10 properties.a6:bar +properties.id:"+testID.String(),
+		"properties.n1:<10^10 properties.a6:bar +properties.id:"+testID.String(),
 		2, 2,
 		map[string]string{
 			"id": testID.String(),
 			"a6": "bar",
 		},
 		map[string]float64{
-			"level": 5,
+			"n1": 5,
 		})
 	if err != nil {
 		t.Fatalf("error matchmaker add: %v", err)

--- a/server/matchmaker_test.go
+++ b/server/matchmaker_test.go
@@ -575,7 +575,6 @@ func TestMatchmakerAddButNotMatchOnRange(t *testing.T) {
 			if len(presences) == 1 {
 				matchesSeen[presences[0].SessionID.String()] = envelope.GetMatchmakerMatched()
 			}
-			t.Logf("see match: %#v, ticket %s", presences, envelope.GetMatchmakerMatched().Ticket)
 		})
 	if err != nil {
 		t.Fatalf("error creating test matchmaker: %v", err)
@@ -811,9 +810,238 @@ func TestMatchmakerAddMultipleAndSomeMatch(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
+	// assert that 2 are notified of a match
 	if len(matchesSeen) != 2 {
 		t.Fatalf("expected 2 matches, got %d", len(matchesSeen))
 	}
+	// assert that session1 is one of the ones notified
+	if _, ok := matchesSeen[sessionID.String()]; !ok {
+		t.Errorf("expected session1 to match, it didn't %#v", matchesSeen)
+	}
+	// cannot assert session2 or session3, one of them will match, but it
+	// cannot be assured which one
+}
+
+// should add multiple to matchmaker and some match
+func TestMatchmakerAddMultipleAndSomeMatchWithBoost(t *testing.T) {
+	consoleLogger := loggerForTest(t)
+	matchesSeen := make(map[string]*rtapi.MatchmakerMatched)
+	matchMaker, cleanup, err := createTestMatchmaker(t, consoleLogger,
+		func(presences []*PresenceID, envelope *rtapi.Envelope) {
+			if len(presences) == 1 {
+				matchesSeen[presences[0].SessionID.String()] = envelope.GetMatchmakerMatched()
+			}
+		})
+	if err != nil {
+		t.Fatalf("error creating test matchmaker: %v", err)
+	}
+	defer cleanup()
+
+	testID, _ := uuid.NewV4()
+
+	sessionID, _ := uuid.NewV4()
+	ticket1, err := matchMaker.Add([]*MatchmakerPresence{
+		&MatchmakerPresence{
+			UserId:    "a",
+			SessionId: "a",
+			Username:  "a",
+			Node:      "a",
+			SessionID: sessionID,
+		},
+	}, sessionID.String(), "",
+		"properties.level:<10^10 properties.a6:bar +properties.id:"+testID.String(),
+		2, 2,
+		map[string]string{
+			"id": testID.String(),
+			"a6": "bar",
+		},
+		map[string]float64{
+			"level": 5,
+		})
+	if err != nil {
+		t.Fatalf("error matchmaker add: %v", err)
+	}
+	if ticket1 == "" {
+		t.Fatal("expected non-empty ticket1")
+	}
+
+	sessionID2, _ := uuid.NewV4()
+	ticket2, err := matchMaker.Add([]*MatchmakerPresence{
+		&MatchmakerPresence{
+			UserId:    "b",
+			SessionId: "b",
+			Username:  "b",
+			Node:      "b",
+			SessionID: sessionID2,
+		},
+	}, sessionID2.String(), "",
+		"properties.level:>10^10 properties.a6:bar +properties.id:"+testID.String(),
+		2, 2,
+		map[string]string{
+			"id": testID.String(),
+			"a6": "bar",
+		},
+		map[string]float64{
+			"level": 15,
+		})
+	if err != nil {
+		t.Fatalf("error matchmaker add: %v", err)
+	}
+	if ticket2 == "" {
+		t.Fatal("expected non-empty ticket2")
+	}
+
+	sessionID3, _ := uuid.NewV4()
+	ticket3, err := matchMaker.Add([]*MatchmakerPresence{
+		&MatchmakerPresence{
+			UserId:    "c",
+			SessionId: "c",
+			Username:  "c",
+			Node:      "c",
+			SessionID: sessionID3,
+		},
+	}, sessionID3.String(), "",
+		"properties.level:<10^10 properties.a6:bar +properties.id:"+testID.String(),
+		2, 2,
+		map[string]string{
+			"id": testID.String(),
+			"a6": "bar",
+		},
+		map[string]float64{
+			"level": 5,
+		})
+	if err != nil {
+		t.Fatalf("error matchmaker add: %v", err)
+	}
+	if ticket3 == "" {
+		t.Fatal("expected non-empty ticket3")
+	}
+
+	time.Sleep(5 * time.Second)
+
+	if len(matchesSeen) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matchesSeen))
+	}
+
+	// sessions 1 and 3 prefer to match each other
+	// but if we try to match session2 first, it will choose session1
+	// due to the creation time
+
+	// if session3 matched, session 1 should also
+	if _, ok := matchesSeen[sessionID3.String()]; ok {
+		if _, ok := matchesSeen[sessionID.String()]; !ok {
+			t.Fatalf("session1 matched, but not session 3")
+		}
+	}
+	// if session2 matched, session 1 should also
+	if _, ok := matchesSeen[sessionID2.String()]; ok {
+		if _, ok := matchesSeen[sessionID.String()]; !ok {
+			t.Fatalf("session2 matched, but not session 1")
+		}
+	}
+}
+
+// should add multiple to matchmaker and some match
+func TestMatchmakerAddMultipleAndSomeMatchOptionalTextAlteringScore(t *testing.T) {
+	consoleLogger := loggerForTest(t)
+	matchesSeen := make(map[string]*rtapi.MatchmakerMatched)
+	matchMaker, cleanup, err := createTestMatchmaker(t, consoleLogger,
+		func(presences []*PresenceID, envelope *rtapi.Envelope) {
+			if len(presences) == 1 {
+				matchesSeen[presences[0].SessionID.String()] = envelope.GetMatchmakerMatched()
+			}
+		})
+	if err != nil {
+		t.Fatalf("error creating test matchmaker: %v", err)
+	}
+	defer cleanup()
+
+	testID, _ := uuid.NewV4()
+
+	sessionID, _ := uuid.NewV4()
+	ticket1, err := matchMaker.Add([]*MatchmakerPresence{
+		&MatchmakerPresence{
+			UserId:    "a",
+			SessionId: "a",
+			Username:  "a",
+			Node:      "a",
+			SessionID: sessionID,
+		},
+	}, sessionID.String(), "",
+		"properties.a6:bar properties.a6:foo +properties.id:"+testID.String(),
+		2, 2,
+		map[string]string{
+			"id": testID.String(),
+			"a6": "bar",
+		},
+		map[string]float64{})
+	if err != nil {
+		t.Fatalf("error matchmaker add: %v", err)
+	}
+	if ticket1 == "" {
+		t.Fatal("expected non-empty ticket1")
+	}
+
+	sessionID2, _ := uuid.NewV4()
+	ticket2, err := matchMaker.Add([]*MatchmakerPresence{
+		&MatchmakerPresence{
+			UserId:    "b",
+			SessionId: "b",
+			Username:  "b",
+			Node:      "b",
+			SessionID: sessionID2,
+		},
+	}, sessionID2.String(), "",
+		"properties.a6:bar properties.a6:foo +properties.id:"+testID.String(),
+		2, 2,
+		map[string]string{
+			"id": testID.String(),
+			"a6": "foo",
+		},
+		map[string]float64{})
+	if err != nil {
+		t.Fatalf("error matchmaker add: %v", err)
+	}
+	if ticket2 == "" {
+		t.Fatal("expected non-empty ticket2")
+	}
+
+	sessionID3, _ := uuid.NewV4()
+	ticket3, err := matchMaker.Add([]*MatchmakerPresence{
+		&MatchmakerPresence{
+			UserId:    "c",
+			SessionId: "c",
+			Username:  "c",
+			Node:      "c",
+			SessionID: sessionID3,
+		},
+	}, sessionID3.String(), "",
+		"properties.a6:bar properties.a6:foo +properties.id:"+testID.String(),
+		2, 2,
+		map[string]string{
+			"id": testID.String(),
+			"a6": "bar",
+		},
+		map[string]float64{})
+	if err != nil {
+		t.Fatalf("error matchmaker add: %v", err)
+	}
+	if ticket3 == "" {
+		t.Fatal("expected non-empty ticket3")
+	}
+
+	time.Sleep(5 * time.Second)
+
+	// assert that 2 are notified of a match
+	if len(matchesSeen) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matchesSeen))
+	}
+	// assert that session1 is one of the ones notified
+	if _, ok := matchesSeen[sessionID.String()]; !ok {
+		t.Errorf("expected session1 to match, it didn't %#v", matchesSeen)
+	}
+	// cannot assert session2 or session3, one of them will match, but it
+	// cannot be assured which one
 }
 
 // should add to matchmaker and match authoritative


### PR DESCRIPTION
Match listing results are now ordered by -_score first, followed
by -create_time.  This allows careful use of query boosting in
the query string to influence the order of the matches.