### PR TITLE
fix behavior with query string *

### DIFF
--- a/server/match_common.go
+++ b/server/match_common.go
@@ -242,6 +242,10 @@ type ValidatableQuery interface {
 var BlugeKeywordAnalyzer = analyzer.NewKeywordAnalyzer()
 
 func ParseQueryString(query string) (bluge.Query, error) {
+	// Ensure that * matches all documents
+	if query == "*" {
+		return bluge.NewMatchAllQuery(), nil
+	}
 	opt := queryStr.DefaultOptions().WithDefaultAnalyzer(BlugeKeywordAnalyzer)
 	return queryStr.ParseQueryString(query, opt)
 }

--- a/server/match_registry_test.go
+++ b/server/match_registry_test.go
@@ -175,6 +175,40 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQuerying(t *testing.T)
 	}
 }
 
+// should create authoritative match, list matches with querying
+func TestMatchRegistryAuthoritativeMatchAndListAllMatchesWithQueryStar(t *testing.T) {
+	consoleLogger := loggerForTest(t)
+	matchRegistry, runtimeMatchCreateFunc, err := createTestMatchRegistry(t, consoleLogger)
+	if err != nil {
+		t.Fatalf("error creating test match registry: %v", err)
+	}
+	defer matchRegistry.Stop(0)
+
+	_, err = matchRegistry.CreateMatch(context.Background(), consoleLogger,
+		runtimeMatchCreateFunc, "match", map[string]interface{}{
+			"label": `{"skill":60}`,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	matches, err := matchRegistry.ListMatches(context.Background(), 2, wrapperspb.Bool(true),
+		wrapperspb.String("label"), wrapperspb.Int32(0), wrapperspb.Int32(5),
+		wrapperspb.String("*"))
+	if len(matches) != 1 {
+		t.Fatalf("expected one match, got %d", len(matches))
+	}
+	matchZero := matches[0]
+	if matchZero.MatchId == "" {
+		t.Fatalf("expected non-empty  match id, was empty")
+	}
+	if !matchZero.Authoritative {
+		t.Fatalf("expected authoritative match, got non-authoritative")
+	}
+}
+
 // should create authoritative match, list matches with querying arrays
 func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQueryingArrays(t *testing.T) {
 	consoleLogger := loggerForTest(t)

--- a/server/match_registry_test.go
+++ b/server/match_registry_test.go
@@ -175,7 +175,7 @@ func TestMatchRegistryAuthoritativeMatchAndListMatchesWithQuerying(t *testing.T)
 	}
 }
 
-// should create authoritative match, list matches with querying
+// should create authoritative match, list matches with query *
 func TestMatchRegistryAuthoritativeMatchAndListAllMatchesWithQueryStar(t *testing.T) {
 	consoleLogger := loggerForTest(t)
 	matchRegistry, runtimeMatchCreateFunc, err := createTestMatchRegistry(t, consoleLogger)


### PR DESCRIPTION
A query string of * should return all matches, however this
behavior was lost during the Bleve->Bluge conversion.  Additional
unit tests have been added to ensure correct behavior going
forward.