### PR TITLE
Fix ptr slices assertions in js nk module arguments

### DIFF
--- a/server/runtime_javascript_init.go
+++ b/server/runtime_javascript_init.go
@@ -1011,25 +1011,13 @@ func (im *RuntimeJavascriptInitModule) registerStorageIndex(r *goja.Runtime) fun
 			idxKey = getJsString(r, f.Argument(2))
 		}
 
-		var fields []string
 		ownersArray := f.Argument(3)
 		if goja.IsUndefined(ownersArray) || goja.IsNull(ownersArray) {
 			panic(r.NewTypeError("expects an array of fields"))
 		}
-		fieldsSlice, ok := ownersArray.Export().([]interface{})
-		if !ok {
-			panic(r.NewTypeError("expects an array of fields"))
-		}
-		if len(fieldsSlice) < 1 {
-			panic(r.NewTypeError("expects at least one field to be set"))
-		}
-		fields = make([]string, 0, len(fieldsSlice))
-		for _, field := range fieldsSlice {
-			fieldStr, ok := field.(string)
-			if !ok {
-				panic(r.NewTypeError("expects a string field"))
-			}
-			fields = append(fields, fieldStr)
+		fields, err := exportToSlice[[]string](ownersArray)
+		if err != nil {
+			panic(r.NewTypeError("expects an array of strings"))
 		}
 
 		idxMaxEntries := int(getJsInt(r, f.Argument(4)))

--- a/server/runtime_javascript_match_core.go
+++ b/server/runtime_javascript_match_core.go
@@ -632,18 +632,13 @@ func (rm *RuntimeJavaScriptMatchCore) validateBroadcast(r *goja.Runtime, f goja.
 	filter := f.Argument(2)
 	var presenceIDs []*PresenceID
 	if !goja.IsUndefined(filter) && !goja.IsNull(filter) {
-		filterSlice, ok := filter.Export().([]interface{})
-		if !ok {
+		filters, err := exportToSlice[[]map[string]any](filter)
+		if err != nil {
 			panic(r.NewTypeError("expects an array of presences or nil"))
 		}
 
-		presenceIDs = make([]*PresenceID, 0, len(filterSlice))
-		for _, p := range filterSlice {
-			pMap, ok := p.(map[string]interface{})
-			if !ok {
-				panic(r.NewTypeError("expects a valid set of presences"))
-			}
-
+		presenceIDs = make([]*PresenceID, 0, len(filters))
+		for _, pMap := range filters {
 			presenceID := &PresenceID{}
 
 			sidVal := pMap["sessionId"]
@@ -776,18 +771,13 @@ func (rm *RuntimeJavaScriptMatchCore) matchKick(r *goja.Runtime) func(goja.Funct
 			return goja.Undefined()
 		}
 
-		presencesSlice, ok := input.Export().([]interface{})
-		if !ok {
+		presencesSlice, err := exportToSlice[[]map[string]any](input)
+		if err != nil {
 			panic(r.NewTypeError("expects an array of presence objects"))
 		}
 
 		presences := make([]*MatchPresence, 0, len(presencesSlice))
-		for _, p := range presencesSlice {
-			pMap, ok := p.(map[string]interface{})
-			if !ok {
-				panic(r.NewTypeError("expects a valid set of presences"))
-			}
-
+		for _, pMap := range presencesSlice {
 			presence := &MatchPresence{}
 			userIdVal := pMap["userId"]
 			if userIdVal == nil {


### PR DESCRIPTION
Goja introduced the following change:
https://github.com/dop251/goja/commit/7749907a8a20719efef6c6fb4d39f2ba64f7557c JS arrays backed by a Go slice referenced by a pointer would be returned by .Export() as []S, but now are returned as *[]S which requires changing all the type assertions when dealing with these values.