### PR TITLE
add rest interface with default raw json content type

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -206,6 +206,7 @@ func StartApiServer(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, p
 	// Another nested router to hijack RPC requests bound for GRPC Gateway.
 	grpcGatewayMux := mux.NewRouter()
 	grpcGatewayMux.HandleFunc("/v2/rpc/{id:.*}", s.RpcFuncHttp).Methods("GET", "POST")
+	grpcGatewayMux.HandleFunc("/v2/rest/{id:.*}", s.RestFuncHttp).Methods("GET", "POST")
 	grpcGatewayMux.NewRoute().Handler(grpcGateway)
 
 	// Enable stats recording on all request paths except:


### PR DESCRIPTION
This adds a by default unwrapped `/v2/rest` route, which routes to the same RPC endpoints.  This was needed by us for some integrations (Xsolla purchsing for one) that need to connect to endpoints with unwrapped application/json content-type requests, but are unable to add the `unwrap=X` URI parameter.   