### PR TITLE
Support purchases-not-null-uid.sql migration crdb.

### DIFF
--- a/migrate/sql/20230222172540-purchases-not-null-uid-1.sql
+++ b/migrate/sql/20230222172540-purchases-not-null-uid-1.sql
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
--- +migrate Up notransaction
+-- +migrate Up
+-- This migration is split in two files due to the following CRDB limitation
 -- https://stackoverflow.com/questions/68803747/encapsulating-a-drop-and-add-constraint-in-a-transaction
 ALTER TABLE purchase
     DROP CONSTRAINT IF EXISTS purchase_user_id_fkey,
@@ -28,36 +29,9 @@ UPDATE purchase
 UPDATE subscription
     SET user_id = '00000000-0000-0000-0000-000000000000' WHERE user_id IS NULL;
 
-ALTER TABLE purchase
-    ALTER COLUMN user_id SET NOT NULL,
-    ALTER COLUMN user_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
-
-ALTER TABLE subscription
-    ALTER COLUMN user_id SET NOT NULL,
-    ALTER COLUMN user_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
-
-ALTER TABLE purchase
-    ADD CONSTRAINT purchase_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET DEFAULT;
-ALTER TABLE subscription
-    ADD CONSTRAINT subscription_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET DEFAULT;
-
--- +migrate Down notransaction
+-- +migrate Down
+-- This migration is split in two files due to the following CRDB limitation
 -- https://stackoverflow.com/questions/68803747/encapsulating-a-drop-and-add-constraint-in-a-transaction
-ALTER TABLE purchase
-    DROP CONSTRAINT IF EXISTS purchase_user_id_fkey,
-    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
-ALTER TABLE subscription
-    DROP CONSTRAINT IF EXISTS subscription_user_id_fkey,
-    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
-
-ALTER TABLE purchase
-    ALTER COLUMN user_id DROP DEFAULT,
-    ALTER COLUMN user_id DROP NOT NULL;
-
-ALTER TABLE subscription
-    ALTER COLUMN user_id DROP DEFAULT,
-    ALTER COLUMN user_id DROP NOT NULL;
-
 UPDATE purchase
     SET user_id = NULL WHERE user_id = '00000000-0000-0000-0000-000000000000';
 UPDATE subscription

--- a/migrate/sql/20230222172540-purchases-not-null-uid-2.sql
+++ b/migrate/sql/20230222172540-purchases-not-null-uid-2.sql
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 The Nakama Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- +migrate Up
+-- This migration is split in two files due to the following CRDB limitation
+-- https://stackoverflow.com/questions/68803747/encapsulating-a-drop-and-add-constraint-in-a-transaction
+ALTER TABLE purchase
+    ALTER COLUMN user_id SET NOT NULL,
+    ALTER COLUMN user_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
+ALTER TABLE subscription
+    ALTER COLUMN user_id SET NOT NULL,
+    ALTER COLUMN user_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
+
+ALTER TABLE purchase
+    ADD CONSTRAINT purchase_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET DEFAULT;
+ALTER TABLE subscription
+    ADD CONSTRAINT subscription_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET DEFAULT;
+
+-- +migrate Down
+-- This migration is split in two files due to the following CRDB limitation
+-- https://stackoverflow.com/questions/68803747/encapsulating-a-drop-and-add-constraint-in-a-transaction
+ALTER TABLE purchase
+    DROP CONSTRAINT IF EXISTS purchase_user_id_fkey,
+    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
+ALTER TABLE subscription
+    DROP CONSTRAINT IF EXISTS subscription_user_id_fkey,
+    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
+
+ALTER TABLE purchase
+    ALTER COLUMN user_id DROP DEFAULT,
+    ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE subscription
+    ALTER COLUMN user_id DROP DEFAULT,
+    ALTER COLUMN user_id DROP NOT NULL;

--- a/migrate/sql/20230222172540-purchases-not-null-uid.sql
+++ b/migrate/sql/20230222172540-purchases-not-null-uid.sql
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
--- +migrate Up
+-- +migrate Up notransaction
+-- https://stackoverflow.com/questions/68803747/encapsulating-a-drop-and-add-constraint-in-a-transaction
 ALTER TABLE purchase
-    DROP CONSTRAINT purchase_user_id_fkey;
+    DROP CONSTRAINT IF EXISTS purchase_user_id_fkey,
+    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
 ALTER TABLE subscription
-    DROP CONSTRAINT subscription_user_id_fkey;
+    DROP CONSTRAINT IF EXISTS subscription_user_id_fkey,
+    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
 
 UPDATE purchase
     SET user_id = '00000000-0000-0000-0000-000000000000' WHERE user_id IS NULL;
@@ -26,13 +29,11 @@ UPDATE subscription
     SET user_id = '00000000-0000-0000-0000-000000000000' WHERE user_id IS NULL;
 
 ALTER TABLE purchase
-    ALTER COLUMN user_id SET NOT NULL;
-ALTER TABLE purchase
+    ALTER COLUMN user_id SET NOT NULL,
     ALTER COLUMN user_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
 
 ALTER TABLE subscription
-    ALTER COLUMN user_id SET NOT NULL;
-ALTER TABLE subscription
+    ALTER COLUMN user_id SET NOT NULL,
     ALTER COLUMN user_id SET DEFAULT '00000000-0000-0000-0000-000000000000';
 
 ALTER TABLE purchase
@@ -40,20 +41,21 @@ ALTER TABLE purchase
 ALTER TABLE subscription
     ADD CONSTRAINT subscription_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET DEFAULT;
 
--- +migrate Down
+-- +migrate Down notransaction
+-- https://stackoverflow.com/questions/68803747/encapsulating-a-drop-and-add-constraint-in-a-transaction
 ALTER TABLE purchase
-    DROP CONSTRAINT purchase_user_id_fkey;
+    DROP CONSTRAINT IF EXISTS purchase_user_id_fkey,
+    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
 ALTER TABLE subscription
-    DROP CONSTRAINT subscription_user_id_fkey;
+    DROP CONSTRAINT IF EXISTS subscription_user_id_fkey,
+    DROP CONSTRAINT IF EXISTS fk_user_id_ref_users;
 
 ALTER TABLE purchase
-    ALTER COLUMN user_id DROP DEFAULT;
-ALTER TABLE purchase
+    ALTER COLUMN user_id DROP DEFAULT,
     ALTER COLUMN user_id DROP NOT NULL;
 
 ALTER TABLE subscription
-    ALTER COLUMN user_id DROP DEFAULT;
-ALTER TABLE subscription
+    ALTER COLUMN user_id DROP DEFAULT,
     ALTER COLUMN user_id DROP NOT NULL;
 
 UPDATE purchase


### PR DESCRIPTION
Fix purchases-not-null-uid.sql migration for crdb. 
Address fk inconsistent naming across pg and crdb. 
Split the migration in two files so that the alter statements are executed in two separate transactions (crdb fails to migrate if multiple alter table statements are made within the same transaction).
See https://stackoverflow.com/questions/68803747/encapsulating-a-drop-and-add-constraint-in-a-transaction.