### PR TITLE
Optional token parameter on unlink functions

### DIFF
--- a/server/core_unlink.go
+++ b/server/core_unlink.go
@@ -28,10 +28,6 @@ import (
 )
 
 func UnlinkApple(ctx context.Context, logger *zap.Logger, db *sql.DB, config Config, socialClient *social.Client, id uuid.UUID, token string) error {
-	if config.GetSocial().Apple.BundleId == "" {
-		return status.Error(codes.FailedPrecondition, "Apple authentication is not configured.")
-	}
-
 	params := []any{id}
 	query := `UPDATE users SET apple_id = NULL, update_time = now() WHERE id = $1`
 
@@ -331,10 +327,6 @@ func UnlinkGoogle(ctx context.Context, logger *zap.Logger, db *sql.DB, socialCli
 }
 
 func UnlinkSteam(ctx context.Context, logger *zap.Logger, db *sql.DB, config Config, socialClient *social.Client, id uuid.UUID, token string) error {
-	if config.GetSocial().Steam.PublisherKey == "" || config.GetSocial().Steam.AppID == 0 {
-		return status.Error(codes.FailedPrecondition, "Steam authentication is not configured.")
-	}
-
 	params := []any{id}
 	query := `UPDATE users SET steam_id = NULL, update_time = now() WHERE id = $1`
 

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -836,7 +836,7 @@ func (n *RuntimeGoNakamaModule) ReadFile(relPath string) (*os.File, error) {
 // @summary Unlink Apple authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Apple sign in token.
+// @param token(type=string, optional=true) Apple sign in token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkApple(ctx context.Context, userID, token string) error {
 	id, err := uuid.FromString(userID)
@@ -851,7 +851,7 @@ func (n *RuntimeGoNakamaModule) UnlinkApple(ctx context.Context, userID, token s
 // @summary Unlink custom authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The user ID to be unlinked.
-// @param customId(type=string) Custom ID to be unlinked from the user.
+// @param customId(type=string, optional=true) Custom ID to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkCustom(ctx context.Context, userID, customID string) error {
 	id, err := uuid.FromString(userID)
@@ -881,7 +881,7 @@ func (n *RuntimeGoNakamaModule) UnlinkDevice(ctx context.Context, userID, device
 // @summary Unlink email authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The user ID to be unlinked.
-// @param email(type=string) Email to be unlinked from the user.
+// @param email(type=string, optional=true) Email to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkEmail(ctx context.Context, userID, email string) error {
 	id, err := uuid.FromString(userID)
@@ -911,7 +911,7 @@ func (n *RuntimeGoNakamaModule) UnlinkFacebook(ctx context.Context, userID, toke
 // @summary Unlink Facebook Instant Game authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The user ID to be unlinked.
-// @param playerInfo(type=string) Facebook player info.
+// @param playerInfo(type=string, optional=true) Facebook player info.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkFacebookInstantGame(ctx context.Context, userID, signedPlayerInfo string) error {
 	id, err := uuid.FromString(userID)
@@ -946,7 +946,7 @@ func (n *RuntimeGoNakamaModule) UnlinkGameCenter(ctx context.Context, userID, pl
 // @summary Unlink Google authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Google OAuth access token.
+// @param token(type=string, optional=true) Google OAuth access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkGoogle(ctx context.Context, userID, token string) error {
 	id, err := uuid.FromString(userID)
@@ -961,7 +961,7 @@ func (n *RuntimeGoNakamaModule) UnlinkGoogle(ctx context.Context, userID, token 
 // @summary Unlink Steam authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Steam access token.
+// @param token(type=string, optional=true) Steam access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkSteam(ctx context.Context, userID, token string) error {
 	id, err := uuid.FromString(userID)

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -896,7 +896,7 @@ func (n *RuntimeGoNakamaModule) UnlinkEmail(ctx context.Context, userID, email s
 // @summary Unlink Facebook authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
+// @param token(type=string, optional=true) Facebook OAuth or Limited Login (JWT) access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkFacebook(ctx context.Context, userID, token string) error {
 	id, err := uuid.FromString(userID)

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -2521,7 +2521,7 @@ func (n *runtimeJavascriptNakamaModule) unlinkEmail(r *goja.Runtime) func(goja.F
 // @group authenticate
 // @summary Unlink Facebook authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
+// @param token(type=string, optional=true) Facebook OAuth or Limited Login (JWT) access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *runtimeJavascriptNakamaModule) unlinkFacebook(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2531,9 +2531,9 @@ func (n *runtimeJavascriptNakamaModule) unlinkFacebook(r *goja.Runtime) func(goj
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		token := getJsString(r, f.Argument(1))
-		if token == "" {
-			panic(r.NewTypeError("expects token string"))
+		token := ""
+		if f.Argument(1) != goja.Undefined() {
+			token = getJsString(r, f.Argument(1))
 		}
 
 		if err := UnlinkFacebook(n.ctx, n.logger, n.db, n.socialClient, n.config.GetSocial().FacebookLimitedLogin.AppId, id, token); err != nil {

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -2427,9 +2427,9 @@ func (n *runtimeJavascriptNakamaModule) unlinkApple(r *goja.Runtime) func(goja.F
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		token := getJsString(r, f.Argument(1))
-		if token == "" {
-			panic(r.NewTypeError("expects token string"))
+		token := ""
+		if f.Argument(1) != goja.Undefined() {
+			token = getJsString(r, f.Argument(1))
 		}
 
 		if err := UnlinkApple(n.ctx, n.logger, n.db, n.config, n.socialClient, id, token); err != nil {
@@ -2443,7 +2443,7 @@ func (n *runtimeJavascriptNakamaModule) unlinkApple(r *goja.Runtime) func(goja.F
 // @group authenticate
 // @summary Unlink custom authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param customId(type=string) Custom ID to be unlinked from the user.
+// @param customId(type=string, optional=true) Custom ID to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *runtimeJavascriptNakamaModule) unlinkCustom(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2453,9 +2453,9 @@ func (n *runtimeJavascriptNakamaModule) unlinkCustom(r *goja.Runtime) func(goja.
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		customID := getJsString(r, f.Argument(1))
-		if customID == "" {
-			panic(r.NewTypeError("expects custom ID string"))
+		customID := ""
+		if f.Argument(1) != goja.Undefined() {
+			customID = getJsString(r, f.Argument(1))
 		}
 
 		if err := UnlinkCustom(n.ctx, n.logger, n.db, id, customID); err != nil {
@@ -2495,7 +2495,7 @@ func (n *runtimeJavascriptNakamaModule) unlinkDevice(r *goja.Runtime) func(goja.
 // @group authenticate
 // @summary Unlink email authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param email(type=string) Email to be unlinked from the user.
+// @param email(type=string, optional=true) Email to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *runtimeJavascriptNakamaModule) unlinkEmail(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2505,9 +2505,9 @@ func (n *runtimeJavascriptNakamaModule) unlinkEmail(r *goja.Runtime) func(goja.F
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		email := getJsString(r, f.Argument(1))
-		if email == "" {
-			panic(r.NewTypeError("expects email string"))
+		email := ""
+		if f.Argument(1) != goja.Undefined() {
+			email = getJsString(r, f.Argument(1))
 		}
 
 		if err := UnlinkEmail(n.ctx, n.logger, n.db, id, email); err != nil {
@@ -2547,7 +2547,7 @@ func (n *runtimeJavascriptNakamaModule) unlinkFacebook(r *goja.Runtime) func(goj
 // @group authenticate
 // @summary Unlink Facebook Instant Game authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param playerInfo(type=string) Facebook player info.
+// @param playerInfo(type=string, optional=true) Facebook player info.
 // @return error(error) An optional error value if an error occurred.
 func (n *runtimeJavascriptNakamaModule) unlinkFacebookInstantGame(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2557,9 +2557,9 @@ func (n *runtimeJavascriptNakamaModule) unlinkFacebookInstantGame(r *goja.Runtim
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		signedPlayerInfo := getJsString(r, f.Argument(1))
-		if signedPlayerInfo == "" {
-			panic(r.NewTypeError("expects signed player info string"))
+		signedPlayerInfo := ""
+		if f.Argument(1) != goja.Undefined() {
+			signedPlayerInfo = getJsString(r, f.Argument(1))
 		}
 
 		if err := UnlinkFacebookInstantGame(n.ctx, n.logger, n.db, n.config, n.socialClient, id, signedPlayerInfo); err != nil {
@@ -2588,29 +2588,29 @@ func (n *runtimeJavascriptNakamaModule) unlinkGameCenter(r *goja.Runtime) func(g
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		playerID := getJsString(r, f.Argument(1))
-		if playerID == "" {
-			panic(r.NewTypeError("expects player ID string"))
+		playerID := ""
+		if f.Argument(1) != goja.Undefined() {
+			playerID = getJsString(r, f.Argument(1))
 		}
-		bundleID := getJsString(r, f.Argument(2))
-		if bundleID == "" {
-			panic(r.NewTypeError("expects bundle ID string"))
+		bundleID := ""
+		if f.Argument(2) != goja.Undefined() {
+			bundleID = getJsString(r, f.Argument(2))
 		}
-		ts := getJsInt(r, f.Argument(3))
-		if ts == 0 {
-			panic(r.NewTypeError("expects timestamp value"))
+		ts := int64(0)
+		if f.Argument(3) != goja.Undefined() {
+			ts = getJsInt(r, f.Argument(3))
 		}
-		salt := getJsString(r, f.Argument(4))
-		if salt == "" {
-			panic(r.NewTypeError("expects salt string"))
+		salt := ""
+		if f.Argument(4) != goja.Undefined() {
+			salt = getJsString(r, f.Argument(4))
 		}
-		signature := getJsString(r, f.Argument(5))
-		if signature == "" {
-			panic(r.NewTypeError("expects signature string"))
+		signature := ""
+		if f.Argument(5) != goja.Undefined() {
+			signature = getJsString(r, f.Argument(5))
 		}
-		publicKeyURL := getJsString(r, f.Argument(6))
-		if publicKeyURL == "" {
-			panic(r.NewTypeError("expects public key URL string"))
+		publicKeyURL := ""
+		if f.Argument(6) != goja.Undefined() {
+			publicKeyURL = getJsString(r, f.Argument(6))
 		}
 
 		if err := UnlinkGameCenter(n.ctx, n.logger, n.db, n.socialClient, id, playerID, bundleID, ts, salt, signature, publicKeyURL); err != nil {
@@ -2624,7 +2624,7 @@ func (n *runtimeJavascriptNakamaModule) unlinkGameCenter(r *goja.Runtime) func(g
 // @group authenticate
 // @summary Unlink Google authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Google OAuth access token.
+// @param token(type=string, optional=true) Google OAuth access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *runtimeJavascriptNakamaModule) unlinkGoogle(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2634,9 +2634,9 @@ func (n *runtimeJavascriptNakamaModule) unlinkGoogle(r *goja.Runtime) func(goja.
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		token := getJsString(r, f.Argument(1))
-		if token == "" {
-			panic(r.NewTypeError("expects token string"))
+		token := ""
+		if f.Argument(1) != goja.Undefined() {
+			token = getJsString(r, f.Argument(1))
 		}
 
 		if err := UnlinkGoogle(n.ctx, n.logger, n.db, n.socialClient, id, token); err != nil {
@@ -2650,7 +2650,7 @@ func (n *runtimeJavascriptNakamaModule) unlinkGoogle(r *goja.Runtime) func(goja.
 // @group authenticate
 // @summary Unlink Steam authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Steam access token.
+// @param token(type=string, optional=true) Steam access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *runtimeJavascriptNakamaModule) unlinkSteam(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2660,9 +2660,9 @@ func (n *runtimeJavascriptNakamaModule) unlinkSteam(r *goja.Runtime) func(goja.F
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		token := getJsString(r, f.Argument(1))
-		if token == "" {
-			panic(r.NewTypeError("expects token string"))
+		token := ""
+		if f.Argument(1) != goja.Undefined() {
+			token = getJsString(r, f.Argument(1))
 		}
 
 		if err := UnlinkSteam(n.ctx, n.logger, n.db, n.config, n.socialClient, id, token); err != nil {

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -3220,7 +3220,7 @@ func (n *RuntimeLuaNakamaModule) unlinkEmail(l *lua.LState) int {
 // @group authenticate
 // @summary Unlink Facebook authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
+// @param token(type=string, optional=true) Facebook OAuth or Limited Login (JWT) access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) unlinkFacebook(l *lua.LState) int {
 	userID := l.CheckString(1)
@@ -3230,11 +3230,7 @@ func (n *RuntimeLuaNakamaModule) unlinkFacebook(l *lua.LState) int {
 		return 0
 	}
 
-	token := l.CheckString(2)
-	if token == "" {
-		l.ArgError(2, "expects token string")
-		return 0
-	}
+	token := l.OptString(2, "")
 
 	if err := UnlinkFacebook(l.Context(), n.logger, n.db, n.socialClient, n.config.GetSocial().FacebookLimitedLogin.AppId, id, token); err != nil {
 		l.RaiseError("error unlinking: %v", err.Error())

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -3120,7 +3120,7 @@ func (n *RuntimeLuaNakamaModule) linkSteam(l *lua.LState) int {
 // @group authenticate
 // @summary Unlink Apple authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Apple sign in token.
+// @param token(type=string, optional=true) Apple sign in token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) unlinkApple(l *lua.LState) int {
 	userID := l.CheckString(1)
@@ -3130,11 +3130,7 @@ func (n *RuntimeLuaNakamaModule) unlinkApple(l *lua.LState) int {
 		return 0
 	}
 
-	token := l.CheckString(2)
-	if token == "" {
-		l.ArgError(2, "expects token string")
-		return 0
-	}
+	token := l.OptString(2, "")
 
 	if err := UnlinkApple(l.Context(), n.logger, n.db, n.config, n.socialClient, id, token); err != nil {
 		l.RaiseError("error unlinking: %v", err.Error())
@@ -3145,7 +3141,7 @@ func (n *RuntimeLuaNakamaModule) unlinkApple(l *lua.LState) int {
 // @group authenticate
 // @summary Unlink custom authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param customId(type=string) Custom ID to be unlinked from the user.
+// @param customId(type=string, optional=true) Custom ID to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) unlinkCustom(l *lua.LState) int {
 	userID := l.CheckString(1)
@@ -3155,11 +3151,7 @@ func (n *RuntimeLuaNakamaModule) unlinkCustom(l *lua.LState) int {
 		return 0
 	}
 
-	customID := l.CheckString(2)
-	if customID == "" {
-		l.ArgError(2, "expects custom ID string")
-		return 0
-	}
+	customID := l.OptString(2, "")
 
 	if err := UnlinkCustom(l.Context(), n.logger, n.db, id, customID); err != nil {
 		l.RaiseError("error unlinking: %v", err.Error())
@@ -3195,7 +3187,7 @@ func (n *RuntimeLuaNakamaModule) unlinkDevice(l *lua.LState) int {
 // @group authenticate
 // @summary Unlink email authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param email(type=string) Email to be unlinked from the user.
+// @param email(type=string, optional=true) Email to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) unlinkEmail(l *lua.LState) int {
 	userID := l.CheckString(1)
@@ -3205,11 +3197,7 @@ func (n *RuntimeLuaNakamaModule) unlinkEmail(l *lua.LState) int {
 		return 0
 	}
 
-	email := l.CheckString(2)
-	if email == "" {
-		l.ArgError(2, "expects email string")
-		return 0
-	}
+	email := l.OptString(2, "")
 
 	if err := UnlinkEmail(l.Context(), n.logger, n.db, id, email); err != nil {
 		l.RaiseError("error unlinking: %v", err.Error())
@@ -3241,7 +3229,7 @@ func (n *RuntimeLuaNakamaModule) unlinkFacebook(l *lua.LState) int {
 // @group authenticate
 // @summary Unlink Facebook Instant Game authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param playerInfo(type=string) Facebook player info.
+// @param playerInfo(type=string, optional=true) Facebook player info.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) unlinkFacebookInstantGame(l *lua.LState) int {
 	userID := l.CheckString(1)
@@ -3251,11 +3239,7 @@ func (n *RuntimeLuaNakamaModule) unlinkFacebookInstantGame(l *lua.LState) int {
 		return 0
 	}
 
-	signedPlayerInfo := l.CheckString(2)
-	if signedPlayerInfo == "" {
-		l.ArgError(2, "expects signed player info string")
-		return 0
-	}
+	signedPlayerInfo := l.OptString(2, "")
 
 	if err := UnlinkFacebookInstantGame(l.Context(), n.logger, n.db, n.config, n.socialClient, id, signedPlayerInfo); err != nil {
 		l.RaiseError("error unlinking: %v", err.Error())
@@ -3281,33 +3265,33 @@ func (n *RuntimeLuaNakamaModule) unlinkGameCenter(l *lua.LState) int {
 		return 0
 	}
 
-	playerID := l.CheckString(2)
-	if playerID == "" {
-		l.ArgError(2, "expects player ID string")
-		return 0
+	setArgs := false
+	playerID := l.OptString(2, "")
+	if playerID != "" {
+		setArgs = true
 	}
-	bundleID := l.CheckString(3)
-	if bundleID == "" {
+	bundleID := l.OptString(3, "")
+	if bundleID == "" && setArgs {
 		l.ArgError(3, "expects bundle ID string")
 		return 0
 	}
-	ts := l.CheckInt64(4)
-	if ts == 0 {
+	ts := l.OptInt64(4, 0)
+	if ts == 0 && setArgs {
 		l.ArgError(4, "expects timestamp value")
 		return 0
 	}
-	salt := l.CheckString(5)
-	if salt == "" {
+	salt := l.OptString(5, "")
+	if salt == "" && setArgs {
 		l.ArgError(5, "expects salt string")
 		return 0
 	}
-	signature := l.CheckString(6)
-	if signature == "" {
+	signature := l.OptString(6, "")
+	if signature == "" && setArgs {
 		l.ArgError(6, "expects signature string")
 		return 0
 	}
-	publicKeyURL := l.CheckString(7)
-	if publicKeyURL == "" {
+	publicKeyURL := l.OptString(7, "")
+	if publicKeyURL == "" && setArgs {
 		l.ArgError(7, "expects public key URL string")
 		return 0
 	}
@@ -3321,7 +3305,7 @@ func (n *RuntimeLuaNakamaModule) unlinkGameCenter(l *lua.LState) int {
 // @group authenticate
 // @summary Unlink Google authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Google OAuth access token.
+// @param token(type=string, optional=true) Google OAuth access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) unlinkGoogle(l *lua.LState) int {
 	userID := l.CheckString(1)
@@ -3331,11 +3315,7 @@ func (n *RuntimeLuaNakamaModule) unlinkGoogle(l *lua.LState) int {
 		return 0
 	}
 
-	token := l.CheckString(2)
-	if token == "" {
-		l.ArgError(2, "expects token string")
-		return 0
-	}
+	token := l.OptString(2, "")
 
 	if err := UnlinkGoogle(l.Context(), n.logger, n.db, n.socialClient, id, token); err != nil {
 		l.RaiseError("error unlinking: %v", err.Error())
@@ -3346,7 +3326,7 @@ func (n *RuntimeLuaNakamaModule) unlinkGoogle(l *lua.LState) int {
 // @group authenticate
 // @summary Unlink Steam authentication from a user ID.
 // @param userId(type=string) The user ID to be unlinked.
-// @param token(type=string) Steam access token.
+// @param token(type=string, optional=true) Steam access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) unlinkSteam(l *lua.LState) int {
 	userID := l.CheckString(1)
@@ -3356,11 +3336,7 @@ func (n *RuntimeLuaNakamaModule) unlinkSteam(l *lua.LState) int {
 		return 0
 	}
 
-	token := l.CheckString(2)
-	if token == "" {
-		l.ArgError(2, "expects token string")
-		return 0
-	}
+	token := l.OptString(2, "")
 
 	if err := UnlinkSteam(l.Context(), n.logger, n.db, n.config, n.socialClient, id, token); err != nil {
 		l.RaiseError("error unlinking: %v", err.Error())


### PR DESCRIPTION
Unlink functions will still accept the token parameter, providing the option of a more restrictive "check-if-exists" unlink action.

Resolves #366 