### PR TITLE
[Fix] Generate Missing Username

### DIFF
--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -411,7 +411,7 @@ func (n *RuntimeGoNakamaModule) AuthenticateTokenGenerate(userID, username strin
 	}
 
 	if username == "" {
-		return "", 0, errors.New("expects username")
+		username = generateUsername()
 	}
 
 	if exp == 0 {


### PR DESCRIPTION
According to the [docs](https://heroiclabs.com/docs/nakama/server-framework/function-reference/go/#AuthenticateTokenGenerate) for `AuthenticateTokenGenerate` the username is optional and a missing username is automatically generated. However the implementation fails with an error if no username was provided.

This PR fixes this.