### PR TITLE
Limit unsuccessful login attempts on the console

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,6 +141,7 @@ func main() {
 	sessionRegistry := server.NewLocalSessionRegistry(metrics)
 	sessionCache := server.NewLocalSessionCache(config.GetSession().TokenExpirySec)
 	consoleSessionCache := server.NewLocalSessionCache(config.GetConsole().TokenExpirySec)
+	loginAttemptCache := server.NewLocalLoginAttemptCache()
 	statusRegistry := server.NewStatusRegistry(logger, config, sessionRegistry, jsonpbMarshaler)
 	tracker := server.StartLocalTracker(logger, config, sessionRegistry, statusRegistry, metrics, jsonpbMarshaler)
 	router := server.NewLocalMessageRouter(sessionRegistry, tracker, jsonpbMarshaler)
@@ -166,7 +167,7 @@ func main() {
 	statusHandler := server.NewLocalStatusHandler(logger, sessionRegistry, matchRegistry, tracker, metrics, config.GetName())
 
 	apiServer := server.StartApiServer(logger, startupLogger, db, jsonpbMarshaler, jsonpbUnmarshaler, config, socialClient, leaderboardCache, leaderboardRankCache, sessionRegistry, sessionCache, statusRegistry, matchRegistry, matchmaker, tracker, router, streamManager, metrics, pipeline, runtime)
-	consoleServer := server.StartConsoleServer(logger, startupLogger, db, config, tracker, router, streamManager, sessionCache, consoleSessionCache, statusRegistry, statusHandler, runtimeInfo, matchRegistry, configWarnings, semver, leaderboardCache, leaderboardRankCache, apiServer, cookie)
+	consoleServer := server.StartConsoleServer(logger, startupLogger, db, config, tracker, router, streamManager, sessionCache, consoleSessionCache, loginAttemptCache, statusRegistry, statusHandler, runtimeInfo, matchRegistry, configWarnings, semver, leaderboardCache, leaderboardRankCache, apiServer, cookie)
 
 	gaenabled := len(os.Getenv("NAKAMA_TELEMETRY")) < 1
 	const gacode = "UA-89792135-1"

--- a/main.go
+++ b/main.go
@@ -233,6 +233,7 @@ func main() {
 	sessionCache.Stop()
 	sessionRegistry.Stop()
 	metrics.Stop(logger)
+	loginAttemptCache.Stop()
 
 	if gaenabled {
 		_ = ga.SendSessionStop(telemetryClient, gacode, cookie)

--- a/server/console.go
+++ b/server/console.go
@@ -138,6 +138,7 @@ type ConsoleServer struct {
 	StreamManager        StreamManager
 	sessionCache         SessionCache
 	consoleSessionCache  SessionCache
+	loginAttemptCache    LoginAttemptCache
 	statusRegistry       *StatusRegistry
 	matchRegistry        MatchRegistry
 	statusHandler        StatusHandler
@@ -155,7 +156,7 @@ type ConsoleServer struct {
 	httpClient           *http.Client
 }
 
-func StartConsoleServer(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, config Config, tracker Tracker, router MessageRouter, streamManager StreamManager, sessionCache SessionCache, consoleSessionCache SessionCache, statusRegistry *StatusRegistry, statusHandler StatusHandler, runtimeInfo *RuntimeInfo, matchRegistry MatchRegistry, configWarnings map[string]string, serverVersion string, leaderboardCache LeaderboardCache, leaderboardRankCache LeaderboardRankCache, api *ApiServer, cookie string) *ConsoleServer {
+func StartConsoleServer(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, config Config, tracker Tracker, router MessageRouter, streamManager StreamManager, sessionCache SessionCache, consoleSessionCache SessionCache, loginAttemptCache LoginAttemptCache, statusRegistry *StatusRegistry, statusHandler StatusHandler, runtimeInfo *RuntimeInfo, matchRegistry MatchRegistry, configWarnings map[string]string, serverVersion string, leaderboardCache LeaderboardCache, leaderboardRankCache LeaderboardRankCache, api *ApiServer, cookie string) *ConsoleServer {
 	var gatewayContextTimeoutMs string
 	if config.GetConsole().IdleTimeoutMs > 500 {
 		// Ensure the GRPC Gateway timeout is just under the idle timeout (if possible) to ensure it has priority.
@@ -182,6 +183,7 @@ func StartConsoleServer(logger *zap.Logger, startupLogger *zap.Logger, db *sql.D
 		StreamManager:        streamManager,
 		sessionCache:         sessionCache,
 		consoleSessionCache:  consoleSessionCache,
+		loginAttemptCache:    loginAttemptCache,
 		statusRegistry:       statusRegistry,
 		matchRegistry:        matchRegistry,
 		statusHandler:        statusHandler,

--- a/server/console_authenticate.go
+++ b/server/console_authenticate.go
@@ -158,13 +158,8 @@ func (s *ConsoleServer) lookupConsoleUser(ctx context.Context, unameOrEmail, pas
 	err = s.db.QueryRowContext(ctx, query, unameOrEmail).Scan(&id, &uname, &email, &role, &dbPassword, &dbDisableTime)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			if lockout, until := s.loginAttemptCache.Add("", ip); lockout != LockoutTypeNone {
-				switch lockout {
-				case LockoutTypeAccount:
-					s.logger.Info(fmt.Sprintf("Console user account locked until %v.", until))
-				case LockoutTypeIp:
-					s.logger.Info(fmt.Sprintf("Console user IP locked until %v.", until))
-				}
+			if lockout, until := s.loginAttemptCache.Add("", ip); lockout == LockoutTypeIp {
+				s.logger.Info(fmt.Sprintf("Console user IP locked until %v.", until))
 			}
 			err = status.Error(codes.Unauthenticated, "Invalid credentials.")
 		}

--- a/server/console_authenticate.go
+++ b/server/console_authenticate.go
@@ -180,6 +180,12 @@ func (s *ConsoleServer) lookupConsoleUser(ctx context.Context, unameOrEmail, pas
 		return
 	}
 
+	// Check lockout again as the login attempt may have been through email
+	lockout, _ := s.loginAttemptCache.IsLockedOut(uname, "")
+	if lockout != unlocked {
+		err = status.Error(codes.ResourceExhausted, "Try again later.")
+	}
+
 	// Check if it's disabled.
 	if dbDisableTime.Status == pgtype.Present && dbDisableTime.Time.Unix() != 0 {
 		s.logger.Info("Console user account is disabled.", zap.String("username", unameOrEmail))

--- a/server/console_authenticate.go
+++ b/server/console_authenticate.go
@@ -71,6 +71,16 @@ func parseConsoleToken(hmacSecretByte []byte, tokenString string) (id, username,
 }
 
 func (s *ConsoleServer) Authenticate(ctx context.Context, in *console.AuthenticateRequest) (*console.ConsoleSession, error) {
+	ip, _ := extractClientAddressFromContext(s.logger, ctx)
+	lockout, until := s.loginAttemptCache.IsLockedOut(in.Username, ip)
+	now := time.Now()
+	switch lockout {
+	case accountBased:
+		return nil, status.Error(codes.PermissionDenied, fmt.Sprintf("Account locked out for %v.", until.Sub(now)))
+	case ipBased:
+		return nil, status.Error(codes.PermissionDenied, fmt.Sprintf("IP locked out for %v.", until.Sub(now)))
+	}
+
 	role := console.UserRole_USER_ROLE_UNKNOWN
 	var uname string
 	var email string
@@ -94,7 +104,10 @@ func (s *ConsoleServer) Authenticate(ctx context.Context, in *console.Authentica
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials.")
 	}
 
+	s.loginAttemptCache.ResetAttempts(uname, ip)
+
 	exp := time.Now().UTC().Add(time.Duration(s.config.GetConsole().TokenExpirySec) * time.Second).Unix()
+
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &ConsoleTokenClaims{
 		ExpiresAt: exp,
 		ID:        id.String(),

--- a/server/console_authenticate.go
+++ b/server/console_authenticate.go
@@ -114,7 +114,7 @@ func (s *ConsoleServer) Authenticate(ctx context.Context, in *console.Authentica
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials.")
 	}
 
-	s.loginAttemptCache.ResetAttempts(uname, ip)
+	s.loginAttemptCache.ResetAttempts(uname)
 
 	exp := time.Now().UTC().Add(time.Duration(s.config.GetConsole().TokenExpirySec) * time.Second).Unix()
 

--- a/server/console_authenticate.go
+++ b/server/console_authenticate.go
@@ -20,10 +20,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/gofrs/uuid"
-	"google.golang.org/protobuf/types/known/emptypb"
 	"time"
 
+	"github.com/gofrs/uuid"
 	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/heroiclabs/nakama/v3/console"
 	"github.com/jackc/pgtype"
@@ -31,6 +30,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type ConsoleTokenClaims struct {

--- a/server/failed_login_cache.go
+++ b/server/failed_login_cache.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"math"
 	"sync"
 	"time"
 )
@@ -93,6 +94,8 @@ func (c *LocalLoginAttemptCache) AddAttempt(account string, ip string) (remainin
 			st.attempts = append(st.attempts, now)
 			accRemainingAttempts = maxAccountAttempts - len(st.attempts)
 		}
+	} else {
+		accRemainingAttempts = math.MaxInt
 	}
 	if ip != "" {
 		st, ipFound := c.ipCache[ip]

--- a/server/failed_login_cache.go
+++ b/server/failed_login_cache.go
@@ -31,7 +31,7 @@ type LoginAttemptCache interface {
 	ResetAttempts(account string, ip string)
 }
 
-type status struct {
+type lockoutStatus struct {
 	lockedUntil time.Time
 	attempts    []time.Time
 }
@@ -39,14 +39,14 @@ type status struct {
 type LocalLoginAttemptCache struct {
 	sync.RWMutex
 
-	accountCache map[string]*status
-	ipCache      map[string]*status
+	accountCache map[string]*lockoutStatus
+	ipCache      map[string]*lockoutStatus
 }
 
 func NewLocalLoginAttemptCache() LoginAttemptCache {
 	return &LocalLoginAttemptCache{
-		accountCache: make(map[string]*status),
-		ipCache:      make(map[string]*status),
+		accountCache: make(map[string]*lockoutStatus),
+		ipCache:      make(map[string]*lockoutStatus),
 	}
 }
 
@@ -78,7 +78,7 @@ func (c *LocalLoginAttemptCache) AddAttempt(account string, ip string) (remainin
 		st, accFound := c.accountCache[account]
 		if !accFound {
 			// First failed attempt.
-			st = &status{
+			st = &lockoutStatus{
 				attempts: make([]time.Time, 0, maxAccountAttempts),
 			}
 			st.attempts = append(st.attempts, now)
@@ -97,7 +97,7 @@ func (c *LocalLoginAttemptCache) AddAttempt(account string, ip string) (remainin
 		st, ipFound := c.ipCache[ip]
 		if !ipFound {
 			// First failed attempt.
-			st = &status{
+			st = &lockoutStatus{
 				attempts: make([]time.Time, 0, maxIpAttempts),
 			}
 			st.attempts = append(st.attempts, now)

--- a/server/failed_login_cache.go
+++ b/server/failed_login_cache.go
@@ -24,10 +24,11 @@ const (
 )
 
 type LoginAttemptCache interface {
-	// IsLockedOut Checks if locked out and resets lockout or attempts if expired.
+	// IsLockedOut Checks whether account or ip is locked out and resets lockout/attempts if expired.
 	IsLockedOut(account string, ip string) (lockout LockoutType, lockedUntil time.Time)
 	// AddAttempt Adds failed attempt and returns current lockout status.
 	AddAttempt(account string, ip string) (remainingAttempts int, lockout LockoutType, lockedUntil time.Time)
+	// ResetAttempts Resets account and ip lockouts on successful login.
 	ResetAttempts(account string, ip string)
 }
 

--- a/server/failed_login_cache.go
+++ b/server/failed_login_cache.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type LockoutType int
+
+const (
+	maxAccountAttempts   = 5
+	accountLockoutPeriod = time.Minute * 5
+	maxIpAttempts        = 10
+	ipLockoutPeriod      = time.Minute * 10
+)
+
+const (
+	unlocked LockoutType = iota
+	accountBased
+	ipBased
+)
+
+type FailedLoginCache interface {
+	AddAttempt(account string, ip string) LockoutType
+	ResetAttempts(account string, ip string)
+}
+
+type status struct {
+	lockedUntil time.Time
+	attempts    []time.Time
+}
+
+type LocalFailedLoginCache struct {
+	sync.RWMutex
+	ctx         context.Context
+	ctxCancelFn context.CancelFunc
+
+	accountCache map[string]*status
+	ipCache      map[string]*status
+}
+
+func (c *LocalFailedLoginCache) AddAttempt(account string, ip string) (remainingChances int, lockout LockoutType, lockedUntil time.Time) {
+	// TODO: check if there are any locks first
+	now := time.Now().UTC()
+	lockout = unlocked
+	c.Lock()
+	if account != "" {
+		st, accFound := c.accountCache[account]
+		if !accFound {
+			// First failed attempt.
+			st = &status{
+				attempts: make([]time.Time, 0, maxAccountAttempts),
+			}
+			st.attempts = append(st.attempts, now)
+			c.accountCache[account] = st
+			remainingChances = maxAccountAttempts - 1
+		} else {
+			if st.lockedUntil.IsZero() {
+				if len(st.attempts) >= maxAccountAttempts-1 {
+					// Reached attempt limit.
+					st.lockedUntil = now.Add(accountLockoutPeriod)
+					lockout = accountBased
+					lockedUntil = st.lockedUntil
+				}
+			} else {
+				// Currently locked out.
+				lockout = accountBased
+				lockedUntil = st.lockedUntil
+			}
+		}
+	}
+	if ip != "" {
+		_, ipFound := c.ipCache[ip]
+		if !ipFound {
+			c.ipCache[ip] = &status{
+				attempts: make([]time.Time, 0, maxIpAttempts),
+			}
+		} else {
+
+		}
+	}
+	c.Unlock()
+	return
+}

--- a/server/login_attempt_cache.go
+++ b/server/login_attempt_cache.go
@@ -16,7 +16,7 @@ const (
 	ipLockoutPeriod      = time.Minute * 10
 
 	// Period to which the max attempts apply, counting from the first attempt.
-	storeAttemptsPeriod = time.Minute * 10
+	cacheAttemptsPeriod = time.Minute * 10
 )
 
 const (
@@ -72,7 +72,7 @@ func NewLocalLoginAttemptCache() LoginAttemptCache {
 				c.Lock()
 				for account, status := range c.accountCache {
 					if status.lockedUntil.IsZero() {
-						if len(status.attempts) == 0 || status.attempts[0].Add(storeAttemptsPeriod).Before(tM) {
+						if len(status.attempts) == 0 || status.attempts[0].Add(cacheAttemptsPeriod).Before(tM) {
 							delete(c.accountCache, account)
 						}
 					} else if status.lockedUntil.Before(tM) {
@@ -81,7 +81,7 @@ func NewLocalLoginAttemptCache() LoginAttemptCache {
 				}
 				for ip, status := range c.ipCache {
 					if status.lockedUntil.IsZero() {
-						if len(status.attempts) == 0 || status.attempts[0].Add(storeAttemptsPeriod).Before(tM) {
+						if len(status.attempts) == 0 || status.attempts[0].Add(cacheAttemptsPeriod).Before(tM) {
 							delete(c.ipCache, ip)
 						}
 					} else if status.lockedUntil.Before(tM) {
@@ -184,7 +184,7 @@ func isLockedOut(c *LocalLoginAttemptCache, account string, ip string, now time.
 	if accFound {
 		if accStatus.lockedUntil.IsZero() {
 			accLockedUntil = time.Time{}
-			if len(accStatus.attempts) == 0 || accStatus.attempts[0].Add(storeAttemptsPeriod).Before(now) {
+			if len(accStatus.attempts) == 0 || accStatus.attempts[0].Add(cacheAttemptsPeriod).Before(now) {
 				delete(c.accountCache, account)
 			}
 		} else {
@@ -199,7 +199,7 @@ func isLockedOut(c *LocalLoginAttemptCache, account string, ip string, now time.
 	if ipFound {
 		if ipStatus.lockedUntil.IsZero() {
 			ipLockedUntil = time.Time{}
-			if len(ipStatus.attempts) == 0 || ipStatus.attempts[0].Add(storeAttemptsPeriod).Before(now) {
+			if len(ipStatus.attempts) == 0 || ipStatus.attempts[0].Add(cacheAttemptsPeriod).Before(now) {
 				delete(c.ipCache, ip)
 			}
 		} else {

--- a/server/login_attempt_cache.go
+++ b/server/login_attempt_cache.go
@@ -1,43 +1,68 @@
+// Copyright 2022 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (
 	"context"
-	"math"
 	"sync"
 	"time"
 )
 
-type LockoutType int
+type LockoutType uint8
 
 const (
-	maxAccountAttempts   = 5
-	accountLockoutPeriod = time.Minute * 10
-	maxIpAttempts        = 10
-	ipLockoutPeriod      = time.Minute * 10
-
-	// Period to which the max attempts apply, counting from the first attempt.
-	cacheAttemptsPeriod = time.Minute * 10
+	LockoutTypeNone LockoutType = iota
+	LockoutTypeAccount
+	LockoutTypeIp
 )
 
 const (
-	unlocked LockoutType = iota
-	accountBased
-	ipBased
+	maxAttemptsAccount   = 5
+	lockoutPeriodAccount = time.Minute * 1
+
+	maxAttemptsIp   = 10
+	lockoutPeriodIp = time.Minute * 10
 )
 
 type LoginAttemptCache interface {
 	Stop()
-	// IsLockedOut Checks whether account or ip is locked out and resets lockout/attempts if expired.
-	IsLockedOut(account string, ip string) (lockout LockoutType, lockedUntil time.Time)
-	// AddAttempt Adds failed attempt and returns current lockout status.
-	AddAttempt(account string, ip string) (remainingAttempts int, lockout LockoutType, lockedUntil time.Time)
-	// ResetAttempts Resets account attempts on successful login.
-	ResetAttempts(account string)
+	// Allow checks whether account or IP is locked out or should be allowed to attempt to authenticate.
+	Allow(account, ip string) bool
+	// Add a failed attempt and return current lockout status.
+	Add(account, ip string) (LockoutType, time.Time)
+	// Reset account attempts on successful login.
+	Reset(account string)
 }
 
 type lockoutStatus struct {
 	lockedUntil time.Time
 	attempts    []time.Time
+}
+
+func (ls *lockoutStatus) trim(now time.Time, retentionPeriod time.Duration) bool {
+	if ls.lockedUntil.Before(now) {
+		ls.lockedUntil = time.Time{}
+	}
+	for i := len(ls.attempts) - 1; i >= 0; i-- {
+		if now.Sub(ls.attempts[i]) >= retentionPeriod {
+			ls.attempts = ls.attempts[i+1:]
+			break
+		}
+	}
+
+	return ls.lockedUntil.IsZero() && len(ls.attempts) == 0
 }
 
 type LocalLoginAttemptCache struct {
@@ -68,23 +93,15 @@ func NewLocalLoginAttemptCache() LoginAttemptCache {
 				ticker.Stop()
 				return
 			case t := <-ticker.C:
-				tM := t.UTC()
+				now := t.UTC()
 				c.Lock()
 				for account, status := range c.accountCache {
-					if status.lockedUntil.IsZero() {
-						if len(status.attempts) == 0 || status.attempts[0].Add(cacheAttemptsPeriod).Before(tM) {
-							delete(c.accountCache, account)
-						}
-					} else if status.lockedUntil.Before(tM) {
+					if status.trim(now, lockoutPeriodAccount) {
 						delete(c.accountCache, account)
 					}
 				}
 				for ip, status := range c.ipCache {
-					if status.lockedUntil.IsZero() {
-						if len(status.attempts) == 0 || status.attempts[0].Add(cacheAttemptsPeriod).Before(tM) {
-							delete(c.ipCache, ip)
-						}
-					} else if status.lockedUntil.Before(tM) {
+					if status.trim(now, lockoutPeriodIp) {
 						delete(c.ipCache, ip)
 					}
 				}
@@ -100,133 +117,58 @@ func (c *LocalLoginAttemptCache) Stop() {
 	c.ctxCancelFn()
 }
 
-func (c *LocalLoginAttemptCache) IsLockedOut(account string, ip string) (lockout LockoutType, lockedUntil time.Time) {
-	now := time.Now()
-	c.Lock()
-	defer c.Unlock()
-	return isLockedOut(c, account, ip, now)
+func (c *LocalLoginAttemptCache) Allow(account, ip string) bool {
+	now := time.Now().UTC()
+	c.RLock()
+	defer c.RUnlock()
+	if status, found := c.accountCache[account]; found && !status.lockedUntil.IsZero() && status.lockedUntil.After(now) {
+		return false
+	}
+	if status, found := c.ipCache[ip]; found && !status.lockedUntil.IsZero() && status.lockedUntil.After(now) {
+		return false
+	}
+	return true
 }
 
-func (c *LocalLoginAttemptCache) ResetAttempts(account string) {
+func (c *LocalLoginAttemptCache) Reset(account string) {
 	c.Lock()
 	delete(c.accountCache, account)
 	c.Unlock()
 }
 
-func (c *LocalLoginAttemptCache) AddAttempt(account string, ip string) (remainingAttempts int, lockout LockoutType, lockedUntil time.Time) {
+func (c *LocalLoginAttemptCache) Add(account, ip string) (LockoutType, time.Time) {
 	now := time.Now().UTC()
+	var lockoutType LockoutType
+	var lockedUntil time.Time
 	c.Lock()
 	defer c.Unlock()
-	lockout, until := isLockedOut(c, account, ip, now)
-	if lockout != unlocked {
-		return 0, lockout, until
-	}
-	var accLockedUntil, ipLockedUntil time.Time
-	var accRemainingAttempts, ipRemainingAttempts int
 	if account != "" {
-		st, accFound := c.accountCache[account]
-		if !accFound {
-			// First failed attempt.
-			st = &lockoutStatus{
-				attempts: make([]time.Time, 0, maxAccountAttempts),
-			}
-			st.attempts = append(st.attempts, now)
-			c.accountCache[account] = st
-			accRemainingAttempts = maxAccountAttempts - 1
-		} else if len(st.attempts) >= maxAccountAttempts-1 {
-			// Reached attempt limit.
-			st.lockedUntil = now.Add(accountLockoutPeriod)
-			accLockedUntil = st.lockedUntil
-		} else {
-			st.attempts = append(st.attempts, now)
-			accRemainingAttempts = maxAccountAttempts - len(st.attempts)
+		status, found := c.accountCache[account]
+		if !found {
+			status = &lockoutStatus{}
+			c.accountCache[account] = status
 		}
-	} else {
-		accRemainingAttempts = math.MaxInt
+		status.attempts = append(status.attempts, now)
+		_ = status.trim(now, lockoutPeriodAccount)
+		if len(status.attempts) >= maxAttemptsAccount {
+			status.lockedUntil = now.Add(lockoutPeriodAccount)
+			lockedUntil = status.lockedUntil
+			lockoutType = LockoutTypeAccount
+		}
 	}
 	if ip != "" {
-		st, ipFound := c.ipCache[ip]
-		if !ipFound {
-			// First failed attempt.
-			st = &lockoutStatus{
-				attempts: make([]time.Time, 0, maxIpAttempts),
-			}
-			st.attempts = append(st.attempts, now)
-			c.ipCache[ip] = st
-			ipRemainingAttempts = maxIpAttempts - 1
-		} else if len(st.attempts) >= maxIpAttempts-1 {
-			// Reached attempt limit.
-			st.lockedUntil = now.Add(ipLockoutPeriod)
-			ipLockedUntil = st.lockedUntil
-		} else {
-			st.attempts = append(st.attempts, now)
-			ipRemainingAttempts = maxIpAttempts - len(st.attempts)
+		status, found := c.ipCache[ip]
+		if !found {
+			status = &lockoutStatus{}
+			c.ipCache[ip] = status
+		}
+		status.attempts = append(status.attempts, now)
+		_ = status.trim(now, lockoutPeriodIp)
+		if len(status.attempts) >= maxAttemptsIp {
+			status.lockedUntil = now.Add(lockoutPeriodIp)
+			lockedUntil = status.lockedUntil
+			lockoutType = LockoutTypeIp
 		}
 	}
-	if accLockedUntil.After(ipLockedUntil) {
-		lockedUntil = accLockedUntil
-		lockout = accountBased
-	} else {
-		lockedUntil = ipLockedUntil
-		lockout = ipBased
-	}
-	if lockedUntil.IsZero() {
-		lockout = unlocked
-	}
-	remainingAttempts = min(accRemainingAttempts, ipRemainingAttempts)
-	return
-}
-
-func isLockedOut(c *LocalLoginAttemptCache, account string, ip string, now time.Time) (lockout LockoutType, lockedUntil time.Time) {
-	accStatus, accFound := c.accountCache[account]
-	ipStatus, ipFound := c.ipCache[ip]
-	var accLockedUntil, ipLockedUntil time.Time
-	if accFound {
-		if accStatus.lockedUntil.IsZero() {
-			accLockedUntil = time.Time{}
-			if len(accStatus.attempts) == 0 || accStatus.attempts[0].Add(cacheAttemptsPeriod).Before(now) {
-				delete(c.accountCache, account)
-			}
-		} else {
-			if accStatus.lockedUntil.After(now) {
-				accLockedUntil = accStatus.lockedUntil
-			} else {
-				delete(c.accountCache, account)
-				accLockedUntil = time.Time{}
-			}
-		}
-	}
-	if ipFound {
-		if ipStatus.lockedUntil.IsZero() {
-			ipLockedUntil = time.Time{}
-			if len(ipStatus.attempts) == 0 || ipStatus.attempts[0].Add(cacheAttemptsPeriod).Before(now) {
-				delete(c.ipCache, ip)
-			}
-		} else {
-			if ipStatus.lockedUntil.After(now) {
-				ipLockedUntil = ipStatus.lockedUntil
-			} else {
-				delete(c.ipCache, ip)
-				ipLockedUntil = time.Time{}
-			}
-		}
-	}
-	if accLockedUntil.After(ipLockedUntil) {
-		lockedUntil = accLockedUntil
-		lockout = accountBased
-	} else {
-		lockedUntil = ipLockedUntil
-		lockout = ipBased
-	}
-	if lockedUntil.IsZero() {
-		lockout = unlocked
-	}
-	return
-}
-
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
+	return lockoutType, lockedUntil
 }


### PR DESCRIPTION
- Adds a cache of failed login attempts, providing both account-based and IP-based lockouts after a number of failed login attempts have been received in a determined amount of time.

- The user is locked from making any further login attempts until it automatically unlocks after a period of time.

- A successful login clears the failed attempts for that account, but cached IP failed attempts only clear after the specific timespan.