### PR TITLE
Adjust console development server environment

### DIFF
--- a/console/ui/angular.json
+++ b/console/ui/angular.json
@@ -114,7 +114,7 @@
               ]
             }
           },
-          "defaultConfiguration": "production"
+          "defaultConfiguration": "local"
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",


### PR DESCRIPTION
Sets `ng serve` to not use production environment variables, pointing to the correct api base url.