### PR TITLE
fix Matchmaker enforcement of max tickets

### DIFF
--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -408,7 +408,7 @@ func (m *LocalMatchmaker) process(batch *index.Batch) {
 						if l := len(sessionTickets); l <= 1 {
 							delete(m.sessionTickets, entry.Presence.SessionId)
 						} else {
-							delete(sessionTickets, ticket)
+							delete(sessionTickets, entry.Ticket)
 						}
 					}
 					if entry.PartyId != "" {
@@ -416,7 +416,7 @@ func (m *LocalMatchmaker) process(batch *index.Batch) {
 							if l := len(partyTickets); l <= 1 {
 								delete(m.partyTickets, entry.PartyId)
 							} else {
-								delete(partyTickets, ticket)
+								delete(partyTickets, entry.Ticket)
 							}
 						}
 					}


### PR DESCRIPTION
The Matchmaker tracks tickets by session and party for the
purposes of enforcing a MaxTickets configuration setting.  It
has been observed that in some cases, we attempt to remove
incorrect entries, which results in the correct entries leaking
inside the tracking maps.  In addition to leaking resources,
this could cause incorrect behavior for the affected session
and party identifiers.

Two unit tests have been added to illustrate the problem and
validate the fix.  These tests fail without the fix on a
random basis, and it is recommended to run them with
-count=100 to ensure the problematic scenario is encountered.