### PR TITLE
Demonstrator how we can get away with just single unique index

### DIFF
--- a/migrate/sql/20230208224400-storage-optimize-idx.sql
+++ b/migrate/sql/20230208224400-storage-optimize-idx.sql
@@ -1,0 +1,6 @@
+ALTER TABLE storage
+  drop constraint storage_pkey, add primary key using index "storage_collection_key_user_id_key";
+
+DROP INDEX storage_pkey RESTRICT;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS collection_user_id_key_idx ON storage (collection, user_id, key);

--- a/migrate/sql/20230208224400-storage-optimize-idx.sql
+++ b/migrate/sql/20230208224400-storage-optimize-idx.sql
@@ -1,6 +1,13 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS storage_collection_user_id_key_idx ON storage (collection, user_id, key);
+
+--TODO: wait for index to complete
+
 ALTER TABLE storage
-  drop constraint storage_pkey, add primary key using index "storage_collection_key_user_id_key";
+  drop constraint storage_pkey, add primary key using index "storage_collection_user_id_key_idx";
 
 DROP INDEX storage_pkey RESTRICT;
+DROP INDEX storage_collection_key_user_id_key RESTRICT;
+DROP INDEX collection_read_user_id_key_idx RESTRICT;
+DROP INDEX collection_user_id_read_key_idx RESTRICT;
 
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS collection_user_id_key_idx ON storage (collection, user_id, key);
+

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -590,7 +590,7 @@ func storageWriteObject(ctx context.Context, logger *zap.Logger, metrics Metrics
 	case !dbVersion.Valid && object.Version == "":
 		// An existing storage object was not present, and no OCC of any kind is specified.
 		// Separate to the case above to handle concurrent non-OCC object creations, where all but the first must become updates.
-		query = "INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time) VALUES ($1, $2, $3::UUID, $4, $5, $6, $7, now(), now()) ON CONFLICT (collection, key, user_id) DO UPDATE SET value = $4, version = $5, read = $6, write = $7, update_time = now()"
+		query = "INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time) VALUES ($1, $2, $3::UUID, $4, $5, $6, $7, now(), now()) ON CONFLICT (collection, user_id, key) DO UPDATE SET value = $4, version = $5, read = $6, write = $7, update_time = now()"
 		// Respect permissions in non-authoritative writes, where this operation also loses the race to insert the object.
 		if !authoritativeWrite {
 			query += " WHERE storage.write = 1"

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -151,7 +151,7 @@ func StorageListObjectsAll(ctx context.Context, logger *zap.Logger, db *sql.DB, 
 	cursorQuery := ""
 	params := []interface{}{collection, limit + 1}
 	if storageCursor != nil {
-		cursorQuery = ` AND (collection, user_id, key) > ($1, $3, $4) `
+		cursorQuery = ` AND (user_id, key) > ($3, $4) `
 		params = append(params, storageCursor.UserID, storageCursor.Key)
 	}
 

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -151,9 +151,8 @@ func StorageListObjectsAll(ctx context.Context, logger *zap.Logger, db *sql.DB, 
 	cursorQuery := ""
 	params := []interface{}{collection, limit + 1}
 	if storageCursor != nil {
-		//TODO: check if we can reorder collection,user_id, key
-		cursorQuery = ` AND (collection, key, user_id) > ($1, $3, $4) `
-		params = append(params, storageCursor.Key, storageCursor.UserID)
+		cursorQuery = ` AND (collection, user_id, key) > ($1, $3, $4) `
+		params = append(params, storageCursor.UserID, storageCursor.Key)
 	}
 
 	var query string
@@ -162,14 +161,14 @@ func StorageListObjectsAll(ctx context.Context, logger *zap.Logger, db *sql.DB, 
 SELECT collection, key, user_id, value, version, read, write, create_time, update_time
 FROM storage
 WHERE collection = $1` + cursorQuery + `
-ORDER BY key ASC, user_id ASC
+ORDER BY user_id ASC, key ASC
 LIMIT $2`
 	} else {
 		query = `
 SELECT collection, key, user_id, value, version, read, write, create_time, update_time
 FROM storage
 WHERE collection = $1 AND read >= 2` + cursorQuery + `
-ORDER BY key ASC, user_id ASC
+ORDER BY user_id ASC, key ASC
 LIMIT $2`
 	}
 

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -241,7 +241,7 @@ func StorageListObjectsUser(ctx context.Context, logger *zap.Logger, db *sql.DB,
 	params := []interface{}{collection, userID, limit + 1}
 	if storageCursor != nil {
 		// User ID is always a known user based on the type of the listing operation.
-		cursorQuery = ` AND key > $5 `
+		cursorQuery = ` AND key > $4 `
 		params = append(params, storageCursor.Key)
 	}
 


### PR DESCRIPTION
This shows how instead of 4 indexes (396GB) (all of which are unique, but not all of them are marked as such in DB):

```
    "storage_pkey" PRIMARY KEY, btree (collection, read, key, user_id)  (78GB)
    "collection_read_user_id_key_idx" btree (collection, read, user_id, key)  (122GB)
    "collection_user_id_read_key_idx" btree (collection, user_id, read, key) (122GB)
    "storage_collection_key_user_id_key" UNIQUE CONSTRAINT, btree (collection, key, user_id)  (74GB)
```


we can have just one unique (primary key) index of 74GB:

```
"storage_collection_user_id_key_idx" btree (collection, user_id, key)   (~74GB)
```



I reviewed every query to check that index will be used (did run some, but not all, for rest  assumed what PG will do). All requsts have collection fixed and many have `user_id` fixed as well, leaving `key` to be actually queried. where `user_id` is not fixed, it is used in the pagination key, so it is still using index. 

Main changes in this PR are:
- `read` column is gone from all indexes. 
- Pagination cursor uses only ORDER BY columns. I verified with PG11 it continues to use index if leading index columns like `collection` are fixed by WHERE, so no need for them to be in the cursor
- StorageListObjectsAll returns objects ordered by `(collection,user_id,key)` instead of `(collection, read, key, user_id)`. I dont think we guarantee order of returned objects as long as we return all of them it is not a breaking change, but it allows us to removes indexes


Not mergeable AS-IS because migration need to be more sophisticated

