### PR TITLE
Account party only once when finding candidates to remove to round down to CountMultple

### DIFF
--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -203,7 +203,7 @@ type LocalMatchmaker struct {
 	indexWriter      *bluge.Writer
 	sessionTickets   map[string]map[string]struct{}
 	partyTickets     map[string]map[string]struct{}
-	entries          map[string][]*MatchmakerEntry
+	entries          map[string][]*MatchmakerEntry // all presences for a given ticket
 	indexes          map[string]*MatchmakerIndex
 	activeIndexes    map[string]*MatchmakerIndex
 	revCache         map[string]map[string]bool
@@ -486,6 +486,8 @@ func (m *LocalMatchmaker) Process() {
 					break
 				}
 			}
+
+			// either processing first hit or current hit entries combined with previous hits will tip over index.MaxCount
 			if foundCombo == nil {
 				entryCombo := make([]*MatchmakerEntry, len(entries))
 				copy(entryCombo, entries)
@@ -528,7 +530,6 @@ func (m *LocalMatchmaker) Process() {
 						for i := 0; i < len(foundCombo); i++ {
 							if egIndex.Ticket == foundCombo[i].Ticket {
 								foundCombo[i] = foundCombo[len(foundCombo)-1]
-								foundCombo[len(foundCombo)-1] = nil
 								foundCombo = foundCombo[:len(foundCombo)-1]
 								break
 							}

--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -507,13 +507,18 @@ func (m *LocalMatchmaker) Process() {
 					// The size of the combination being considered does not satisfy the count multiple.
 					// Attempt to adjust the combo by removing the smallest possible number of entries.
 					// Prefer keeping entries that have been in the matchmaker the longest, if possible.
-					eligibleIndexes := make([]*MatchmakerIndex, 0, len(foundCombo))
+					eligibleIndexesUniq := make(map[*MatchmakerIndex]struct{}, len(foundCombo))
 					for _, e := range foundCombo {
 						// Only tickets individually less <= the removable size are considered.
 						// For example removing a party of 3 when we're only looking to remove 2 is not allowed.
 						if foundIndex, ok := m.indexes[e.Ticket]; ok && foundIndex.Count <= rem {
-							eligibleIndexes = append(eligibleIndexes, foundIndex)
+							eligibleIndexesUniq[foundIndex] = struct{}{}
 						}
+					}
+
+					eligibleIndexes := make([]*MatchmakerIndex, 0, len(eligibleIndexesUniq))
+					for _, egi := range eligibleIndexes {
+						eligibleIndexes = append(eligibleIndexes, egi)
 					}
 
 					eligibleGroups := groupIndexes(eligibleIndexes, rem)

--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -536,7 +536,6 @@ func (m *LocalMatchmaker) Process() {
 							if egIndex.Ticket == foundCombo[i].Ticket {
 								foundCombo[i] = foundCombo[len(foundCombo)-1]
 								foundCombo = foundCombo[:len(foundCombo)-1]
-								break
 							}
 						}
 					}


### PR DESCRIPTION
CountMultiple matchmaking attempts to reduce number of matched entries
if MinCount is satisfied, but MaxCount is not.  When party enters matchmaking
all party members either get matched or not, so party as a whole need to be
removed when doing adjusting. 

There can be multiple candidate tickets (players or parties) to removal. Matchmaking
tries to group them and find best (by wait time) group to keep, rest gets removing.

When grouping happens, every ticket should be presented only once, otherwise it makes 
candidate group count number of players incorrect.