### PR TITLE
Fix tournament active time calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - Skip Google refund handling for deleted users.
 - Fix storage engine version check regression.
 - Fix JS runtime tournament records list owner ids param.
+- Fix regression in tournament end active time calculation when it coincides with reset schedule.
 
 ## [3.20.0] - 2023-12-15
 ### Changed

--- a/server/core_tournament.go
+++ b/server/core_tournament.go
@@ -717,7 +717,7 @@ func calculateTournamentDeadlines(startTime, endTime, duration int64, resetSched
 			startActiveUnix = resetSchedule.Next(time.Unix(startTime, 0).UTC()).UTC().Unix()
 		} else {
 			// check if we are landing squarely on the reset schedule
-			landsOnSched := resetSchedule.Next(t.Add(-1*time.Second)) == t
+			landsOnSched := resetSchedule.Next(t.Add(-1*time.Second)).Unix() == t.Unix()
 			if landsOnSched {
 				startActiveUnix = tUnix
 			} else {


### PR DESCRIPTION
Return correct active time when tournament duration collides with reset schedule.