### PR TITLE
Expose leaderboardRecordsAroundOwner to JS runtime

### DIFF
--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -216,6 +216,7 @@ func (n *runtimeJavascriptNakamaModule) mappings(r *goja.Runtime) map[string]fun
 		"leaderboardRecordWrite":          n.leaderboardRecordWrite(r),
 		"leaderboardRecordDelete":         n.leaderboardRecordDelete(r),
 		"leaderboardsGetId":               n.leaderboardsGetId(r),
+		"leaderboardRecordsAroundOwner":   n.leaderboardRecordsAroundOwner(r),
 		"purchaseValidateApple":           n.purchaseValidateApple(r),
 		"purchaseValidateGoogle":          n.purchaseValidateGoogle(r),
 		"purchaseValidateHuawei":          n.purchaseValidateHuawei(r),
@@ -5016,6 +5017,58 @@ func (n *runtimeJavascriptNakamaModule) leaderboardsGetId(r *goja.Runtime) func(
 		}
 
 		return r.ToValue(leaderboardsSlice)
+	}
+}
+
+// @group Leaderboards
+// @summary Fetch the list of leaderboard records around the owner.
+// @param id(type=string) The unique identifier for the leaderboard.
+// @param owner(type=string) The owner of the score to list records around. Mandatory field.
+// @param limit(type=number) Return only the required number of leaderboard records denoted by this limit value.
+// @param overrideExpiry(type=number) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
+// @return records(nkruntime.LeaderboardRecordList) The leaderboard records according to ID.
+// @return error(error) An optional error value if an error occurred.
+func (n *runtimeJavascriptNakamaModule) leaderboardRecordsAroundOwner(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(f goja.FunctionCall) goja.Value {
+		id := getJsString(r, f.Argument(0))
+		if id == "" {
+			panic(r.NewTypeError("expects a leaderboard ID string"))
+		}
+
+		ownerID := getJsString(r, f.Argument(1))
+		uid, err := uuid.FromString(ownerID)
+		if err != nil {
+			panic(r.NewTypeError("expects user ID to be a valid identifier"))
+		}
+
+		limit := 10
+		if f.Argument(2) != goja.Undefined() && f.Argument(2) != goja.Null() {
+			limit = int(getJsInt(r, f.Argument(2)))
+			if limit < 1 || limit > 100 {
+				panic(r.NewTypeError("limit must be 1-100"))
+			}
+		}
+
+		overrideExpiry := int64(0)
+		if f.Argument(4) != goja.Undefined() {
+			overrideExpiry = getJsInt(r, f.Argument(4))
+		}
+
+		records, err := LeaderboardRecordsHaystack(context.Background(), n.logger, n.db, n.leaderboardCache, n.rankCache, id, uid, limit, overrideExpiry)
+		if err != nil {
+			panic(r.NewGoError(fmt.Errorf("error listing leaderboard records around owner: %v", err.Error())))
+		}
+
+		recordsSlice := make([]interface{}, 0, len(records))
+		for _, record := range records {
+			recordsSlice = append(recordsSlice, leaderboardRecordToJsMap(r, record))
+		}
+
+		resultMap := make(map[string]interface{}, 1)
+
+		resultMap["records"] = recordsSlice
+
+		return r.ToValue(resultMap)
 	}
 }
 

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -216,7 +216,7 @@ func (n *runtimeJavascriptNakamaModule) mappings(r *goja.Runtime) map[string]fun
 		"leaderboardRecordWrite":          n.leaderboardRecordWrite(r),
 		"leaderboardRecordDelete":         n.leaderboardRecordDelete(r),
 		"leaderboardsGetId":               n.leaderboardsGetId(r),
-		"leaderboardRecordsAroundOwner":   n.leaderboardRecordsAroundOwner(r),
+		"leaderboardRecordsHaystack":      n.leaderboardRecordsHaystack(r),
 		"purchaseValidateApple":           n.purchaseValidateApple(r),
 		"purchaseValidateGoogle":          n.purchaseValidateGoogle(r),
 		"purchaseValidateHuawei":          n.purchaseValidateHuawei(r),
@@ -5028,7 +5028,7 @@ func (n *runtimeJavascriptNakamaModule) leaderboardsGetId(r *goja.Runtime) func(
 // @param overrideExpiry(type=number) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
 // @return records(nkruntime.LeaderboardRecordList) The leaderboard records according to ID.
 // @return error(error) An optional error value if an error occurred.
-func (n *runtimeJavascriptNakamaModule) leaderboardRecordsAroundOwner(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
+func (n *runtimeJavascriptNakamaModule) leaderboardRecordsHaystack(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		id := getJsString(r, f.Argument(0))
 		if id == "" {
@@ -5050,8 +5050,8 @@ func (n *runtimeJavascriptNakamaModule) leaderboardRecordsAroundOwner(r *goja.Ru
 		}
 
 		overrideExpiry := int64(0)
-		if f.Argument(4) != goja.Undefined() {
-			overrideExpiry = getJsInt(r, f.Argument(4))
+		if f.Argument(3) != goja.Undefined() {
+			overrideExpiry = getJsInt(r, f.Argument(3))
 		}
 
 		records, err := LeaderboardRecordsHaystack(context.Background(), n.logger, n.db, n.leaderboardCache, n.rankCache, id, uid, limit, overrideExpiry)


### PR DESCRIPTION
https://github.com/heroiclabs/nakama/issues/755

https://heroiclabs.com/docs/nakama/concepts/leaderboards/#list-leaderboard-records-around-owner

Fetches a list of leaderboard records around a owner. Please let me know if I should make any corrections.
The resulting LeaderboardRecordList[] reflects the same object returned by the Client API.

I will also create a PR for the nakama-common package to update the typing file.