### PR TITLE
Ignore conflicting storage inserts with version="*"

### DIFF
--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -699,6 +699,7 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		query = `
 		INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
+		ON CONFLICT (collection, key, user_id) DO NOTHING 
 		RETURNING read, write, version, create_time, update_time`
 
 		// Outcomes:

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -699,11 +699,11 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		query = `
 		INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
-		ON CONFLICT (collection, key, user_id) DO NOTHING 
+		ON CONFLICT (collection, key, user_id) DO NOTHING
 		RETURNING read, write, version, create_time, update_time`
 
 		// Outcomes:
-		// - NoRows - insert failed due to constraint violation (concurrent insert)
+		// - NoRows - insert was ignored due to constraint violation (concurrent insert or non-OCC existing row)
 	}
 
 	batch.Queue(query, params...)


### PR DESCRIPTION
Upsert with `DO NOTHING` will ignore insert on conflicting key, instead of failing. The intended upside is that transactions with conflicting inserts will not have to be retried anymore, saving unnecessary database processing. 

Results do not change, as the new query will still return no rows on conflict, hence the batch insert will be aborted with `ErrStorageRejectedVersion`.