### PR TITLE
Rename stackdriver field 'timestamp' to 'time'

### DIFF
--- a/server/logger.go
+++ b/server/logger.go
@@ -151,7 +151,7 @@ func NewJSONLogger(output *os.File, level zapcore.Level, format LoggingFormat) *
 func newJSONEncoder(format LoggingFormat) zapcore.Encoder {
 	if format == StackdriverFormat {
 		return zapcore.NewJSONEncoder(zapcore.EncoderConfig{
-			TimeKey:        "timestamp",
+			TimeKey:        "time",
 			LevelKey:       "severity",
 			NameKey:        "logger",
 			CallerKey:      "caller",


### PR DESCRIPTION
The objective was to make GCP understand the strutured data that was encoded as a string in the msg payload and this was accomplished by the following commit(28bd9a1f28bbe76a576a2caaffd04a4505f75534) that renamed the field msg to message.

However, that commit changed also the time field to timestamp and the format to have nano precision but the renaming made the logs include two timestamps values, fluent-d and Nakama. This behavious is undesired and it happens because fluent-d searchs for a time field which wasn't there anymore.

This commit solves that problem by renaming it back to 'time'. Changing the configuration of fluent-d isn't possible and we should note that is prone to be changed by Google in future.