### PR TITLE
Proper check for registering Go Matchmaker Override

### DIFF
--- a/server/runtime.go
+++ b/server/runtime.go
@@ -2458,7 +2458,7 @@ func NewRuntime(ctx context.Context, logger, startupLogger *zap.Logger, db *sql.
 
 	var allMatchmakerOverrideFunction RuntimeMatchmakerOverrideFunction
 	switch {
-	case goMatchmakerMatchedFn != nil:
+	case goMatchmakerCustomMatchingFn != nil:
 		allMatchmakerOverrideFunction = goMatchmakerCustomMatchingFn
 		startupLogger.Info("Registered Go runtime Matchmaker Override function invocation")
 	}


### PR DESCRIPTION
Go runtime is not registering Matchmaker Override functionality because of incorrect check