### PR TITLE
storage: optimize multiple objects write

### DIFF
--- a/server/core_multi.go
+++ b/server/core_multi.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
+	pgx "github.com/jackc/pgx/v4"
 	"go.uber.org/zap"
 )
 
@@ -31,7 +32,7 @@ func MultiUpdate(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Me
 	var storageWriteAcks []*api.StorageObjectAck
 	var walletUpdateResults []*runtime.WalletUpdateResult
 
-	if err := ExecuteInTx(ctx, db, func(tx *sql.Tx) error {
+	if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
 		storageWriteAcks = nil
 		walletUpdateResults = nil
 

--- a/server/core_wallet.go
+++ b/server/core_wallet.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/jackc/pgtype"
+	pgx "github.com/jackc/pgx/v4"
 	"go.uber.org/zap"
 )
 
@@ -89,7 +90,7 @@ func UpdateWallets(ctx context.Context, logger *zap.Logger, db *sql.DB, updates 
 
 	var results []*runtime.WalletUpdateResult
 
-	if err := ExecuteInTx(ctx, db, func(tx *sql.Tx) error {
+	if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
 		var updateErr error
 		results, updateErr = updateWallets(ctx, logger, tx, updates, updateLedger)
 		if updateErr != nil {
@@ -110,7 +111,7 @@ func UpdateWallets(ctx context.Context, logger *zap.Logger, db *sql.DB, updates 
 	return results, nil
 }
 
-func updateWallets(ctx context.Context, logger *zap.Logger, tx *sql.Tx, updates []*walletUpdate, updateLedger bool) ([]*runtime.WalletUpdateResult, error) {
+func updateWallets(ctx context.Context, logger *zap.Logger, tx pgx.Tx, updates []*walletUpdate, updateLedger bool) ([]*runtime.WalletUpdateResult, error) {
 	if len(updates) == 0 {
 		return nil, nil
 	}
@@ -126,7 +127,7 @@ func updateWallets(ctx context.Context, logger *zap.Logger, tx *sql.Tx, updates 
 
 	// Select the wallets from the DB and decode them.
 	wallets := make(map[string]map[string]int64, len(updates))
-	rows, err := tx.QueryContext(ctx, initialQuery, initialParams...)
+	rows, err := tx.Query(ctx, initialQuery, initialParams...)
 	if err != nil {
 		logger.Debug("Error retrieving user wallets.", zap.Error(err))
 		return nil, err
@@ -136,7 +137,7 @@ func updateWallets(ctx context.Context, logger *zap.Logger, tx *sql.Tx, updates 
 		var wallet sql.NullString
 		err = rows.Scan(&id, &wallet)
 		if err != nil {
-			_ = rows.Close()
+			rows.Close()
 			logger.Debug("Error reading user wallets.", zap.Error(err))
 			return nil, err
 		}
@@ -144,14 +145,14 @@ func updateWallets(ctx context.Context, logger *zap.Logger, tx *sql.Tx, updates 
 		var walletMap map[string]int64
 		err = json.Unmarshal([]byte(wallet.String), &walletMap)
 		if err != nil {
-			_ = rows.Close()
+			rows.Close()
 			logger.Debug("Error converting user wallet.", zap.String("user_id", id), zap.Error(err))
 			return nil, err
 		}
 
 		wallets[id] = walletMap
 	}
-	_ = rows.Close()
+	rows.Close()
 
 	results := make([]*runtime.WalletUpdateResult, 0, len(updates))
 
@@ -232,7 +233,7 @@ func updateWallets(ctx context.Context, logger *zap.Logger, tx *sql.Tx, updates 
 				logger.Warn("Missing wallet update for user.", zap.String("user_id", userID))
 				continue
 			}
-			_, err = tx.ExecContext(ctx, "UPDATE users SET update_time = now(), wallet = $2 WHERE id = $1", userID, updatedWallet)
+			_, err = tx.Exec(ctx, "UPDATE users SET update_time = now(), wallet = $2 WHERE id = $1", userID, updatedWallet)
 			if err != nil {
 				logger.Debug("Error writing user wallet.", zap.String("user_id", userID), zap.Error(err))
 				return nil, err
@@ -241,7 +242,7 @@ func updateWallets(ctx context.Context, logger *zap.Logger, tx *sql.Tx, updates 
 
 		// Write the ledger updates, if any.
 		if updateLedger && (len(statements) > 0) {
-			_, err = tx.ExecContext(ctx, "INSERT INTO wallet_ledger (id, user_id, changeset, metadata) VALUES "+strings.Join(statements, ", "), params...)
+			_, err = tx.Exec(ctx, "INSERT INTO wallet_ledger (id, user_id, changeset, metadata) VALUES "+strings.Join(statements, ", "), params...)
 			if err != nil {
 				logger.Debug("Error writing user wallet ledgers.", zap.Error(err))
 				return nil, err

--- a/server/leaderboard_rank_cache_test.go
+++ b/server/leaderboard_rank_cache_test.go
@@ -15,10 +15,11 @@
 package server
 
 import (
+	"testing"
+
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestLocalLeaderboardRankCache_Insert_Ascending(t *testing.T) {

--- a/server/match_common_test.go
+++ b/server/match_common_test.go
@@ -17,16 +17,17 @@ package server
 import (
 	"context"
 	"database/sql"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"os"
-	"strconv"
-	"testing"
-	"time"
 )
 
 // loggerForTest allows for easily adjusting log output produced by tests in one place

--- a/server/match_presence_test.go
+++ b/server/match_presence_test.go
@@ -15,8 +15,9 @@
 package server
 
 import (
-	"github.com/gofrs/uuid/v5"
 	"testing"
+
+	"github.com/gofrs/uuid/v5"
 )
 
 func TestMatchPresenceList(t *testing.T) {


### PR DESCRIPTION
Previously multiple objects write required 2 round trips
    to DB per object: one to fetch object state from DB and second
    to update object. Each query is indexed and fast, but
    with latency to DB comparable to query execution time it adds
    significant overhead.
    
This change optimizes multiple objects write in 2 steps:
    
1. Instead of reading DB state for each object and then deciding
       on possible write operation, perform write operation unconditionally
       with correct predicates (version and permissions) defined where
       applicable. That said write operation might not succeed if row doesn't
       match predicate. Write query is structured in such way, that
       final state of the row in the database is returned, regardless
       whether writeop successed or not. By inspecting returned row we can
       infer whether it was success, version conflict or permission error.
    
2. Now that each object is written to DB in a single query, there
       is no dependencies between queries and all of them can be blasted
       to DB in a batch without waiting for result of each. Whole batch
       continues to be executed in a single transaction, so outcome is
       the same, but batching negates latency penalty.
       
To support batching access to native pgx connection is required, for that `ExecuteInTxPgx` variant was added and all call-site of StorageWrite converted to it.