### PR TITLE
fixed sql query missing param GetPurchaseByTransactionID

### DIFF
--- a/server/core_purchase.go
+++ b/server/core_purchase.go
@@ -294,6 +294,7 @@ SELECT
     transaction_id,
     product_id,
     store,
+	raw_response,
     purchase_time,
     create_time,
     update_time,


### PR DESCRIPTION
PurchaseGetByTransactionId currently scans 9 arguments but is only populated with 8 fields in the sql query.
Added the missing param to match full request.