### PR TITLE
Making all console authentication end-user error messages identical 

### DIFF
--- a/server/console_authenticate.go
+++ b/server/console_authenticate.go
@@ -86,7 +86,7 @@ func (s *ConsoleServer) Authenticate(ctx context.Context, in *console.Authentica
 	}
 
 	if role == console.UserRole_USER_ROLE_UNKNOWN {
-		return nil, status.Error(codes.Unauthenticated, "Invalid Nakama Console credentials.")
+		return nil, status.Error(codes.Unauthenticated, "Invalid credentials.")
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &ConsoleTokenClaims{
@@ -117,7 +117,7 @@ func (s *ConsoleServer) lookupConsoleUser(ctx context.Context, unameOrEmail, pas
 	// Check if it's disabled.
 	if dbDisableTime.Status == pgtype.Present && dbDisableTime.Time.Unix() != 0 {
 		s.logger.Info("Console user account is disabled.", zap.String("username", unameOrEmail))
-		err = status.Error(codes.PermissionDenied, "Console user account banned.")
+		err = status.Error(codes.PermissionDenied, "Invalid credentials.")
 		return
 	}
 


### PR DESCRIPTION
- to prevent the possibility of enumerating registered usernames