### PR TITLE
Remove mutex from sessionWS

### DIFF
--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -302,7 +302,7 @@ func (s *sessionWS) processOutgoing() {
 				// Update read deadline, since we aren't sending a ping, which means the pong handler won't be triggered
 				if err := s.conn.SetReadDeadline(time.Now().Add(s.pongWaitDuration)); err != nil {
 					s.logger.Warn("Failed to set read deadline", zap.Error(err))
-					s.Close("failed to set read deadline", runtime.PresenceReasonDisconnect)
+					reason = err.Error()
 					return
 				}
 


### PR DESCRIPTION
There are six different calls to s.Lock() in sessionWS.  Three of these locks are around calls to SetWriteDeadline and WriteMessage on the WebSocket.  WriteMessage will block for up to the timeout set in SetWriteDeadline, which has a default of 5000 milliseconds.  This lock is also acquired by SendBytes to determine if the session has been stopped.  This is a problem as the event processing methods in StatusRegistry and Track call SendBytes directly on the Session.  If one of the Sessions being written to has delays in writing data, this could cause backups in the event processing.

This change is more complex than https://github.com/heroiclabs/nakama/pull/1140/.  It fully removes the mutex from sessionWS.  All writes have been moved to only occur within processOutgoing so no panics are generated by concurrent writes.  The stopped variable is converted to an atomic.Bool, which is only used in the Close method to prevent more than one Close call being made.  As the outgoingCh is not closed, Send() is used to send the final messages and then the ctxCancelFn is called, which causes a Close message to be sent in processOutgoing after all messages are sent.  The ping backoff logic was also simplified.