### PR TITLE
Remove lock from sessionWS.SendBytes

### DIFF
--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -400,22 +400,14 @@ func (s *sessionWS) Send(envelope *rtapi.Envelope, reliable bool) error {
 }
 
 func (s *sessionWS) SendBytes(payload []byte, reliable bool) error {
-	s.Lock()
-	if s.stopped {
-		s.Unlock()
-		return nil
-	}
-
 	// Attempt to queue messages and observe failures.
 	select {
 	case s.outgoingCh <- payload:
-		s.Unlock()
 		return nil
 	default:
 		// The outgoing queue is full, likely because the remote client can't keep up.
 		// Terminate the connection immediately because the only alternative that doesn't block the server is
 		// to start dropping messages, which might cause unexpected behaviour.
-		s.Unlock()
 		s.logger.Warn("Could not write message, session outgoing queue full")
 		s.Close(ErrSessionQueueFull.Error(), runtime.PresenceReasonDisconnect)
 		return ErrSessionQueueFull
@@ -460,7 +452,6 @@ func (s *sessionWS) Close(msg string, reason runtime.PresenceReason, envelopes .
 
 	// Clean up internals.
 	s.pingTimer.Stop()
-	close(s.outgoingCh)
 
 	// Send final messages, if any are specified.
 	for _, envelope := range envelopes {

--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -409,7 +409,8 @@ func (s *sessionWS) SendBytes(payload []byte, reliable bool) error {
 		// Terminate the connection immediately because the only alternative that doesn't block the server is
 		// to start dropping messages, which might cause unexpected behaviour.
 		s.logger.Warn("Could not write message, session outgoing queue full")
-		s.Close(ErrSessionQueueFull.Error(), runtime.PresenceReasonDisconnect)
+		// Close in a goroutine as the method can block
+		go s.Close(ErrSessionQueueFull.Error(), runtime.PresenceReasonDisconnect)
 		return ErrSessionQueueFull
 	}
 }


### PR DESCRIPTION
There are six different calls to s.Lock() in sessionWS.  Three of these locks are around calls to SetWriteDeadline and WriteMessage on the WebSocket.  WriteMessage will block for up to the timeout set in SetWriteDeadline, which has a default of 5000 milliseconds.  This lock is also acquired by SendBytes to determine if the session has been stopped.  This is a problem as the event processing methods in StatusRegistry and Track call SendBytes directly on the Session.  If one of the Sessions being written to has delays in writing data, this could cause backups in the event processing.

The simplest approach (this commit) is to just remove the lock within SendBytes.  To avoid a race condition with writing to a closed channel, we need to not close the outgoingCh channel in the Close method.  This is safe to do as channels do not need to be explicitly closed and will automatically be cleaned up by the garbage collector.  It should also be possible to remove the lock entirely from sessionWS, but that is a much larger change.