### PR TITLE
Fix CountMultiple rounding down

### DIFF
--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -522,8 +522,8 @@ func (m *LocalMatchmaker) Process() {
 					}
 
 					eligibleIndexes := make([]*MatchmakerIndex, 0, len(eligibleIndexesUniq))
-					for _, egi := range eligibleIndexes {
-						eligibleIndexes = append(eligibleIndexes, egi)
+					for idx := range eligibleIndexesUniq {
+						eligibleIndexes = append(eligibleIndexes, idx)
 					}
 
 					eligibleGroups := groupIndexes(eligibleIndexes, rem)


### PR DESCRIPTION
Due to a typo, eligibleIndexes were always empty and as a result "rounding down" to a countMultiple didn't work in practice.