### PR TITLE
Improve query planning in StorageReadObjects

### DIFF
--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -423,6 +423,10 @@ type storageQueryArg struct {
 }
 
 func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, caller uuid.UUID, objectIDs []*api.ReadStorageObjectId) (*api.StorageObjects, error) {
+	if objectIDs == nil || len(objectIDs) == 0 {
+		return &api.StorageObjects{}, nil
+	}
+
 	collectionParams := make([]string, 0, len(objectIDs))
 	keyParams := make([]string, 0, len(objectIDs))
 	userIdParams := make([]uuid.UUID, 0, len(objectIDs))

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -440,7 +440,7 @@ func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, cal
 
 	for _, id := range objectIDs {
 		collectionParams = append(collectionParams, id.Collection)
-		if isCollectionSetUnique && len(collectionParams) > 1 {
+		if isCollectionSetUnique {
 			if id.Collection != collectionParams[0] {
 				isCollectionSetUnique = false
 				distinctArgs = append(distinctArgs, storageQueryArg{name: "collection", dbType: "text[]", param: &collectionParams})
@@ -448,7 +448,7 @@ func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, cal
 		}
 
 		keyParams = append(keyParams, id.Key)
-		if isKeySetUnique && len(keyParams) > 1 {
+		if isKeySetUnique {
 			if id.Key != keyParams[0] {
 				isKeySetUnique = false
 				distinctArgs = append(distinctArgs, storageQueryArg{name: "key", dbType: "text[]", param: &keyParams})
@@ -465,7 +465,7 @@ func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, cal
 			}
 		}
 		userIdParams = append(userIdParams, reqUid)
-		if isUserIdSetUnique && len(userIdParams) > 1 {
+		if isUserIdSetUnique {
 			if reqUid != userIdParams[0] {
 				isUserIdSetUnique = false
 				distinctArgs = append(distinctArgs, storageQueryArg{name: "user_id", dbType: "uuid[]", param: &userIdParams})

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -423,7 +423,7 @@ type storageQueryArg struct {
 }
 
 func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, caller uuid.UUID, objectIDs []*api.ReadStorageObjectId) (*api.StorageObjects, error) {
-	if objectIDs == nil || len(objectIDs) == 0 {
+	if len(objectIDs) == 0 {
 		return &api.StorageObjects{}, nil
 	}
 

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -540,11 +540,7 @@ SELECT collection, key, user_id, value, version, read, write, create_time, updat
 		query += `(read = 2 or (read = 1 and storage.user_id = $4))`
 		params = append(params, caller)
 	}
-
-	println(query)
-
-	fmt.Printf("%+v\n", params)
-
+	
 	var objects *api.StorageObjects
 	err := ExecuteRetryablePgx(ctx, db, func(conn *pgx.Conn) error {
 		rows, _ := conn.Query(ctx, query, params...)

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -540,7 +540,7 @@ SELECT collection, key, user_id, value, version, read, write, create_time, updat
 		query += `(read = 2 or (read = 1 and storage.user_id = $4))`
 		params = append(params, caller)
 	}
-	
+
 	var objects *api.StorageObjects
 	err := ExecuteRetryablePgx(ctx, db, func(conn *pgx.Conn) error {
 		rows, _ := conn.Query(ctx, query, params...)

--- a/server/core_storage_test.go
+++ b/server/core_storage_test.go
@@ -2389,3 +2389,372 @@ func TestOCCWriteSameValueCorrectVersionSuccess(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, acks.Acks, 1)
 }
+
+func TestStorageListSameArgs(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	key := GenerateString()
+	uid := uuid.Must(uuid.NewV4())
+	value := "{\"foo\": \"bar\"}"
+	InsertUser(t, db, uid)
+
+	ops := StorageOpWrites{
+		&StorageOpWrite{
+			OwnerID: uid.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection1",
+				Key:             key,
+				Value:           value,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection2",
+				Key:             key,
+				Value:           value,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 1},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+	}
+
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+
+	assert.Nil(t, err, "err was not nil")
+	assert.Equal(t, codes.OK, code, "code was not 0")
+	assert.NotNil(t, acks, "acks was nil")
+
+	ids := []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key,
+		UserId:     uid.String(),
+	}, {
+		Collection: "testcollection1",
+		Key:        key,
+		UserId:     uid.String(),
+	}}
+
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 1, "readData length was not 1")
+	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
+	assert.Equal(t, key, readData.Objects[0].Key, "record did not match")
+	assert.Equal(t, uid.String(), readData.Objects[0].UserId, "user id did not match")
+	assert.Equal(t, value, readData.Objects[0].Value, "value did not match")
+
+	ids = []*api.ReadStorageObjectId{{
+		Collection: "testcollection2",
+		Key:        key,
+		UserId:     uid.String(),
+	}, {
+		Collection: "testcollection2",
+		Key:        key,
+		UserId:     uid.String(),
+	}}
+
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 1, "readData length was not 1")
+	assert.Equal(t, "testcollection2", readData.Objects[0].Collection, "collection did not match")
+	assert.Equal(t, key, readData.Objects[0].Key, "record did not match")
+	assert.Equal(t, uid.String(), readData.Objects[0].UserId, "user id did not match")
+	assert.Equal(t, value, readData.Objects[0].Value, "value did not match")
+}
+
+func TestStorageListOneDistinctArg(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	key1 := GenerateString()
+	key2 := GenerateString()
+	uid1 := uuid.Must(uuid.NewV4())
+	uid2 := uuid.Must(uuid.NewV4())
+	value1 := "{\"foo\": \"bar\"}"
+	InsertUser(t, db, uid1)
+	InsertUser(t, db, uid2)
+
+	ops := StorageOpWrites{
+		&StorageOpWrite{
+			OwnerID: uid1.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection1",
+				Key:             key1,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid2.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection1",
+				Key:             key1,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid1.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection1",
+				Key:             key2,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid1.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection2",
+				Key:             key1,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+	}
+
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+
+	assert.Nil(t, err, "err was not nil")
+	assert.Equal(t, codes.OK, code, "code was not 0")
+	assert.NotNil(t, acks, "acks was nil")
+
+	ids := []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}, {
+		Collection: "testcollection2",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}}
+
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 2, "readData length was not 2")
+	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
+	assert.Equal(t, key1, readData.Objects[0].Key, "key did not match")
+	assert.Equal(t, key1, readData.Objects[1].Key, "key did not match")
+	assert.Equal(t, uid1.String(), readData.Objects[0].UserId, "user id did not match")
+	assert.Equal(t, uid1.String(), readData.Objects[1].UserId, "user id did not match")
+
+	ids = []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}, {
+		Collection: "testcollection1",
+		Key:        key2,
+		UserId:     uid1.String(),
+	}}
+
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 2, "readData length was not 2")
+	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
+	assert.Equal(t, "testcollection1", readData.Objects[1].Collection, "collection did not match")
+	assert.ElementsMatch(t, []string{key1, key2}, []string{readData.Objects[0].Key, readData.Objects[1].Key}, "key did not match")
+	assert.Equal(t, uid1.String(), readData.Objects[0].UserId, "user id did not match")
+	assert.Equal(t, uid1.String(), readData.Objects[1].UserId, "user id did not match")
+
+	ids = []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}, {
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid2.String(),
+	}}
+
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 2, "readData length was not 2")
+	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
+	assert.Equal(t, "testcollection1", readData.Objects[1].Collection, "collection did not match")
+	assert.Equal(t, key1, readData.Objects[0].Key, "record did not match")
+	assert.Equal(t, key1, readData.Objects[1].Key, "record did not match")
+	assert.ElementsMatch(t, []string{uid1.String(), uid2.String()}, []string{readData.Objects[0].UserId, readData.Objects[1].UserId}, "user id did not match")
+}
+
+func TestStorageListTwoDistinctArgs(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	key1 := GenerateString()
+	key2 := GenerateString()
+	uid1 := uuid.Must(uuid.NewV4())
+	uid2 := uuid.Must(uuid.NewV4())
+	value1 := "{\"foo\": \"bar\"}"
+	InsertUser(t, db, uid1)
+	InsertUser(t, db, uid2)
+
+	ops := StorageOpWrites{
+		&StorageOpWrite{
+			OwnerID: uid1.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection1",
+				Key:             key1,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid1.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection2",
+				Key:             key2,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid2.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection1",
+				Key:             key2,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid2.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection2",
+				Key:             key1,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+	}
+
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+
+	assert.Nil(t, err, "err was not nil")
+	assert.Equal(t, codes.OK, code, "code was not 0")
+	assert.NotNil(t, acks, "acks was nil")
+
+	ids := []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}, {
+		Collection: "testcollection2",
+		Key:        key2,
+		UserId:     uid1.String(),
+	}}
+
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 2, "readData length was not 2")
+	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
+	assert.ElementsMatch(t, []string{key1, key2}, []string{readData.Objects[0].Key, readData.Objects[1].Key}, "key did not match")
+	assert.Equal(t, uid1.String(), readData.Objects[0].UserId, "user id did not match")
+	assert.Equal(t, uid1.String(), readData.Objects[1].UserId, "user id did not match")
+
+	ids = []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}, {
+		Collection: "testcollection1",
+		Key:        key2,
+		UserId:     uid2.String(),
+	}}
+
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 2, "readData length was not 2")
+	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
+	assert.Equal(t, "testcollection1", readData.Objects[1].Collection, "collection did not match")
+	assert.ElementsMatch(t, []string{key1, key2}, []string{readData.Objects[0].Key, readData.Objects[1].Key}, "key did not match")
+	assert.ElementsMatch(t, []string{uid1.String(), uid2.String()}, []string{readData.Objects[0].UserId, readData.Objects[1].UserId}, "user id did not match")
+
+	ids = []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}, {
+		Collection: "testcollection2",
+		Key:        key1,
+		UserId:     uid2.String(),
+	}}
+
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 2, "readData length was not 2")
+	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
+	assert.Equal(t, key1, readData.Objects[0].Key, "record did not match")
+	assert.Equal(t, key1, readData.Objects[1].Key, "record did not match")
+	assert.ElementsMatch(t, []string{uid1.String(), uid2.String()}, []string{readData.Objects[0].UserId, readData.Objects[1].UserId}, "user id did not match")
+}
+
+func TestStorageListAllDistinctArgs(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	key1 := GenerateString()
+	key2 := GenerateString()
+	uid1 := uuid.Must(uuid.NewV4())
+	uid2 := uuid.Must(uuid.NewV4())
+	value1 := "{\"foo\": \"bar\"}"
+	InsertUser(t, db, uid1)
+	InsertUser(t, db, uid2)
+
+	ops := StorageOpWrites{
+		&StorageOpWrite{
+			OwnerID: uid1.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection1",
+				Key:             key1,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+		&StorageOpWrite{
+			OwnerID: uid2.String(),
+			Object: &api.WriteStorageObject{
+				Collection:      "testcollection2",
+				Key:             key2,
+				Value:           value1,
+				PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+				PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+			},
+		},
+	}
+
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+
+	assert.Nil(t, err, "err was not nil")
+	assert.Equal(t, codes.OK, code, "code was not 0")
+	assert.NotNil(t, acks, "acks was nil")
+
+	ids := []*api.ReadStorageObjectId{{
+		Collection: "testcollection1",
+		Key:        key1,
+		UserId:     uid1.String(),
+	}, {
+		Collection: "testcollection2",
+		Key:        key2,
+		UserId:     uid2.String(),
+	}}
+
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	assert.Nil(t, err, "err was not nil")
+	assert.Len(t, readData.Objects, 2, "readData length was not 2")
+	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
+	assert.ElementsMatch(t, []string{key1, key2}, []string{readData.Objects[0].Key, readData.Objects[1].Key}, "key did not match")
+	assert.ElementsMatch(t, []string{uid1.String(), uid2.String()}, []string{readData.Objects[0].UserId, readData.Objects[1].UserId}, "user id did not match")
+}

--- a/server/core_storage_test.go
+++ b/server/core_storage_test.go
@@ -2390,7 +2390,7 @@ func TestOCCWriteSameValueCorrectVersionSuccess(t *testing.T) {
 	assert.Len(t, acks.Acks, 1)
 }
 
-func TestStorageListSameArgs(t *testing.T) {
+func TestStorageReadObjectsSameArgs(t *testing.T) {
 	db := NewDB(t)
 	defer db.Close()
 
@@ -2465,7 +2465,7 @@ func TestStorageListSameArgs(t *testing.T) {
 	assert.Equal(t, value, readData.Objects[0].Value, "value did not match")
 }
 
-func TestStorageListOneDistinctArg(t *testing.T) {
+func TestStorageReadObjectsOneDistinctArg(t *testing.T) {
 	db := NewDB(t)
 	defer db.Close()
 
@@ -2584,7 +2584,7 @@ func TestStorageListOneDistinctArg(t *testing.T) {
 	assert.ElementsMatch(t, []string{uid1.String(), uid2.String()}, []string{readData.Objects[0].UserId, readData.Objects[1].UserId}, "user id did not match")
 }
 
-func TestStorageListTwoDistinctArgs(t *testing.T) {
+func TestStorageReadObjectsTwoDistinctArgs(t *testing.T) {
 	db := NewDB(t)
 	defer db.Close()
 
@@ -2700,7 +2700,7 @@ func TestStorageListTwoDistinctArgs(t *testing.T) {
 	assert.ElementsMatch(t, []string{uid1.String(), uid2.String()}, []string{readData.Objects[0].UserId, readData.Objects[1].UserId}, "user id did not match")
 }
 
-func TestStorageListAllDistinctArgs(t *testing.T) {
+func TestStorageReadObjectsAllDistinctArgs(t *testing.T) {
 	db := NewDB(t)
 	defer db.Close()
 


### PR DESCRIPTION
This aims to optimize queries for cases where all requested storage objects are for the same user/key/collection:

1. For any requested column, if all requested values are the same then it becomes a simple `WHERE $column = $value` condition;
2. If among all requested columns only one has multiple distinct values requested, it becomes a `WHERE $column = ANY($values[])` condition;
3. Otherwise, if we have two or three columns with multiple distinct values requested, these columns become part of a `JOIN ROWS FROM ()` virtual table clause.