### PR TITLE
Adds a flag for disabling the console

### DIFF
--- a/main.go
+++ b/main.go
@@ -164,7 +164,11 @@ func main() {
 	statusHandler := server.NewLocalStatusHandler(logger, sessionRegistry, matchRegistry, tracker, metrics, config.GetName())
 
 	apiServer := server.StartApiServer(logger, startupLogger, db, jsonpbMarshaler, jsonpbUnmarshaler, config, socialClient, leaderboardCache, leaderboardRankCache, sessionRegistry, sessionCache, statusRegistry, matchRegistry, matchmaker, tracker, router, metrics, pipeline, runtime)
-	consoleServer := server.StartConsoleServer(logger, startupLogger, db, config, tracker, router, sessionCache, statusHandler, runtimeInfo, matchRegistry, configWarnings, semver, leaderboardCache, leaderboardRankCache, apiServer, cookie)
+
+	var consoleServer *server.ConsoleServer
+	if !config.GetConsole().Disable {
+		consoleServer = server.StartConsoleServer(logger, startupLogger, db, config, tracker, router, sessionCache, statusHandler, runtimeInfo, matchRegistry, configWarnings, semver, leaderboardCache, leaderboardRankCache, apiServer, cookie)
+	}
 
 	gaenabled := len(os.Getenv("NAKAMA_TELEMETRY")) < 1
 	const gacode = "UA-89792135-1"
@@ -222,7 +226,9 @@ func main() {
 
 	// Gracefully stop remaining server components.
 	apiServer.Stop()
-	consoleServer.Stop()
+	if consoleServer != nil {
+		consoleServer.Stop()
+	}
 	matchmaker.Stop()
 	leaderboardScheduler.Stop()
 	tracker.Stop()

--- a/server/config.go
+++ b/server/config.go
@@ -895,6 +895,7 @@ type ConsoleConfig struct {
 	Password            string `yaml:"password" json:"password" usage:"Password for the embedded console. Default password is 'password'."`
 	TokenExpirySec      int64  `yaml:"token_expiry_sec" json:"token_expiry_sec" usage:"Token expiry in seconds. Default 86400."`
 	SigningKey          string `yaml:"signing_key" json:"signing_key" usage:"Key used to sign console session tokens."`
+	Disable             bool   `yaml:"disable" json:"disable" usage:"Use to skip launching the embedded console. Default is 'false'."`
 }
 
 // NewConsoleConfig creates a new ConsoleConfig struct.
@@ -909,6 +910,7 @@ func NewConsoleConfig() *ConsoleConfig {
 		Password:            "password",
 		TokenExpirySec:      86400,
 		SigningKey:          "defaultsigningkey",
+		Disable:             false,
 	}
 }
 


### PR DESCRIPTION
Hi folks, one of my test server environment has quite a limit on the values of exposed ports (and a limit on them) and I wondered if being able to disable the console as a config option would be viable upstream? 

( This is also my first PR to a go project, so I'm not sure if I've missed something too! )