### PR TITLE
Remap Google IDs for new auth flow. Issue #1033

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 ## [Unreleased]
 ### Fixed
 - Correct cursor usage in group listings using only open/closed group state filter.
+- Remap original Google IDs to "next generation player IDs" 
 
 ## [3.16.0] - 2023-04-18
 ### Added

--- a/server/core_link.go
+++ b/server/core_link.go
@@ -355,6 +355,13 @@ func LinkGoogle(ctx context.Context, logger *zap.Logger, db *sql.DB, socialClien
 		avatarURL = ""
 	}
 
+	err = RemapGoogleId(ctx, logger, db, googleProfile)
+	if err != nil {
+		logger.Error("Could not remap Google ID.", zap.Error(err), zap.String("googleId", googleProfile.GetGoogleId()),
+			zap.String("originalGoogleId", googleProfile.GetOriginalGoogleId()), zap.Any("input", idToken))
+		return status.Error(codes.Internal, "Error while trying to link Google ID.")
+	}
+
 	res, err := db.ExecContext(ctx, `
 UPDATE users AS u
 SET google_id = $2, display_name = COALESCE(NULLIF(u.display_name, ''), $3), avatar_url = COALESCE(NULLIF(u.avatar_url, ''), $4), update_time = now()

--- a/social/social.go
+++ b/social/social.go
@@ -125,6 +125,7 @@ type GoogleProfile interface {
 	GetEmail() string
 	GetAvatarImageUrl() string
 	GetGoogleId() string
+	GetOriginalGoogleId() string
 }
 
 // JWTGoogleProfile is an abbreviated version of a Google profile extracted from a verified JWT token.
@@ -160,11 +161,17 @@ func (p *JWTGoogleProfile) GetGoogleId() string {
 	return p.Sub
 }
 
+func (p *JWTGoogleProfile) GetOriginalGoogleId() string {
+	// Dummy implementation
+	return ""
+}
+
 // GooglePlayServiceProfile is an abbreviated version of a Google profile using an access token.
 type GooglePlayServiceProfile struct {
-	PlayerId       string `json:"playerId"`
-	DisplayName    string `json:"displayName"`
-	AvatarImageUrl string `json:"avatarImageUrl"`
+	PlayerId         string `json:"playerId"`
+	DisplayName      string `json:"displayName"`
+	AvatarImageUrl   string `json:"avatarImageUrl"`
+	OriginalPlayerId string `json:"originalPlayerId"`
 }
 
 func (p *GooglePlayServiceProfile) GetDisplayName() string {
@@ -179,6 +186,9 @@ func (p *GooglePlayServiceProfile) GetAvatarImageUrl() string {
 }
 func (p *GooglePlayServiceProfile) GetGoogleId() string {
 	return p.PlayerId
+}
+func (p *GooglePlayServiceProfile) GetOriginalGoogleId() string {
+	return p.OriginalPlayerId
 }
 
 // SteamProfile is an abbreviated version of a Steam profile.
@@ -416,7 +426,7 @@ func (c *Client) CheckGoogleToken(ctx context.Context, idToken string) (GooglePr
 
 	// All verification attempts failed.
 	if token == nil {
-		// The id provided could be from the new auth flow. Let's exchahge it for a token.
+		// The id provided could be from the new auth flow. Let's exchange it for a token.
 		t, err := c.exchangeGoogleAuthCode(ctx, idToken)
 		if err != nil {
 			c.logger.Debug("Failed to exchange an authorization code for an access token.", zap.String("auth_token", idToken), zap.Error(err))


### PR DESCRIPTION
Google's "Next Generation Player IDs" mean player's are assigned a different ID for each game played. Pre-existing players will have their old ID mapped to a new ID for continuity.