### PR TITLE
Runtime base64Decode pad input strings by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - Fix In-App Purchase subscription notification handling.
 - Fix handling of party leader transition if previous leader and other members leave concurrently.
 - Fix exact enforcement of maximum party size.
+- Fix JS/Lua runtime base64Decode functions to pad input strings by default if needed.
 
 ## [3.14.0] - 2022-10-14
 ### Added

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -706,6 +706,7 @@ func (n *runtimeJavascriptNakamaModule) base64Encode(r *goja.Runtime) func(goja.
 // @group utils
 // @summary Decode a base64 encoded string.
 // @param input(type=string) The string which will be base64 decoded.
+// @param padding(type=bool, optional=true, default=true) Pad the string if padding is missing.
 // @return out(ArrayBuffer) Decoded data.
 // @return error(error) An optional error value if an error occurred.
 func (n *runtimeJavascriptNakamaModule) base64Decode(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -716,7 +717,7 @@ func (n *runtimeJavascriptNakamaModule) base64Decode(r *goja.Runtime) func(goja.
 			padding = getJsBool(r, f.Argument(1))
 		}
 
-		if !padding {
+		if padding {
 			// Pad string up to length multiple of 4 if needed to effectively make padding optional.
 			if maybePad := len(in) % 4; maybePad != 0 {
 				in += strings.Repeat("=", 4-maybePad)

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -1168,6 +1168,7 @@ func (n *RuntimeLuaNakamaModule) base64Encode(l *lua.LState) int {
 // @group utils
 // @summary Decode a base64 encoded string.
 // @param input(type=string) The string which will be base64 decoded.
+// @param padding(type=bool, optional=true, default=true) Pad the string if padding is missing.
 // @return output(string) Decoded string.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) base64Decode(l *lua.LState) int {
@@ -1177,9 +1178,9 @@ func (n *RuntimeLuaNakamaModule) base64Decode(l *lua.LState) int {
 		return 0
 	}
 
-	padding := l.OptBool(2, false)
+	padding := l.OptBool(2, true)
 
-	if !padding {
+	if padding {
 		// Pad string up to length multiple of 4 if needed to effectively make padding optional.
 		if maybePad := len(input) % 4; maybePad != 0 {
 			input += strings.Repeat("=", 4-maybePad)


### PR DESCRIPTION
Fix JS/Lua runtime base64Decode functions to pad input strings by default if needed.