### PR TITLE
Split matchmaker.Process into smaller functions for readability

### DIFF
--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -300,7 +300,7 @@ func (m *LocalMatchmaker) Process() {
 	indexCount := len(m.indexes)
 
 	defer func() {
-		m.metrics.Matchmaker(float64(indexCount), float64(activeIndexCount), time.Now().Sub(startTime))
+		m.metrics.Matchmaker(float64(indexCount), float64(activeIndexCount), time.Since(startTime))
 	}()
 
 	// No active matchmaking tickets, the pool may be non-empty but there are no new tickets to check/query with.

--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -439,7 +439,7 @@ func (m *LocalMatchmaker) Process() {
 				continue
 			}
 
-			entries, ok := m.entries[hit.ID]
+			hitEntries, ok := m.entries[hit.ID]
 			if !ok {
 				// Ticket did not exist, should not happen.
 				m.logger.Warn("matchmaker process missing entries", zap.String("ticket", hit.ID))
@@ -450,7 +450,7 @@ func (m *LocalMatchmaker) Process() {
 			var foundCombo []*MatchmakerEntry
 			var mutualMatchConflict bool
 			for entryComboIdx, entryCombo := range entryCombos {
-				if len(entryCombo)+len(entries)+index.Count <= index.MaxCount {
+				if len(entryCombo)+len(hitEntries)+index.Count <= index.MaxCount {
 					// There is room in this combo for these entries. Check if there are session ID conflicts with current combo.
 					for _, entry := range entryCombo {
 						if _, found := hitIndex.SessionIDs[entry.Presence.SessionId]; found {
@@ -489,7 +489,7 @@ func (m *LocalMatchmaker) Process() {
 						continue
 					}
 
-					entryCombo = append(entryCombo, entries...)
+					entryCombo = append(entryCombo, hitEntries...)
 					entryCombos[entryComboIdx] = entryCombo
 
 					foundCombo = entryCombo
@@ -499,8 +499,8 @@ func (m *LocalMatchmaker) Process() {
 			}
 			// Either processing first hit, or current hit entries combined with previous hits may tip over index.MaxCount.
 			if foundCombo == nil {
-				entryCombo := make([]*MatchmakerEntry, len(entries))
-				copy(entryCombo, entries)
+				entryCombo := make([]*MatchmakerEntry, len(hitEntries))
+				copy(entryCombo, hitEntries)
 				entryCombos = append(entryCombos, entryCombo)
 
 				foundCombo = entryCombo

--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -292,8 +292,6 @@ func (m *LocalMatchmaker) OnMatchedEntries(fn func(entries [][]*MatchmakerEntry)
 }
 
 func (m *LocalMatchmaker) Process() {
-	matchedEntries := make([][]*MatchmakerEntry, 0, 5)
-
 	startTime := time.Now()
 
 	m.Lock()
@@ -318,6 +316,7 @@ func (m *LocalMatchmaker) Process() {
 		defer timer.Stop()
 	}
 
+	var matchedEntries [][]*MatchmakerEntry
 	for ticket, index := range m.activeIndexes {
 		if !threshold && timer != nil {
 			select {
@@ -540,7 +539,7 @@ func (m *LocalMatchmaker) Process() {
 					m.logger.Warn("matchmaker process missing entries", zap.String("ticket", hit.ID))
 					break
 				}
-				matchedEntries = m.finalizeMatchMaking(ticketEntries, foundCombo, matchedEntries)
+				matchedEntries = m.finalizeMatchMaking(ticketEntries, foundCombo)
 
 				break
 			}
@@ -665,7 +664,8 @@ func (m *LocalMatchmaker) roundToCountMultiple(foundCombo []*MatchmakerEntry, re
 	return foundCombo, true
 }
 
-func (m *LocalMatchmaker) finalizeMatchMaking(entries []*MatchmakerEntry, foundCombo []*MatchmakerEntry, matchedEntries [][]*MatchmakerEntry) [][]*MatchmakerEntry {
+func (m *LocalMatchmaker) finalizeMatchMaking(entries []*MatchmakerEntry, foundCombo []*MatchmakerEntry) [][]*MatchmakerEntry {
+	matchedEntries := make([][]*MatchmakerEntry, 0, 5)
 	currentMatchedEntries := append(foundCombo, entries...)
 
 	matchedEntries = append(matchedEntries, currentMatchedEntries)

--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -548,6 +548,11 @@ func (m *LocalMatchmaker) Process() {
 
 	m.Unlock()
 
+	m.sendMatchMakingResult(matchedEntries)
+}
+
+// sendMatchMakingResult notifies all presences which found their match
+func (m *LocalMatchmaker) sendMatchMakingResult(matchedEntries [][]*MatchmakerEntry) {
 	if matchedEntriesCount := len(matchedEntries); matchedEntriesCount > 0 {
 		wg := &sync.WaitGroup{}
 		wg.Add(matchedEntriesCount)


### PR DESCRIPTION
matchmaker.Process was one big hard to follow function. This PR attempts to extract isolated pieces of logic into own function.

It is probably best to review on commit by commit basis, rather than in PR diff interface.

All commits except last two are either trivial changes or result of IDE's refactor tool, so very mechanical in essence and chance of introducing bugs is minimal. Only manual input required in these refactors was to bubble up `break`/`continue` control statements from within function via bool return param.


Last two commits are more substantial:

- https://github.com/heroiclabs/nakama/pull/943/commits/ccf77ab5650583b9e7228237ce1648fe1b82737d (and preceeding https://github.com/heroiclabs/nakama/pull/943/commits/8de9f0fe822c581d9e13eb801c724161c64a2db7): unifies conflict check between indexes. We have 3 conflicts checks: hit -> current index,  each combo entry -> hit and hit -> each combo entry. All three are now done with the same function accepting 2 indexes and a boolean flag to check whether reverse conflict check is required.

- https://github.com/heroiclabs/nakama/pull/943/commits/19b9ecf59c14bf9d36b8f86f4203058d6a7ff315 : atomic unit of matchmaking is matchmaking index, but MM logic used to operate on entries, which required converting to index in multiple places. This commits makes MM loop to operate on indexes, producing final entries only at the very end.

