### PR TITLE
Add safeguard around js caching api

### DIFF
--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -8004,7 +8004,15 @@ func (n *runtimeJavascriptNakamaModule) localcachePut(r *goja.Runtime) func(goja
 			panic(r.NewTypeError("ttl must be 0 or more"))
 		}
 
-		n.localCache.Put(key, value.Export(), ttl)
+		v := value.Export()
+
+		switch v.(type) {
+		case string, int64, float64, bool:
+		default:
+			panic(r.NewTypeError("unsupported value type: must be string, numeric or boolean"))
+		}
+
+		n.localCache.Put(key, v, ttl)
 
 		return goja.Undefined()
 	}


### PR DESCRIPTION
Prevent js objects and other types to leak vm context through the localcache by disallowing such types to be cached and restricting to primitive data types only on put.