### PR TITLE
Outgoing and incoming payloads in realtime after hooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - JavaScript global variables are made immutable after the `InitModule` function is invoked.
 - JavaScript global variables are made immutable by default after the `InitModule` function is invoked.
 - Return system user uuid string in `StorageWrite` acks for all runtimes.
+- Realtime after hooks now include both the outgoing and incoming payload.
+- Realtime after hooks do not run when the operation fails.
 
 ### Fixed
 - Fix the registered function name for 'nk.channelIdBuild' in the JavaScript runtime.

--- a/server/pipeline_match.go
+++ b/server/pipeline_match.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -34,7 +34,7 @@ type matchDataFilter struct {
 	sessionID uuid.UUID
 }
 
-func (p *Pipeline) matchCreate(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) matchCreate(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	name := envelope.GetMatchCreate().Name
 	var matchID uuid.UUID
 	if name != "" {
@@ -53,7 +53,7 @@ func (p *Pipeline) matchCreate(logger *zap.Logger, session Session, envelope *rt
 	success, isNew := p.tracker.Track(session.Context(), sessionID, stream, userID, PresenceMeta{Username: username, Format: session.Format()}, false)
 	if !success {
 		// Presence creation was rejected due to `allowIfFirstForSession` flag, session is gone so no need to reply.
-		return
+		return false, nil
 	}
 
 	var size int32 = 1
@@ -75,7 +75,7 @@ func (p *Pipeline) matchCreate(logger *zap.Logger, session Session, envelope *rt
 		}
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Match{Match: &rtapi.Match{
+	out := &rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Match{Match: &rtapi.Match{
 		MatchId:       fmt.Sprintf("%v.", matchID.String()),
 		Authoritative: false,
 		// No label.
@@ -86,10 +86,13 @@ func (p *Pipeline) matchCreate(logger *zap.Logger, session Session, envelope *rt
 			SessionId: sessionID.String(),
 			Username:  username,
 		},
-	}}}, true)
+	}}}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetMatchJoin()
 	var err error
 	var matchID uuid.UUID
@@ -107,7 +110,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_BAD_INPUT),
 				Message: "Invalid match ID",
 			}}}, true)
-			return
+			return false, nil
 		}
 		matchID, err = uuid.FromString(matchIDComponents[0])
 		if err != nil {
@@ -115,7 +118,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_BAD_INPUT),
 				Message: "Invalid match ID",
 			}}}, true)
-			return
+			return false, nil
 		}
 		node = matchIDComponents[1]
 	case *rtapi.MatchJoin_Token:
@@ -130,7 +133,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_BAD_INPUT),
 				Message: "Invalid match token",
 			}}}, true)
-			return
+			return false, nil
 		}
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok || !token.Valid {
@@ -138,7 +141,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_BAD_INPUT),
 				Message: "Invalid match token",
 			}}}, true)
-			return
+			return false, nil
 		}
 		matchIDString = claims["mid"].(string)
 		// Validate the match ID.
@@ -148,7 +151,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_BAD_INPUT),
 				Message: "Invalid match token",
 			}}}, true)
-			return
+			return false, nil
 		}
 		matchID, err = uuid.FromString(matchIDComponents[0])
 		if err != nil {
@@ -156,7 +159,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_BAD_INPUT),
 				Message: "Invalid match token",
 			}}}, true)
-			return
+			return false, nil
 		}
 		node = matchIDComponents[1]
 		allowEmpty = true
@@ -165,13 +168,13 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "No match ID or token found",
 		}}}, true)
-		return
+		return false, nil
 	default:
 		session.Send(&rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Error{Error: &rtapi.Error{
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Unrecognized match ID or token",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	var mode uint8
@@ -188,7 +191,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_MATCH_NOT_FOUND),
 				Message: "Match not found",
 			}}}, true)
-			return
+			return false, nil
 		}
 
 		isNew := p.tracker.GetLocalBySessionIDStreamUserID(session.ID(), stream, session.UserID()) == nil
@@ -199,7 +202,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 			}
 			if success, _ := p.tracker.Track(session.Context(), session.ID(), stream, session.UserID(), m, false); !success {
 				// Presence creation was rejected due to `allowIfFirstForSession` flag, session is gone so no need to reply.
-				return
+				return false, nil
 			}
 
 			if p.config.GetSession().SingleMatch {
@@ -234,7 +237,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_MATCH_NOT_FOUND),
 				Message: "Match not found",
 			}}}, true)
-			return
+			return false, nil
 		}
 		if !allow {
 			// Use the reject reason set by the match handler, if available.
@@ -246,7 +249,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_MATCH_JOIN_REJECTED),
 				Message: reason,
 			}}}, true)
-			return
+			return false, nil
 		}
 
 		if isNew {
@@ -279,7 +282,7 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 		}
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Match{Match: &rtapi.Match{
+	out := &rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Match{Match: &rtapi.Match{
 		MatchId:       matchIDString,
 		Authoritative: mode == StreamModeMatchAuthoritative,
 		Label:         label,
@@ -290,10 +293,13 @@ func (p *Pipeline) matchJoin(logger *zap.Logger, session Session, envelope *rtap
 			SessionId: session.ID().String(),
 			Username:  username,
 		},
-	}}}, true)
+	}}}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) matchLeave(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) matchLeave(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	// Validate the match ID.
 	matchIDComponents := strings.SplitN(envelope.GetMatchLeave().MatchId, ".", 2)
 	if len(matchIDComponents) != 2 {
@@ -301,7 +307,7 @@ func (p *Pipeline) matchLeave(logger *zap.Logger, session Session, envelope *rta
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid match ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	matchID, err := uuid.FromString(matchIDComponents[0])
 	if err != nil {
@@ -309,7 +315,7 @@ func (p *Pipeline) matchLeave(logger *zap.Logger, session Session, envelope *rta
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid match ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// Decide if it's an authoritative or relayed match.
@@ -323,10 +329,13 @@ func (p *Pipeline) matchLeave(logger *zap.Logger, session Session, envelope *rta
 
 	p.tracker.Untrack(session.ID(), stream, session.UserID())
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetMatchDataSend()
 
 	// Validate the match ID.
@@ -336,7 +345,7 @@ func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid match ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	matchID, err := uuid.FromString(matchIDComponents[0])
 	if err != nil {
@@ -344,18 +353,18 @@ func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid match ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// If it's an authoritative match pass the data to the match handler.
 	if matchIDComponents[1] != "" {
 		if p.tracker.GetLocalBySessionIDStreamUserID(session.ID(), PresenceStream{Mode: StreamModeMatchAuthoritative, Subject: matchID, Label: matchIDComponents[1]}, session.UserID()) == nil {
 			// User is not part of the match.
-			return
+			return false, nil
 		}
 
 		p.matchRegistry.SendData(matchID, matchIDComponents[1], session.UserID(), session.ID(), session.Username(), p.node, incoming.OpCode, incoming.Data, incoming.Reliable, time.Now().UTC().UnixNano()/int64(time.Millisecond))
-		return
+		return true, nil
 	}
 
 	// Parse any filters.
@@ -365,11 +374,11 @@ func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *
 		for i := 0; i < len(incoming.Presences); i++ {
 			userID, err := uuid.FromString(incoming.Presences[i].UserId)
 			if err != nil {
-				return
+				return false, nil
 			}
 			sessionID, err := uuid.FromString(incoming.Presences[i].SessionId)
 			if err != nil {
-				return
+				return false, nil
 			}
 			filters[i] = &matchDataFilter{userID: userID, sessionID: sessionID}
 		}
@@ -379,7 +388,7 @@ func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *
 	stream := PresenceStream{Mode: StreamModeMatchRelayed, Subject: matchID}
 	presenceIDs := p.tracker.ListPresenceIDByStream(stream)
 	if len(presenceIDs) == 0 {
-		return
+		return false, nil
 	}
 
 	senderFound := false
@@ -418,12 +427,12 @@ func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *
 
 	// If sender wasn't in the presences for this match, they're not a member.
 	if !senderFound {
-		return
+		return false, nil
 	}
 
 	// Check if there are any recipients left.
 	if len(presenceIDs) == 0 {
-		return
+		return true, nil
 	}
 
 	outgoing := &rtapi.Envelope{Message: &rtapi.Envelope_MatchData{MatchData: &rtapi.MatchData{
@@ -439,4 +448,6 @@ func (p *Pipeline) matchDataSend(logger *zap.Logger, session Session, envelope *
 	}}}
 
 	p.router.SendToPresenceIDs(logger, presenceIDs, outgoing, incoming.Reliable)
+
+	return true, nil
 }

--- a/server/pipeline_party.go
+++ b/server/pipeline_party.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (p *Pipeline) partyCreate(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyCreate(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyCreate()
 
 	// Validate party creation parameters.
@@ -32,7 +32,7 @@ func (p *Pipeline) partyCreate(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party max size, must be 1-256",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	presence := &rtapi.UserPresence{
@@ -48,7 +48,7 @@ func (p *Pipeline) partyCreate(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_RUNTIME_EXCEPTION),
 			Message: "Failed to create party",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// If successful, the creator becomes the first user to join the party.
@@ -62,20 +62,23 @@ func (p *Pipeline) partyCreate(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_RUNTIME_EXCEPTION),
 			Message: "Error tracking party creation",
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Party{Party: &rtapi.Party{
+	out := &rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Party{Party: &rtapi.Party{
 		PartyId:   ph.IDStr,
 		Open:      incoming.Open,
 		MaxSize:   incoming.MaxSize,
 		Self:      presence,
 		Leader:    presence,
 		Presences: []*rtapi.UserPresence{presence},
-	}}}, true)
+	}}}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyJoin(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyJoin(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyJoin()
 
 	// Validate the party ID.
@@ -85,7 +88,7 @@ func (p *Pipeline) partyJoin(logger *zap.Logger, session Session, envelope *rtap
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -93,7 +96,7 @@ func (p *Pipeline) partyJoin(logger *zap.Logger, session Session, envelope *rtap
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -115,7 +118,7 @@ func (p *Pipeline) partyJoin(logger *zap.Logger, session Session, envelope *rtap
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error joining party: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// If the party was open and the join was successful, track the new member immediately.
@@ -130,14 +133,17 @@ func (p *Pipeline) partyJoin(logger *zap.Logger, session Session, envelope *rtap
 				Code:    int32(rtapi.Error_RUNTIME_EXCEPTION),
 				Message: "Error tracking party join",
 			}}}, true)
-			return
+			return false, nil
 		}
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyLeave(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyLeave(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyLeave()
 
 	// Validate the party ID.
@@ -147,7 +153,7 @@ func (p *Pipeline) partyLeave(logger *zap.Logger, session Session, envelope *rta
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -155,17 +161,20 @@ func (p *Pipeline) partyLeave(logger *zap.Logger, session Session, envelope *rta
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
 	// Handle through the party registry.
 	p.tracker.Untrack(session.ID(), PresenceStream{Mode: StreamModeParty, Subject: partyID, Label: node}, session.UserID())
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, nil
 }
 
-func (p *Pipeline) partyPromote(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyPromote(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyPromote()
 
 	// Validate presence info.
@@ -174,7 +183,7 @@ func (p *Pipeline) partyPromote(logger *zap.Logger, session Session, envelope *r
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid presence",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// Validate the party ID.
@@ -184,7 +193,7 @@ func (p *Pipeline) partyPromote(logger *zap.Logger, session Session, envelope *r
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -192,7 +201,7 @@ func (p *Pipeline) partyPromote(logger *zap.Logger, session Session, envelope *r
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -203,13 +212,16 @@ func (p *Pipeline) partyPromote(logger *zap.Logger, session Session, envelope *r
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error promoting new party leader: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyAccept(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyAccept(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyAccept()
 
 	// Validate presence info.
@@ -218,7 +230,7 @@ func (p *Pipeline) partyAccept(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid presence",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// Validate the party ID.
@@ -228,7 +240,7 @@ func (p *Pipeline) partyAccept(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -236,7 +248,7 @@ func (p *Pipeline) partyAccept(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -247,13 +259,16 @@ func (p *Pipeline) partyAccept(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error accepting party join request: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyRemove(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyRemove(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyRemove()
 
 	// Validate presence info.
@@ -262,7 +277,7 @@ func (p *Pipeline) partyRemove(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid presence",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// Validate the party ID.
@@ -272,7 +287,7 @@ func (p *Pipeline) partyRemove(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -280,7 +295,7 @@ func (p *Pipeline) partyRemove(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -291,13 +306,16 @@ func (p *Pipeline) partyRemove(logger *zap.Logger, session Session, envelope *rt
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error removing party member or join request: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyClose(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyClose(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyClose()
 
 	// Validate the party ID.
@@ -307,7 +325,7 @@ func (p *Pipeline) partyClose(logger *zap.Logger, session Session, envelope *rta
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -315,7 +333,7 @@ func (p *Pipeline) partyClose(logger *zap.Logger, session Session, envelope *rta
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -326,13 +344,16 @@ func (p *Pipeline) partyClose(logger *zap.Logger, session Session, envelope *rta
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error closing party: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyJoinRequestList(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyJoinRequestList(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyJoinRequestList()
 
 	// Validate the party ID.
@@ -342,7 +363,7 @@ func (p *Pipeline) partyJoinRequestList(logger *zap.Logger, session Session, env
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -350,7 +371,7 @@ func (p *Pipeline) partyJoinRequestList(logger *zap.Logger, session Session, env
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -361,16 +382,19 @@ func (p *Pipeline) partyJoinRequestList(logger *zap.Logger, session Session, env
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error listing party join requests: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_PartyJoinRequest{PartyJoinRequest: &rtapi.PartyJoinRequest{
+	out := &rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_PartyJoinRequest{PartyJoinRequest: &rtapi.PartyJoinRequest{
 		PartyId:   incoming.PartyId,
 		Presences: presences,
-	}}}, true)
+	}}}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyMatchmakerAdd()
 
 	// Minimum count.
@@ -380,7 +404,7 @@ func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envel
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid minimum count, must be >= 2",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// Maximum count, must be at least minimum count.
@@ -390,7 +414,7 @@ func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envel
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid maximum count, must be >= minimum count",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	query := incoming.Query
@@ -405,7 +429,7 @@ func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envel
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -413,7 +437,7 @@ func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envel
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -424,14 +448,15 @@ func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envel
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error adding party to matchmaker: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// Return the ticket to the party leader.
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_PartyMatchmakerTicket{PartyMatchmakerTicket: &rtapi.PartyMatchmakerTicket{
+	out := &rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_PartyMatchmakerTicket{PartyMatchmakerTicket: &rtapi.PartyMatchmakerTicket{
 		PartyId: incoming.PartyId,
 		Ticket:  ticket,
-	}}}, true)
+	}}}
+	session.Send(out, true)
 
 	if len(memberPresenceIDs) != 0 {
 		// Notify all other party members.
@@ -445,9 +470,11 @@ func (p *Pipeline) partyMatchmakerAdd(logger *zap.Logger, session Session, envel
 		}
 		p.router.SendToPresenceIDs(p.logger, memberPresenceIDs, outgoing, true)
 	}
+
+	return true, out
 }
 
-func (p *Pipeline) partyMatchmakerRemove(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyMatchmakerRemove(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyMatchmakerRemove()
 
 	// Ticket is required.
@@ -456,7 +483,7 @@ func (p *Pipeline) partyMatchmakerRemove(logger *zap.Logger, session Session, en
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid matchmaker ticket",
 		}}}, true)
-		return
+		return false, nil
 	}
 
 	// Validate the party ID.
@@ -466,7 +493,7 @@ func (p *Pipeline) partyMatchmakerRemove(logger *zap.Logger, session Session, en
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -474,7 +501,7 @@ func (p *Pipeline) partyMatchmakerRemove(logger *zap.Logger, session Session, en
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -485,13 +512,16 @@ func (p *Pipeline) partyMatchmakerRemove(logger *zap.Logger, session Session, en
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error closing party: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) partyDataSend(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) partyDataSend(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	incoming := envelope.GetPartyDataSend()
 
 	// Validate the party ID.
@@ -501,7 +531,7 @@ func (p *Pipeline) partyDataSend(logger *zap.Logger, session Session, envelope *
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	partyID, err := uuid.FromString(partyIDComponents[0])
 	if err != nil {
@@ -509,7 +539,7 @@ func (p *Pipeline) partyDataSend(logger *zap.Logger, session Session, envelope *
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: "Invalid party ID",
 		}}}, true)
-		return
+		return false, nil
 	}
 	node := partyIDComponents[1]
 
@@ -520,8 +550,11 @@ func (p *Pipeline) partyDataSend(logger *zap.Logger, session Session, envelope *
 			Code:    int32(rtapi.Error_BAD_INPUT),
 			Message: fmt.Sprintf("Error sending party data: %s", err.Error()),
 		}}}, true)
-		return
+		return false, nil
 	}
 
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid}, true)
+	out := &rtapi.Envelope{Cid: envelope.Cid}
+	session.Send(out, true)
+
+	return true, out
 }

--- a/server/pipeline_ping.go
+++ b/server/pipeline_ping.go
@@ -19,10 +19,14 @@ import (
 	"go.uber.org/zap"
 )
 
-func (p *Pipeline) ping(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
-	session.Send(&rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Pong{Pong: &rtapi.Pong{}}}, true)
+func (p *Pipeline) ping(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
+	out := &rtapi.Envelope{Cid: envelope.Cid, Message: &rtapi.Envelope_Pong{Pong: &rtapi.Pong{}}}
+	session.Send(out, true)
+
+	return true, out
 }
 
-func (p *Pipeline) pong(logger *zap.Logger, session Session, envelope *rtapi.Envelope) {
+func (p *Pipeline) pong(logger *zap.Logger, session Session, envelope *rtapi.Envelope) (bool, *rtapi.Envelope) {
 	// No application-level action in response to a pong message.
+	return true, nil
 }

--- a/server/runtime.go
+++ b/server/runtime.go
@@ -48,8 +48,8 @@ var RTAPI_PREFIX_LOWERCASE = strings.ToLower(RTAPI_PREFIX)
 type (
 	RuntimeRpcFunction func(ctx context.Context, headers, queryParams map[string][]string, userID, username string, vars map[string]string, expiry int64, sessionID, clientIP, clientPort, lang, payload string) (string, error, codes.Code)
 
-	RuntimeBeforeRtFunction func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, sessionID, clientIP, clientPort, lang string, envelope *rtapi.Envelope) (*rtapi.Envelope, error)
-	RuntimeAfterRtFunction  func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, sessionID, clientIP, clientPort, lang string, envelope *rtapi.Envelope) error
+	RuntimeBeforeRtFunction func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, sessionID, clientIP, clientPort, lang string, in *rtapi.Envelope) (*rtapi.Envelope, error)
+	RuntimeAfterRtFunction  func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, sessionID, clientIP, clientPort, lang string, out, in *rtapi.Envelope) error
 
 	RuntimeBeforeGetAccountFunction                        func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string) (error, codes.Code)
 	RuntimeAfterGetAccountFunction                         func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Account) error

--- a/server/runtime_go.go
+++ b/server/runtime_go.go
@@ -109,13 +109,13 @@ func (ri *RuntimeGoInitializer) RegisterBeforeRt(id string, fn func(ctx context.
 	return nil
 }
 
-func (ri *RuntimeGoInitializer) RegisterAfterRt(id string, fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, envelope *rtapi.Envelope) error) error {
+func (ri *RuntimeGoInitializer) RegisterAfterRt(id string, fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out, in *rtapi.Envelope) error) error {
 	apiID := strings.ToLower(id)
 	id = strings.ToLower(RTAPI_PREFIX) + apiID
-	ri.afterRt[id] = func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, sessionID, clientIP, clientPort, lang string, envelope *rtapi.Envelope) error {
+	ri.afterRt[id] = func(ctx context.Context, logger *zap.Logger, userID, username string, vars map[string]string, expiry int64, sessionID, clientIP, clientPort, lang string, out, in *rtapi.Envelope) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.env, RuntimeExecutionModeAfter, nil, nil, expiry, userID, username, vars, sessionID, clientIP, clientPort, lang)
 		loggerFields := map[string]interface{}{"api_id": apiID, "mode": RuntimeExecutionModeAfter.String()}
-		return fn(ctx, ri.logger.WithFields(loggerFields), ri.db, ri.nk, envelope)
+		return fn(ctx, ri.logger.WithFields(loggerFields), ri.db, ri.nk, out, in)
 	}
 	return nil
 }

--- a/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
+++ b/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
@@ -311,22 +311,22 @@ type Initializer interface {
 	RegisterRpc(id string, fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, payload string) (string, error)) error
 
 	/*
-		RegisterBeforeRt registers a function for a message. The registered function will be called after the message has been processed in the pipeline.
-		The custom code will be executed asynchronously after the response message has been sent to a client
-
-		Message names can be found here: https://heroiclabs.com/docs/runtime-code-basics/#message-names
-	*/
-	RegisterBeforeRt(id string, fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, envelope *rtapi.Envelope) (*rtapi.Envelope, error)) error
-
-	/*
-		RegisterAfterRt registers a function with for a message. Any function may be registered to intercept a message received from a client and operate on it (or reject it) based on custom logic.
+		RegisterBeforeRt registers a function with for a message. Any function may be registered to intercept a message received from a client and operate on it (or reject it) based on custom logic.
 		This is useful to enforce specific rules on top of the standard features in the server.
 
 		You can return `nil` instead of the `rtapi.Envelope` and this will disable disable that particular server functionality.
 
 		Message names can be found here: https://heroiclabs.com/docs/runtime-code-basics/#message-names
 	*/
-	RegisterAfterRt(id string, fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, envelope *rtapi.Envelope) error) error
+	RegisterBeforeRt(id string, fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, in *rtapi.Envelope) (*rtapi.Envelope, error)) error
+
+	/*
+		RegisterAfterRt registers a function for a message. The registered function will be called after the message has been processed in the pipeline.
+		The custom code will be executed asynchronously after the response message has been sent to a client
+
+		Message names can be found here: https://heroiclabs.com/docs/runtime-code-basics/#message-names
+	*/
+	RegisterAfterRt(id string, fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, out, in *rtapi.Envelope) error) error
 
 	// RegisterMatchmakerMatched
 	RegisterMatchmakerMatched(fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, entries []MatchmakerEntry) (string, error)) error
@@ -1013,7 +1013,10 @@ type NakamaModule interface {
 	LeaderboardRecordsHaystack(ctx context.Context, id, ownerID string, limit int, expiry int64) ([]*api.LeaderboardRecord, error)
 
 	PurchaseValidateApple(ctx context.Context, userID, receipt string, persist bool, passwordOverride ...string) (*api.ValidatePurchaseResponse, error)
-	PurchaseValidateGoogle(ctx context.Context, userID, receipt string, persist bool, overrides ...struct{ClientEmail string; PrivateKey string}) (*api.ValidatePurchaseResponse, error)
+	PurchaseValidateGoogle(ctx context.Context, userID, receipt string, persist bool, overrides ...struct {
+		ClientEmail string
+		PrivateKey  string
+	}) (*api.ValidatePurchaseResponse, error)
 	PurchaseValidateHuawei(ctx context.Context, userID, signature, inAppPurchaseData string, persist bool) (*api.ValidatePurchaseResponse, error)
 	PurchasesList(ctx context.Context, userID string, limit int, cursor string) (*api.PurchaseList, error)
 	PurchaseGetByTransactionId(ctx context.Context, transactionID string) (string, *api.ValidatedPurchase, error)


### PR DESCRIPTION
- Realtime after hooks now include both the outgoing and incoming payload.
- Realtime after hooks do not run when the operation fails.

Corresponding `nakama-common` update in progress.