### PR TITLE
Upgrade docker compose crdb to v23.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cockroachdb:
-    image: cockroachdb/cockroach:latest-v20.2
+    image: cockroachdb/cockroach:latest-v23.1
     command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/
     restart: "no"
     volumes:

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -635,7 +635,7 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		query = `
 		WITH upd AS (
 			UPDATE storage SET value = $4, version = $5, read = $6, write = $7, update_time = now()
-			WHERE collection = $1 AND key = $2 AND user_id = $3::UUID AND version = $8
+			WHERE collection = $1 AND key = $2 AND user_id = $3 AND version = $8
 		` + writeCheck + `
 			AND NOT (storage.version = $5 AND storage.read = $6 AND storage.write = $7) -- micro optimization: don't update row unnecessary
 			RETURNING read, write, version
@@ -662,7 +662,7 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		query = `
 		WITH upd AS (
 			INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time)
-				VALUES ($1, $2, $3::UUID, $4, $5, $6, $7, now(), now())
+				VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
 			ON CONFLICT (collection, key, user_id) DO
 				UPDATE SET value = $4, version = $5, read = $6, write = $7, update_time = now()
 				WHERE TRUE` + writeCheck + `
@@ -683,7 +683,7 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		// Existing permission checks are not applicable for new storage objects.
 		query = `
 		INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time)
-		VALUES ($1, $2, $3::UUID, $4, $5, $6, $7, now(), now())
+		VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
 		RETURNING read, write, version`
 
 		// Outcomes:


### PR DESCRIPTION
The reworked queries introduced in https://github.com/heroiclabs/nakama/pull/1044 are incompatible with some older versions of crdb due to this bug: https://github.com/cockroachdb/cockroach/issues/60907 that has been fixed. 

Upgrading crdb resolves this.

Alternatively, we'd have to merge https://github.com/heroiclabs/nakama/pull/1066 to keep backwards compatibility.