### PR TITLE
Fix storage engine occ regression 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 ## [Unreleased]
 ### Fixed
 - Skip Google refund handling for deleted users.
+- Fix storage engine version check regression.
 
 ## [3.20.0] - 2023-12-15
 ### Changed

--- a/internal/gopher-lua/_glua-tests/goto.lua
+++ b/internal/gopher-lua/_glua-tests/goto.lua
@@ -1,0 +1,173 @@
+local function errmsg (code, m)
+  local st, msg = loadstring(code)
+  assert(not st and string.find(msg, m))
+end
+
+-- cannot see label inside block
+errmsg([[ goto l1; do ::l1:: end ]], "label 'l1'")
+errmsg([[ do ::l1:: end goto l1; ]], "label 'l1'")
+
+-- repeated label
+errmsg([[ ::l1:: ::l1:: ]], "label 'l1'")
+
+
+-- undefined label
+errmsg([[ goto l1; local aa ::l1:: ::l2:: print(3) ]], "local 'aa'")
+
+-- jumping over variable definition
+errmsg([[
+do local bb, cc; goto l1; end
+local aa
+::l1:: print(3)
+]], "local 'aa'")
+
+-- jumping into a block
+errmsg([[ do ::l1:: end goto l1 ]], "label 'l1'")
+errmsg([[ goto l1 do ::l1:: end ]], "label 'l1'")
+
+-- cannot continue a repeat-until with variables
+errmsg([[
+  repeat
+    if x then goto cont end
+    local xuxu = 10
+    ::cont::
+  until xuxu < x
+]], "local 'xuxu'")
+
+-- simple gotos
+local x
+do
+  local y = 12
+  goto l1
+  ::l2:: x = x + 1; goto l3
+  ::l1:: x = y; goto l2
+end
+::l3:: ::l3_1:: assert(x == 13)
+
+
+-- long labels
+do
+  local prog = [[
+  do
+    local a = 1
+    goto l%sa; a = a + 1
+   ::l%sa:: a = a + 10
+    goto l%sb; a = a + 2
+   ::l%sb:: a = a + 20
+    return a
+  end
+  ]]
+  local label = string.rep("0123456789", 40)
+  prog = string.format(prog, label, label, label, label)
+  assert(assert(loadstring(prog))() == 31)
+end
+
+-- goto to correct label when nested
+do goto l3; ::l3:: end   -- does not loop jumping to previous label 'l3'
+
+-- ok to jump over local dec. to end of block
+do
+  goto l1
+  local a = 23
+  x = a
+  ::l1::;
+end
+
+while true do
+  goto l4
+  goto l1  -- ok to jump over local dec. to end of block
+  goto l1  -- multiple uses of same label
+  local x = 45
+  ::l1:: ;;;
+end
+::l4:: assert(x == 13)
+
+if print then
+  goto l1   -- ok to jump over local dec. to end of block
+  error("should not be here")
+  goto l2   -- ok to jump over local dec. to end of block
+  local x
+  ::l1:: ; ::l2:: ;;
+else end
+
+-- to repeat a label in a different function is OK
+local function foo ()
+  local a = {}
+  goto l3
+  ::l1:: a[#a + 1] = 1; goto l2;
+  ::l2:: a[#a + 1] = 2; goto l5;
+  ::l3::
+  ::l3a:: a[#a + 1] = 3; goto l1;
+  ::l4:: a[#a + 1] = 4; goto l6;
+  ::l5:: a[#a + 1] = 5; goto l4;
+  ::l6:: assert(a[1] == 3 and a[2] == 1 and a[3] == 2 and
+    a[4] == 5 and a[5] == 4)
+  if not a[6] then a[6] = true; goto l3a end   -- do it twice
+end
+
+::l6:: foo()
+
+
+
+--------------------------------------------------------------------------------
+-- testing closing of upvalues
+
+local function foo ()
+  local a = {}
+  do
+    local i = 1
+    local k = 0
+    a[0] = function (y) k = y end
+    ::l1:: do
+    local x
+    if i > 2 then goto l2 end
+    a[i] = function (y) if y then x = y else return x + k end end
+    i = i + 1
+    goto l1
+  end
+  end
+  ::l2:: return a
+end
+
+local a = foo()
+a[1](10); a[2](20)
+assert(a[1]() == 10 and a[2]() == 20 and a[3] == nil)
+a[0](13)
+assert(a[1]() == 23 and a[2]() == 33)
+
+--------------------------------------------------------------------------------
+-- testing if x goto optimizations
+
+local function testG (a)
+  if a == 1 then
+    goto l1
+    error("should never be here!")
+  elseif a == 2 then goto l2
+  elseif a == 3 then goto l3
+  elseif a == 4 then
+    goto l1  -- go to inside the block
+    error("should never be here!")
+    ::l1:: a = a + 1   -- must go to 'if' end
+  else
+    goto l4
+    ::l4a:: a = a * 2; goto l4b
+    error("should never be here!")
+    ::l4:: goto l4a
+    error("should never be here!")
+    ::l4b::
+  end
+  do return a end
+  ::l2:: do return "2" end
+  ::l3:: do return "3" end
+  ::l1:: return "1"
+end
+
+assert(testG(1) == "1")
+assert(testG(2) == "2")
+assert(testG(3) == "3")
+assert(testG(4) == 5)
+assert(testG(5) == 10)
+--------------------------------------------------------------------------------
+
+
+print'OK'

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -150,8 +150,8 @@ func NewConsoleLogger(output *os.File, verbose bool) *zap.Logger {
 }
 
 func NewDB(t *testing.T) *sql.DB {
-	// db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
-	db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
+	db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
+	//db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
 	if err != nil {
 		t.Fatal("Error connecting to database", err)
 	}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -150,8 +150,8 @@ func NewConsoleLogger(output *os.File, verbose bool) *zap.Logger {
 }
 
 func NewDB(t *testing.T) *sql.DB {
-	db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
-	//db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
+	// db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
+	db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
 	if err != nil {
 		t.Fatal("Error connecting to database", err)
 	}

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -655,7 +655,8 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		)
 		(SELECT read, write, version, create_time, update_time, true AS update FROM upd)
 		UNION ALL
-		(SELECT read, write, version, create_time, update_time, false AS update FROM storage WHERE collection = $1 and key = $2 and user_id = $3 AND NOT EXISTS (SELECT 1 FROM upd))`
+		(SELECT read, write, version, create_time, update_time, false AS update FROM storage WHERE collection = $1 and key = $2 and user_id = $3 AND NOT EXISTS (SELECT 1 FROM upd))
+		LIMIT 1`
 
 		params = append(params, object.Version)
 
@@ -682,7 +683,8 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		)
 		(SELECT read, write, version, create_time, update_time, true AS upsert FROM upd)
 		UNION ALL
-		(SELECT read, write, version, create_time, update_time, false AS upsert FROM storage WHERE collection = $1 and key = $2 and user_id = $3 AND NOT EXISTS (SELECT 1 FROM upd))`
+		(SELECT read, write, version, create_time, update_time, false AS upsert FROM storage WHERE collection = $1 and key = $2 and user_id = $3 AND NOT EXISTS (SELECT 1 FROM upd))
+		LIMIT 1`
 
 		// Outcomes:
 		// - Row is always returned, need to know if update happened, that WHERE matches

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -574,7 +574,8 @@ func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metric
 		var resultVersion string
 		var createTime time.Time
 		var updateTime time.Time
-		err := br.QueryRow().Scan(&resultRead, &resultWrite, &resultVersion, &createTime, &updateTime)
+		var upserted int32
+		err := br.QueryRow().Scan(&resultRead, &resultWrite, &resultVersion, &createTime, &updateTime, &upserted)
 		var pgErr *pgconn.PgError
 		if err != nil && errors.As(err, &pgErr) {
 			if pgErr.Code == dbErrorUniqueViolation {
@@ -584,28 +585,27 @@ func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metric
 			return nil, err
 		} else if err == pgx.ErrNoRows {
 			// Not every case from storagePrepWriteObject can return NoRows, but those
-			// which do it is always ErrStorageRejectedVersion
+			// which do are always ErrStorageRejectedVersion
 			metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "version"}, 1)
 			return nil, runtime.ErrStorageRejectedVersion
 		} else if err != nil {
 			return nil, err
 		}
 
+		isUpserted := false
+		if upserted == 1 {
+			isUpserted = true
+		}
+
 		if !(op.permissionRead() == resultRead &&
-			op.permissionWrite() == resultWrite &&
-			op.expectedVersion() == resultVersion) {
-			// Write failed, it can happen for 3 reasons:
-			// - constraint violation on insert (handles elsewhere)
-			// - permission: non authoritative write & original row write != 1
+			op.permissionWrite() == resultWrite) && !authoritativeWrite && resultWrite != 1 {
+			// - permission: non-authoritative write & original row write != 1
+			metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "permission"}, 1)
+			return nil, runtime.ErrStorageRejectedPermission
+		} else if op.expectedVersion() != resultVersion || (!isUpserted && op.Object.Version != "" && op.Object.Version != "*" && op.expectedVersion() == resultVersion) {
 			// - version mismatch
-			if !authoritativeWrite && resultWrite != 1 {
-				metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "permission"}, 1)
-				return nil, runtime.ErrStorageRejectedPermission
-			} else {
-				// version check failed
-				metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "version"}, 1)
-				return nil, runtime.ErrStorageRejectedVersion
-			}
+			metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "version"}, 1)
+			return nil, runtime.ErrStorageRejectedVersion
 		}
 		ack := &api.StorageObjectAck{
 			Collection: object.Collection,
@@ -652,19 +652,19 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 			UPDATE storage SET value = $4, version = $5, read = $6, write = $7, update_time = now()
 			WHERE collection = $1 AND key = $2 AND user_id = $3 AND version = $8
 		` + writeCheck + `
-			AND NOT (storage.version = $5 AND storage.read = $6 AND storage.write = $7) -- micro optimization: don't update row unnecessary
+			AND NOT (storage.version = $5 AND storage.read = $6 AND storage.write = $7) -- micro optimization: don't update row unnecessarily
 			RETURNING read, write, version, create_time, update_time
 		)
-		(SELECT read, write, version, create_time, update_time from upd)
+		(SELECT read, write, version, create_time, update_time, 1::integer AS "order" FROM upd)
 		UNION ALL
-		(SELECT read, write, version, create_time, update_time FROM storage WHERE collection = $1 and key = $2 and user_id = $3)
-		LIMIT 1`
+		(SELECT read, write, version, create_time, update_time, 2::integer AS "order" FROM storage WHERE collection = $1 and key = $2 and user_id = $3)
+		ORDER BY "order" LIMIT 1`
 
 		params = append(params, object.Version)
 
 		// Outcomes:
 		// - No rows: if no rows returned, then object was not found in DB and can't be updated
-		// - We have row returned, but now we need to know if update happened, that is its WHERE matched
+		// - We have row returned, but now we need to know if update happened, that is if WHERE matched
 		//	 * write != 1 means no permission to write
 		//	 * dbVersion != original version means OCC failure
 
@@ -681,16 +681,16 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 			ON CONFLICT (collection, key, user_id) DO
 				UPDATE SET value = $4, version = $5, read = $6, write = $7, update_time = now()
 				WHERE TRUE` + writeCheck + `
-				AND NOT (storage.version = $5 AND storage.read = $6 AND storage.write = $7) -- micro optimization: don't update row unnecessary
+				AND NOT (storage.version = $5 AND storage.read = $6 AND storage.write = $7) -- micro optimization: don't update row unnecessarily
 			RETURNING read, write, version, create_time, update_time
 		)
-		(SELECT read, write, version, create_time, update_time from upd)
+		(SELECT read, write, version, create_time, update_time, 1::integer AS "order" FROM upd)
 		UNION ALL
-		(SELECT read, write, version, create_time, update_time FROM storage WHERE collection = $1 and key = $2 and user_id = $3)
-		LIMIT 1`
+		(SELECT read, write, version, create_time, update_time, 2::integer AS "order" FROM storage WHERE collection = $1 and key = $2 and user_id = $3)
+		ORDER BY "order" LIMIT 1`
 
 		// Outcomes:
-		// - Row is always returned, need to know if update happened, that is its WHERE matches
+		// - Row is always returned, need to know if update happened, that WHERE matches
 		// - write != 1 means no permission to write
 
 	case object.Version == "*":
@@ -699,7 +699,7 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		query = `
 		INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
-		RETURNING read, write, version, create_time, update_time`
+		RETURNING read, write, version, create_time, update_time, true`
 
 		// Outcomes:
 		// - NoRows - insert failed due to constraint violation (concurrent insert)

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -656,10 +656,9 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		` + writeCheck + `
 			RETURNING read, write, version, create_time, update_time
 		)
-		(SELECT read, write, version, create_time, update_time, true AS update FROM upd)
+		(SELECT read, write, version, create_time, update_time, true AS update FROM upd WHERE EXISTS (SELECT 1 FROM upd))
 		UNION ALL
-		(SELECT read, write, version, create_time, update_time, false AS update FROM storage WHERE collection = $1 and key = $2 and user_id = $3)
-		ORDER BY update DESC
+		(SELECT read, write, version, create_time, update_time, false AS update FROM storage WHERE collection = $1 and key = $2 and user_id = $3 AND NOT EXISTS (SELECT 1 FROM upd))
 		LIMIT 1`
 
 		params = append(params, object.Version)
@@ -685,10 +684,9 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 				WHERE TRUE` + writeCheck + `
 			RETURNING read, write, version, create_time, update_time
 		)
-		(SELECT read, write, version, create_time, update_time, true AS upsert FROM upd)
+		(SELECT read, write, version, create_time, update_time, true AS upsert FROM upd WHERE EXISTS (SELECT 1 FROM upd))
 		UNION ALL
-		(SELECT read, write, version, create_time, update_time, false AS upsert FROM storage WHERE collection = $1 and key = $2 and user_id = $3)
-		ORDER BY upsert DESC
+		(SELECT read, write, version, create_time, update_time, false AS upsert FROM storage WHERE collection = $1 and key = $2 and user_id = $3 AND NOT EXISTS (SELECT 1 FROM upd))
 		LIMIT 1`
 
 		// Outcomes:

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -653,9 +653,9 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 		// allows us to fetch row state after update even if update itself fails WHERE
 		// condition.
 		// That is returned values are final state of the row regardless of UPDATE success
-		// Order by is required because UNION ALL may not guarantee ordering but order is required
-		// to ensure that if upsert happens values from said upsert are returned.
-		// At most 2 rows are ever returned so ordering operations should be negligible.
+		// Order by is necessary as UNION ALL may not guarantee ordering of results, but it is required
+		// to ensure that if update happens values from said update are returned.
+		// At most 2 rows are ever returned so ordering operation should be negligible.
 		query = `
 		WITH upd AS (
 			UPDATE storage SET value = $4, version = $5, read = $6, write = $7, update_time = now()

--- a/server/core_storage_test.go
+++ b/server/core_storage_test.go
@@ -2334,16 +2334,16 @@ func TestOCCWriteSameValueWithOutdatedVersionFail(t *testing.T) {
 	assert.Len(t, acks.Acks, 1)
 
 	// Change object value
-	outdatedVersion := acks.Acks[0].Version
-	ops[0].Object.Version = outdatedVersion
+	version := acks.Acks[0].Version
+	ops[0].Object.Version = version
 	ops[0].Object.Value = `{"closed":true}`
 
 	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
 	assert.Nil(t, err)
 	assert.Len(t, acks.Acks, 1)
 
-	// Rewrite object to same value with outdated version -- must fail
-	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	// Rewrite object to same value with now invalid version -- must fail
+	_, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error())
 }
@@ -2387,4 +2387,5 @@ func TestOCCWriteSameValueCorrectVersionSuccess(t *testing.T) {
 
 	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
 	assert.Nil(t, err)
+	assert.Len(t, acks.Acks, 1)
 }

--- a/server/core_storage_test.go
+++ b/server/core_storage_test.go
@@ -2306,3 +2306,84 @@ func writeObject(t *testing.T, db *sql.DB, collection, key string, owner uuid.UU
 	}}
 	return StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, authoritative, ops)
 }
+
+func TestOCCWriteSameValueWithOutdatedVersion(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	uid := uuid.Must(uuid.NewV4())
+	InsertUser(t, db, uid)
+	collection := GenerateString()
+	key := GenerateString()
+
+	ops := StorageOpWrites{
+		&StorageOpWrite{
+			OwnerID: uid.String(),
+			Object: &api.WriteStorageObject{
+				Collection: collection,
+				Key:        key,
+				Value:      `{"closed":false}`,
+				Version:    "",
+			},
+		},
+	}
+
+	// Create object
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	assert.Nil(t, err)
+	assert.Len(t, acks.Acks, 1)
+
+	// Change object value
+	outdatedVersion := acks.Acks[0].Version
+	ops[0].Object.Version = outdatedVersion
+	ops[0].Object.Value = `{"closed":true}`
+
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	assert.Nil(t, err)
+	assert.Len(t, acks.Acks, 1)
+
+	// Rewrite object to same value with outdated version
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	assert.NotNil(t, err)
+}
+
+func TestOCCWriteSameValueCorrectVersion(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	uid := uuid.Must(uuid.NewV4())
+	InsertUser(t, db, uid)
+	collection := GenerateString()
+	key := GenerateString()
+
+	ops := StorageOpWrites{
+		&StorageOpWrite{
+			OwnerID: uid.String(),
+			Object: &api.WriteStorageObject{
+				Collection: collection,
+				Key:        key,
+				Value:      `{"closed":false}`,
+				Version:    "",
+			},
+		},
+	}
+
+	// Create object
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	assert.Nil(t, err)
+	assert.Len(t, acks.Acks, 1)
+
+	// Change object value
+	ops[0].Object.Version = acks.Acks[0].Version
+	ops[0].Object.Value = `{"closed":true}`
+
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	assert.Nil(t, err)
+	assert.Len(t, acks.Acks, 1)
+
+	// Rewrite object to same value with correct version
+	ops[0].Object.Version = acks.Acks[0].Version
+
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	assert.NotNil(t, err)
+}

--- a/server/runtime_javascript_test.go
+++ b/server/runtime_javascript_test.go
@@ -73,7 +73,7 @@ m.foo = 'baz';
 		if err == nil {
 			t.Errorf("should've thrown an error")
 		}
-		if !strings.Contains(err.Error(), "TypeError: Cannot assign to read only property 'foo' at test:2:1(2)") {
+		if !strings.Contains(err.Error(), "TypeError: Cannot assign to read only property 'foo'") {
 			t.Errorf("should've thrown an error")
 		}
 	})


### PR DESCRIPTION
Fix an issue where storage object write with version would fail to return version rejected error if the same value is written consecutively using an invalid version.