### PR TITLE
Log returned error from `RowsAffected`

### DIFF
--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -607,7 +607,7 @@ func storageWriteObject(ctx context.Context, logger *zap.Logger, tx *sql.Tx, aut
 		}
 		return nil, err
 	}
-	if rowsAffected, _ := res.RowsAffected(); rowsAffected != 1 {
+	if rowsAffected, err := res.RowsAffected(); rowsAffected != 1 {
 		logger.Debug("Could not write storage object, rowsAffected error.", zap.Any("object", object), zap.String("query", query), zap.Error(err))
 		return nil, runtime.ErrStorageRejectedVersion
 	}


### PR DESCRIPTION
We encountered the following log `Could not write storage object, rowsAffected error.`. 

```
{
    "level": "debug",
    "ts": "2022-07-15T10:40:40.122Z",
    "caller": "server/core_storage.go:603",
    "msg": "Could not write storage object, rowsAffected error.",
    "query": "UPDATE storage SET value = $4, version = $5, read = $6, write = $7, update_time = now() WHERE collection = $1 AND key = $2 AND user_id = $3::UUID AND version = $8"
}
```

It doesn't happen very often but we would like to see if there any returned error here.


