### PR TITLE
Fix missing reference in match registry.

### DIFF
--- a/server/match_registry.go
+++ b/server/match_registry.go
@@ -41,7 +41,7 @@ func init() {
 	gob.Register(map[string]interface{}(nil))
 	gob.Register([]interface{}(nil))
 	gob.Register([]runtime.MatchmakerEntry(nil))
-	gob.Register(MatchmakerEntry{})
+	gob.Register(&MatchmakerEntry{})
 	gob.Register([]*api.User(nil))
 	gob.Register([]*api.Account(nil))
 	gob.Register([]*api.Friend(nil))

--- a/server/match_registry_test.go
+++ b/server/match_registry_test.go
@@ -40,6 +40,24 @@ func TestEncode(t *testing.T) {
 	t.Log("ok")
 }
 
+func TestEncodeDecode(t *testing.T) {
+	entries := []runtime.MatchmakerEntry{
+		&MatchmakerEntry{Ticket: "123", Presence: &MatchmakerPresence{Username: "a"}},
+		&MatchmakerEntry{Ticket: "456", Presence: &MatchmakerPresence{Username: "b"}},
+	}
+	params := map[string]interface{}{
+		"invited": entries,
+	}
+	buf := &bytes.Buffer{}
+	if err := gob.NewEncoder(buf).Encode(params); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if err := gob.NewDecoder(buf).Decode(&params); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	t.Log("ok")
+}
+
 // should create authoritative match, and join with metadata
 func TestMatchRegistryAuthoritativeMatchAndJoin(t *testing.T) {
 	consoleLogger := loggerForTest(t)


### PR DESCRIPTION
There is a bug present in the current version of `match_registry.go` preventing the creation of authoritative matches in certain cases. If the `params` contain the `server.MatchmakerEntry` implementation of the `runtime.MatchmakerEntry` interface the decoding in `CreateMatch` fails because the wrong type is registered (`server.MatchmakerEntry` instead of `*server.MatchmakerEntry`, see [this](https://stackoverflow.com/a/54767962) Stackoverflow answer for more details.)

This PR entails extended testing to show the bug as well as a fix in two different commits for easy reproduction.