### PR TITLE
Move queries with variable number of args to a fixed number of args syntax

### DIFF
--- a/server/console_channel.go
+++ b/server/console_channel.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"net/url"
 	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
@@ -66,20 +64,16 @@ func (s *ConsoleServer) DeleteChannelMessages(ctx context.Context, in *console.D
 		s.logger.Info("Messages deleted.", zap.Int64("affected", affected), zap.String("timestamp", deleteBefore.String()))
 	}
 	if len(in.Ids) > 0 {
-		params := make([]interface{}, 0, len(in.Ids))
-		statements := make([]string, len(in.Ids))
-		for i, id := range in.Ids {
-			idStr, err := uuid.FromString(id)
+		for _, id := range in.Ids {
+			_, err := uuid.FromString(id)
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, "Requires a valid message ID.")
 			}
-			params = append(params, idStr)
-			statements[i] = "$" + strconv.Itoa(i+1)
 		}
-		query := "DELETE FROM message WHERE id IN (" + strings.Join(statements, ",") + ")"
+		query := "DELETE FROM message WHERE id = ANY($1)"
 		var res sql.Result
 		var err error
-		if res, err = s.db.ExecContext(ctx, query, params...); err != nil {
+		if res, err = s.db.ExecContext(ctx, query, in.Ids); err != nil {
 			s.logger.Error("Could not delete messages.", zap.Error(err))
 			return nil, status.Error(codes.Internal, "An error occurred while trying to delete messages.")
 		}

--- a/server/core_authenticate.go
+++ b/server/core_authenticate.go
@@ -854,15 +854,13 @@ func importSteamFriends(ctx context.Context, logger *zap.Logger, db *sql.DB, mes
 			return nil
 		}
 
-		statements := make([]string, 0, len(steamProfiles))
-		params := make([]interface{}, 0, len(steamProfiles))
-		for i, steamProfile := range steamProfiles {
-			statements = append(statements, "$"+strconv.Itoa(i+1))
-			params = append(params, strconv.FormatUint(steamProfile.SteamID, 10))
+		steamIDs := make([]string, 0, len(steamProfiles))
+		for _, steamProfile := range steamProfiles {
+			steamIDs = append(steamIDs, strconv.FormatUint(steamProfile.SteamID, 10))
 		}
 
-		query := "SELECT id FROM users WHERE steam_id IN (" + strings.Join(statements, ", ") + ")"
-		rows, err := tx.QueryContext(ctx, query, params...)
+		query := "SELECT id FROM users WHERE steam_id = ANY($1::text[])"
+		rows, err := tx.QueryContext(ctx, query, steamIDs)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				// None of the friend profiles exist.
@@ -872,7 +870,7 @@ func importSteamFriends(ctx context.Context, logger *zap.Logger, db *sql.DB, mes
 		}
 
 		var id string
-		possibleFriendIDs := make([]uuid.UUID, 0, len(statements))
+		possibleFriendIDs := make([]uuid.UUID, 0, len(steamIDs))
 		for rows.Next() {
 			err = rows.Scan(&id)
 			if err != nil {
@@ -930,15 +928,13 @@ func importFacebookFriends(ctx context.Context, logger *zap.Logger, db *sql.DB, 
 			return nil
 		}
 
-		statements := make([]string, 0, len(facebookProfiles))
-		params := make([]interface{}, 0, len(facebookProfiles))
-		for i, facebookProfile := range facebookProfiles {
-			statements = append(statements, "$"+strconv.Itoa(i+1))
+		params := make([]string, 0, len(facebookProfiles))
+		for _, facebookProfile := range facebookProfiles {
 			params = append(params, facebookProfile.ID)
 		}
 
-		query := "SELECT id FROM users WHERE facebook_id IN (" + strings.Join(statements, ", ") + ")"
-		rows, err := tx.QueryContext(ctx, query, params...)
+		query := "SELECT id FROM users WHERE facebook_id = ANY($1::text[])"
+		rows, err := tx.QueryContext(ctx, query, params)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				// None of the friend profiles exist.
@@ -948,7 +944,7 @@ func importFacebookFriends(ctx context.Context, logger *zap.Logger, db *sql.DB, 
 		}
 
 		var id string
-		possibleFriendIDs := make([]uuid.UUID, 0, len(statements))
+		possibleFriendIDs := make([]uuid.UUID, 0, len(params))
 		for rows.Next() {
 			err = rows.Scan(&id)
 			if err != nil {
@@ -1005,8 +1001,7 @@ func resetUserFriends(ctx context.Context, tx *sql.Tx, userID uuid.UUID) error {
 	if err != nil {
 		return err
 	}
-	statements := make([]string, 0, 10)
-	params := make([]interface{}, 0, 10)
+	params := make([]string, 0, 10)
 	for rows.Next() {
 		var id string
 		err = rows.Scan(&id)
@@ -1015,17 +1010,16 @@ func resetUserFriends(ctx context.Context, tx *sql.Tx, userID uuid.UUID) error {
 			return err
 		}
 		params = append(params, id)
-		statements = append(statements, "$"+strconv.Itoa(len(params)))
 	}
 	_ = rows.Close()
 
-	if len(statements) > 0 {
-		query = "UPDATE users SET edge_count = edge_count - 1 WHERE id IN (" + strings.Join(statements, ",") + ")"
-		result, err := tx.ExecContext(ctx, query, params...)
+	if len(params) > 0 {
+		query = "UPDATE users SET edge_count = edge_count - 1 WHERE id = ANY($1)"
+		result, err := tx.ExecContext(ctx, query, params)
 		if err != nil {
 			return err
 		}
-		if rowsAffectedCount, _ := result.RowsAffected(); rowsAffectedCount != int64(len(statements)) {
+		if rowsAffectedCount, _ := result.RowsAffected(); rowsAffectedCount != int64(len(params)) {
 			return errors.New("error updating edge count after friend reset")
 		}
 	}

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -1624,18 +1624,10 @@ func GetGroups(ctx context.Context, logger *zap.Logger, db *sql.DB, ids []string
 		return make([]*api.Group, 0), nil
 	}
 
-	statements := make([]string, 0, len(ids))
-	params := make([]interface{}, 0, len(ids))
-	for i, id := range ids {
-		statements = append(statements, "$"+strconv.Itoa(i+1))
-		params = append(params, id)
-	}
-
 	query := `SELECT id, creator_id, name, description, avatar_url, state, edge_count, lang_tag, max_count, metadata, create_time, update_time
 FROM groups
-WHERE disable_time = '1970-01-01 00:00:00 UTC'
-AND id IN (` + strings.Join(statements, ",") + `)`
-	rows, err := db.QueryContext(ctx, query, params...)
+WHERE disable_time = '1970-01-01 00:00:00 UTC' AND id = ANY($1)`
+	rows, err := db.QueryContext(ctx, query, ids)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return make([]*api.Group, 0), nil

--- a/server/core_notification.go
+++ b/server/core_notification.go
@@ -261,17 +261,9 @@ ORDER BY create_time ASC, id ASC`+limitQuery, params...)
 }
 
 func NotificationDelete(ctx context.Context, logger *zap.Logger, db *sql.DB, userID uuid.UUID, notificationIDs []string) error {
-	statements := make([]string, 0, len(notificationIDs))
-	params := make([]interface{}, 0, len(notificationIDs)+1)
-	params = append(params, userID)
+	params := []any{userID, notificationIDs}
 
-	for _, id := range notificationIDs {
-		statement := "$" + strconv.Itoa(len(params)+1)
-		statements = append(statements, statement)
-		params = append(params, id)
-	}
-
-	query := "DELETE FROM notification WHERE user_id = $1 AND id IN (" + strings.Join(statements, ", ") + ")"
+	query := "DELETE FROM notification WHERE user_id = $1 AND id = ANY($2)"
 	logger.Debug("Delete notification query", zap.String("query", query), zap.Any("params", params))
 	_, err := db.ExecContext(ctx, query, params...)
 	if err != nil {

--- a/server/core_purchase.go
+++ b/server/core_purchase.go
@@ -576,7 +576,7 @@ func upsertPurchases(ctx context.Context, db *sql.DB, purchases []*storagePurcha
 			purchase.rawResponse = "{}"
 		}
 		transactionIDsToPurchase[purchase.transactionId] = purchase
-		
+
 		userIdParams = append(userIdParams, purchase.userID)
 		storeParams = append(storeParams, purchase.store)
 		transactionIdParams = append(transactionIdParams, purchase.transactionId)
@@ -640,32 +640,6 @@ RETURNING
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-
-	//if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
-	//	br := tx.SendBatch(ctx, batch)
-	//	defer br.Close()
-	//	for range purchases {
-	//		// Newly inserted purchases
-	//		var dbUserID uuid.UUID
-	//		var transactionId string
-	//		var createTime pgtype.Timestamptz
-	//		var updateTime pgtype.Timestamptz
-	//		var refundTime pgtype.Timestamptz
-	//		if err := br.QueryRow().Scan(&dbUserID, &transactionId, &createTime, &updateTime, &refundTime); err != nil {
-	//			return err
-	//		}
-	//		storedPurchase := transactionIDsToPurchase[transactionId]
-	//		storedPurchase.createTime = createTime.Time
-	//		storedPurchase.updateTime = updateTime.Time
-	//		storedPurchase.seenBefore = updateTime.Time.After(createTime.Time)
-	//		if refundTime.Time.Unix() != 0 {
-	//			storedPurchase.refundTime = refundTime.Time
-	//		}
-	//	}
-	//	return br.Close()
-	//}); err != nil {
-	//	return nil, err
-	//}
 
 	storedPurchases := make([]*storagePurchase, 0, len(transactionIDsToPurchase))
 	for _, purchase := range transactionIDsToPurchase {

--- a/server/pipeline_status.go
+++ b/server/pipeline_status.go
@@ -124,11 +124,9 @@ func (p *Pipeline) statusFollow(logger *zap.Logger, session Session, envelope *r
 		for userID := range uniqueUserIDs {
 			ids = append(ids, userID)
 		}
-		counter := 1
 		if len(ids) != 0 {
-			query += fmt.Sprintf("id = ANY($%d::UUID[])", counter)
 			params = append(params, ids)
-			counter++
+			query += fmt.Sprintf("id = ANY($%d::UUID[])", len(params))
 		}
 
 		usernames := make([]string, 0, len(uniqueUsernames))
@@ -138,8 +136,8 @@ func (p *Pipeline) statusFollow(logger *zap.Logger, session Session, envelope *r
 		if len(uniqueUserIDs) != 0 {
 			query += " OR "
 		}
-		query += fmt.Sprintf("username = ANY($%d::text[])", counter)
 		params = append(params, usernames)
+		query += fmt.Sprintf("username = ANY($%d::text[])", len(params))
 
 		// See if all the users exist.
 		rows, err := p.db.QueryContext(session.Context(), query, params...)


### PR DESCRIPTION
Queries with a variable number of arguments are treated as distinct queries from PostgreSQL perspective, and their statistics are tracked separately. This PR aims to improve query metrics' cardinality and, consequently, improve query stats monitoring. This is achieved by using a fixed syntax:

- `WHERE x in ($1,$2,$3, ...)` is replaced with `WHERE x = ANY($1::type_of_x[])`, with all values passed as a single array argument.
- `INSERT INTO t (a,b,c) VALUES ($1,$2,$3), ($4,$5,$6), ...` is replaced with `pgx.Batch`, with a single row insert per query.