### PR TITLE
fix(matchmaker): update total count after rounding to CountMultiple

### DIFF
--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -456,6 +456,7 @@ func (m *LocalMatchmaker) Process() {
 					if !ok {
 						continue
 					}
+					l = sumCount(foundCombo) + index.Count
 				}
 
 				// Check that ALL of these conditions are true for ALL matched entries:


### PR DESCRIPTION
After roundToCountMultiple successfully removes some tickets to satisfy CountMultiple we need to update total number of players in the candidate match (found combo + current index)

Previously final Min/Max/Multiple count check for each selected ticket (MatchmakerIndex) was done against stale total count.

**NOTE**: Bug is present in master, but  PR targets in progress readability PR, not master