### PR TITLE
Fix outdated username in session after UpdateAccount call.

### DIFF
--- a/server/api_account.go
+++ b/server/api_account.go
@@ -163,6 +163,10 @@ func (s *ApiServer) UpdateAccount(ctx context.Context, in *api.UpdateAccountRequ
 		}
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if in.GetUsername() != nil {
+			session := s.sessionRegistry.Get(userID)
+			session.SetUsername(username)
+	}
 
 	// After hook.
 	if fn := s.runtime.AfterUpdateAccount(); fn != nil {


### PR DESCRIPTION
When a client calls UpdateAccount with a new username, it is not fully propogated through the session. One of the places where this can be noticed is within the Match Handler. The presence provided uses the old username of the account and does not properly update until a new session for the user is created.

The username is queried from the session on server/pipeline_match.go:183 (at the time of this commit). Simply updating the session should fix this.

One potential thing that I haven't had the chance to test is, if multiple sessions for the same user are active, and one updates their username, this might not be properly pushed to other sessions, even with the current implementation.

When UpdateAccount is called with a new username and it is successfully updated, the session's stored username is also updated, so subsequent requests on the same session should have the most up-to-date information.