### PR TITLE
Fix storage update query.

### DIFF
--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -596,7 +596,7 @@ func storageWriteObject(ctx context.Context, logger *zap.Logger, metrics Metrics
 	case !dbVersion.Valid && object.Version == "":
 		// An existing storage object was not present, and no OCC of any kind is specified.
 		// Separate to the case above to handle concurrent non-OCC object creations, where all but the first must become updates.
-		query = "INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time) VALUES ($1, $2, $3::UUID, $4, $5, $6, $7, now(), now()) ON CONFLICT (collection, read, key, user_id) DO UPDATE SET value = $4, version = $5, read = $6, write = $7, update_time = now()"
+		query = "INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time) VALUES ($1, $2, $3::UUID, $4, $5, $6, $7, now(), now()) ON CONFLICT (collection, key, user_id) DO UPDATE SET value = $4, version = $5, read = $6, write = $7, update_time = now()"
 		// Respect permissions in non-authoritative writes, where this operation also loses the race to insert the object.
 		if !authoritativeWrite {
 			query += " WHERE storage.write = 1"


### PR DESCRIPTION
Currently there are 2 unique indexes on the table:
```
"storage_pkey" PRIMARY KEY, btree (collection, read, key, user_id)
"storage_collection_key_user_id_key" UNIQUE CONSTRAINT, btree (collection, key, user_id)
```

Only latter trully constraint uniqueness, because it is a subset of former. When using ON CONFLICT, most specific index of these two should be used, otherwise if `read` column is updated it might attempt to insert into table violating unique constraint.