### PR TITLE
feat(build): setup multiarch build for arm64

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,26 +15,39 @@
 # docker build "$PWD" --build-arg commit="$(git rev-parse --short HEAD)" --build-arg version=v2.1.1 -t heroiclabs/nakama:2.1.1
 # docker build "$PWD" --build-arg commit="$(git rev-parse --short HEAD)" --build-arg version="$(git rev-parse --short HEAD)" -t heroiclabs/nakama-prerelease:"$(git rev-parse --short HEAD)"
 
-FROM golang:1.21.5-bookworm as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.5-bookworm as builder
 
+ARG TARGETARCH
 ARG commit
 ARG version
 
 ENV GOOS linux
-ENV GOARCH amd64
+ENV GOARCH=$TARGETARCH
 ENV CGO_ENABLED 1
 
-RUN apt-get update && \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+    dpkg --add-architecture amd64; \
+    fi && \
+    apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends ca-certificates gcc libc6-dev git && \
+    apt-get install -y --no-install-recommends ca-certificates git && \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+    apt-get install -y --no-install-recommends g++-x86-64-linux-gnu libc6-dev-amd64-cross; \
+    elif [ "${TARGETARCH}" = "arm64" ]; then \
+    apt-get install -y --no-install-recommends gcc libc6-dev; \
+    fi && \
     git config --global advice.detachedHead false && \
     git clone --quiet --no-checkout https://github.com/heroiclabs/nakama /go/build/nakama
 
 WORKDIR /go/build/nakama
 RUN git checkout --quiet "$commit" && \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+    export CC=x86_64-linux-gnu-gcc && \
+    export CXX=x86_64-linux-gnu-g++; \
+    fi && \
     go build -o /go/build-out/nakama -trimpath -mod=vendor -gcflags "-trimpath $PWD" -asmflags "-trimpath $PWD" -ldflags "-s -w -X main.version=$version -X main.commitID=$commit"
 
-FROM debian:bookworm-slim
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim
 
 MAINTAINER Heroic Labs <support@heroiclabs.com>
 

--- a/build/multiarch_build
+++ b/build/multiarch_build
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Nakama Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# docker context create container
+# docker buildx create --use container
+
+VER="2.1.1"
+DOCKER_VER=heroiclabs/nakama:$VER
+echo Building $DOCKER_VER
+docker buildx build --platform linux/amd64,linux/arm64 \
+  --builder=container \
+  --build-arg commit="$(git rev-parse --short HEAD)" \
+  --build-arg version=v$VER \
+  --tag $DOCKER_VER \
+  --push .
+
+DOCKER_PREVER=heroiclabs/nakama-prerelease:"$(git rev-parse --short HEAD)"
+echo Building $DOCKER_PREVER
+docker buildx build --platform linux/amd64,linux/arm64 \
+  --builder=container \
+  --build-arg commit="$(git rev-parse --short HEAD)" \
+  --build-arg version="$(git rev-parse --short HEAD)" \
+  --tag $DOCKER_PREVER \
+  --push .


### PR DESCRIPTION
According to issue #1160 #1138 

I do not know what the CI environment is for building the docker images. But I have updated the Dockerfile to be able to accommodate multiarch builds. Note my environment is `arm64` so I have to set up the docker for amd64, the converse may be true for your build CI environment.

As per the `multi_arch` script the docker buildx environment needs to be setup:

```bash
docker context create container
docker buildx create --use container
```

I assume the CI is a linux environment in which case buildx needs to be installed: https://github.com/docker/buildx?tab=readme-ov-file#linux-packages