### PR TITLE
Add support for storage deletes in multiUpdate and adjust storage index writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+replace github.com/heroiclabs/nakama-common => ../nakama-common
+
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1
-	github.com/heroiclabs/nakama-common v1.30.2-0.20240207201555-08682d86735e
+	github.com/heroiclabs/nakama-common v1.30.2-0.20240312140147-3a509c052c10
 	github.com/jackc/pgconn v1.14.1
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgtype v1.14.0
@@ -37,8 +37,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/heroiclabs/nakama-common => ../nakama-common
 
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,12 +155,8 @@ github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZH
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 h1:6UKoz5ujsI55KNpsJH3UwCq3T8kKbZwNZBNPuTTje8U=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1/go.mod h1:YvJ2f6MplWDhfxiUC3KpyTy76kYUZA4W3pTv/wdKQ9Y=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/heroiclabs/nakama-common v1.30.1 h1:2lnP71Rgix/WDbvq4hQ2EoecEiItJtMHcRLdZXpUpeo=
-github.com/heroiclabs/nakama-common v1.30.1/go.mod h1:Os8XeXGvHAap/p6M/8fQ3gle4eEXDGRQmoRNcPQTjXs=
-github.com/heroiclabs/nakama-common v1.30.2-0.20240207195416-15dafabfc934 h1:H33kk2lhsdsSIX7qzKsWgGdl2xDOdSZqhNeo22QQ6XU=
-github.com/heroiclabs/nakama-common v1.30.2-0.20240207195416-15dafabfc934/go.mod h1:Os8XeXGvHAap/p6M/8fQ3gle4eEXDGRQmoRNcPQTjXs=
-github.com/heroiclabs/nakama-common v1.30.2-0.20240207201555-08682d86735e h1:z+YFZcDoaVl9ytUTEI3h5XoakXCqRFRfVXfBsI/bX2U=
-github.com/heroiclabs/nakama-common v1.30.2-0.20240207201555-08682d86735e/go.mod h1:Os8XeXGvHAap/p6M/8fQ3gle4eEXDGRQmoRNcPQTjXs=
+github.com/heroiclabs/nakama-common v1.30.2-0.20240312140147-3a509c052c10 h1:SJAkxoFzg1e+WqtedeggzL3MJC0/vHgJ9iI0GVUawXg=
+github.com/heroiclabs/nakama-common v1.30.2-0.20240312140147-3a509c052c10/go.mod h1:Os8XeXGvHAap/p6M/8fQ3gle4eEXDGRQmoRNcPQTjXs=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=

--- a/server/core_multi.go
+++ b/server/core_multi.go
@@ -24,12 +24,13 @@ import (
 	"go.uber.org/zap"
 )
 
-func MultiUpdate(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Metrics, accountUpdates []*accountUpdate, storageWrites StorageOpWrites, walletUpdates []*walletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
-	if len(accountUpdates) == 0 && len(storageWrites) == 0 && len(walletUpdates) == 0 {
+func MultiUpdate(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Metrics, accountUpdates []*accountUpdate, storageWrites StorageOpWrites, storageDeletes StorageOpDeletes, storageIndex StorageIndex, walletUpdates []*walletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
+	if len(accountUpdates) == 0 && len(storageWrites) == 0 && len(storageDeletes) == 0 && len(walletUpdates) == 0 {
 		return nil, nil, nil
 	}
 
 	var storageWriteAcks []*api.StorageObjectAck
+	var storageWriteOps StorageOpWrites
 	var walletUpdateResults []*runtime.WalletUpdateResult
 
 	if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
@@ -43,9 +44,15 @@ func MultiUpdate(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Me
 		}
 
 		// Execute any storage updates.
-		storageWriteAcks, updateErr = storageWriteObjects(ctx, logger, metrics, tx, true, storageWrites)
+		storageWriteOps, storageWriteAcks, updateErr = storageWriteObjects(ctx, logger, metrics, tx, true, storageWrites)
 		if updateErr != nil {
 			return updateErr
+		}
+
+		// Execute any storage deletes.
+		deleteErr := storageDeleteObjects(ctx, logger, tx, true, storageDeletes)
+		if deleteErr != nil {
+			return deleteErr
 		}
 
 		// Execute any wallet updates.
@@ -62,6 +69,10 @@ func MultiUpdate(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Me
 		logger.Error("Error running multi update.", zap.Error(err))
 		return nil, walletUpdateResults, err
 	}
+
+	// Update storage index.
+	storageIndexWrite(ctx, storageIndex, storageWriteOps, storageWriteAcks)
+	storageIndex.Delete(ctx, storageDeletes)
 
 	return storageWriteAcks, walletUpdateResults, nil
 }

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -503,11 +503,12 @@ func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, cal
 
 func StorageWriteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Metrics, storageIndex StorageIndex, authoritativeWrite bool, ops StorageOpWrites) (*api.StorageObjectAcks, codes.Code, error) {
 	var acks []*api.StorageObjectAck
+	var sortedWrites StorageOpWrites
 
 	if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
 		// If the transaction is retried ensure we wipe any acks that may have been prepared by previous attempts.
 		var writeErr error
-		acks, writeErr = storageWriteObjects(ctx, logger, metrics, tx, authoritativeWrite, ops)
+		sortedWrites, acks, writeErr = storageWriteObjects(ctx, logger, metrics, tx, authoritativeWrite, ops)
 		if writeErr != nil {
 			if writeErr == runtime.ErrStorageRejectedVersion || writeErr == runtime.ErrStorageRejectedPermission {
 				logger.Debug("Error writing storage objects.", zap.Error(writeErr))
@@ -527,27 +528,12 @@ func StorageWriteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, me
 		return nil, codes.Internal, err
 	}
 
-	sw := make([]*api.StorageObject, 0, len(ops))
-	for i, o := range ops {
-		sw = append(sw, &api.StorageObject{
-			Collection:      o.Object.Collection,
-			Key:             o.Object.Key,
-			UserId:          o.OwnerID,
-			Value:           o.Object.Value,
-			Version:         acks[i].Version,
-			PermissionRead:  o.Object.PermissionRead.GetValue(),
-			PermissionWrite: o.Object.PermissionRead.GetValue(),
-			CreateTime:      acks[i].CreateTime,
-			UpdateTime:      acks[i].UpdateTime,
-		})
-	}
-
-	storageIndex.Write(ctx, sw)
+	storageIndexWrite(ctx, storageIndex, sortedWrites, acks)
 
 	return &api.StorageObjectAcks{Acks: acks}, codes.OK, nil
 }
 
-func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metrics, tx pgx.Tx, authoritativeWrite bool, ops StorageOpWrites) ([]*api.StorageObjectAck, error) {
+func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metrics, tx pgx.Tx, authoritativeWrite bool, ops StorageOpWrites) (StorageOpWrites, []*api.StorageObjectAck, error) {
 	// Ensure writes are processed in a consistent order to avoid deadlocks from concurrent operations.
 	// Sorting done on a copy to ensure we don't modify the input, which may be re-used on transaction retries.
 	sortedOps := make(StorageOpWrites, 0, len(ops))
@@ -580,16 +566,16 @@ func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metric
 		if err != nil && errors.As(err, &pgErr) {
 			if pgErr.Code == dbErrorUniqueViolation {
 				metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "version"}, 1)
-				return nil, runtime.ErrStorageRejectedVersion
+				return nil, nil, runtime.ErrStorageRejectedVersion
 			}
-			return nil, err
+			return nil, nil, err
 		} else if err == pgx.ErrNoRows {
 			// Not every case from storagePrepWriteObject can return NoRows, but those
 			// which do are always ErrStorageRejectedVersion
 			metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "version"}, 1)
-			return nil, runtime.ErrStorageRejectedVersion
+			return nil, nil, runtime.ErrStorageRejectedVersion
 		} else if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if !isUpsert {
@@ -598,11 +584,11 @@ func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metric
 			if !authoritativeWrite && resultWrite != 1 {
 				// - permission: non-authoritative write & original row write != 1
 				metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "permission"}, 1)
-				return nil, runtime.ErrStorageRejectedPermission
+				return nil, nil, runtime.ErrStorageRejectedPermission
 			} else if object.Version != "" {
 				// - version mismatch
 				metrics.StorageWriteRejectCount(map[string]string{"collection": object.Collection, "reason": "version"}, 1)
-				return nil, runtime.ErrStorageRejectedVersion
+				return nil, nil, runtime.ErrStorageRejectedVersion
 			}
 		}
 
@@ -617,7 +603,7 @@ func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metric
 		acks[indexedOps[op]] = ack
 	}
 
-	return acks, nil
+	return sortedOps, acks, nil
 }
 
 func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWrite) {
@@ -707,41 +693,10 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 }
 
 func StorageDeleteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, storageIndex StorageIndex, authoritativeDelete bool, ops StorageOpDeletes) (codes.Code, error) {
-	// Ensure deletes are processed in a consistent order.
-	sort.Sort(ops)
-
-	if err := ExecuteInTx(ctx, db, func(tx *sql.Tx) error {
-		for _, op := range ops {
-			params := []interface{}{op.ObjectID.Collection, op.ObjectID.Key, op.OwnerID}
-			var query string
-			if authoritativeDelete {
-				// Deleting from the runtime.
-				query = "DELETE FROM storage WHERE collection = $1 AND key = $2 AND user_id = $3"
-			} else {
-				// Direct client request to delete.
-				query = "DELETE FROM storage WHERE collection = $1 AND key = $2 AND user_id = $3 AND write > 0"
-			}
-			if op.ObjectID.GetVersion() != "" {
-				// Conditional delete.
-				params = append(params, op.ObjectID.Version)
-				query += " AND version = $4"
-			}
-
-			result, err := tx.ExecContext(ctx, query, params...)
-			if err != nil {
-				logger.Debug("Could not delete storage object.", zap.Error(err), zap.String("query", query), zap.Any("object_id", op.ObjectID))
-				return err
-			}
-
-			if authoritativeDelete && op.ObjectID.GetVersion() == "" {
-				// If it's an authoritative delete and there is no OCC, the only reason rows affected would be 0 is having
-				// nothing to delete. In that case it's safe to assume the deletion was just a no-op and there's no need
-				// to check anything further. Should apply something similar to non-authoritative deletes too.
-				continue
-			}
-			if rowsAffected, _ := result.RowsAffected(); rowsAffected == 0 {
-				return StatusError(codes.InvalidArgument, "Storage delete rejected.", errors.New("Storage delete rejected - not found, version check failed, or permission denied."))
-			}
+	if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
+		deleteErr := storageDeleteObjects(ctx, logger, tx, authoritativeDelete, ops)
+		if deleteErr != nil {
+			return deleteErr
 		}
 		return nil
 	}); err != nil {
@@ -755,4 +710,63 @@ func StorageDeleteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, s
 	storageIndex.Delete(ctx, ops)
 
 	return codes.OK, nil
+}
+
+func storageDeleteObjects(ctx context.Context, logger *zap.Logger, tx pgx.Tx, authoritativeDelete bool, ops StorageOpDeletes) error {
+	// Ensure deletes are processed in a consistent order.
+	sort.Sort(ops)
+
+	for _, op := range ops {
+		params := []interface{}{op.ObjectID.Collection, op.ObjectID.Key, op.OwnerID}
+		var query string
+		if authoritativeDelete {
+			// Deleting from the runtime.
+			query = "DELETE FROM storage WHERE collection = $1 AND key = $2 AND user_id = $3"
+		} else {
+			// Direct client request to delete.
+			query = "DELETE FROM storage WHERE collection = $1 AND key = $2 AND user_id = $3 AND write > 0"
+		}
+		if op.ObjectID.GetVersion() != "" {
+			// Conditional delete.
+			params = append(params, op.ObjectID.Version)
+			query += " AND version = $4"
+		}
+
+		result, err := tx.Exec(ctx, query, params...)
+		if err != nil {
+			logger.Debug("Could not delete storage object.", zap.Error(err), zap.String("query", query), zap.Any("object_id", op.ObjectID))
+			return err
+		}
+
+		if authoritativeDelete && op.ObjectID.GetVersion() == "" {
+			// If it's an authoritative delete and there is no OCC, the only reason rows affected would be 0 is having
+			// nothing to delete. In that case it's safe to assume the deletion was just a no-op and there's no need
+			// to check anything further. Should apply something similar to non-authoritative deletes too.
+			continue
+		}
+		if rowsAffected := result.RowsAffected(); rowsAffected == 0 {
+			return StatusError(codes.InvalidArgument, "Storage delete rejected.", errors.New("Storage delete rejected - not found, version check failed, or permission denied."))
+		}
+	}
+
+	return nil
+}
+
+func storageIndexWrite(ctx context.Context, storageIndex StorageIndex, ops StorageOpWrites, acks []*api.StorageObjectAck) {
+	sw := make([]*api.StorageObject, 0, len(ops))
+	for i, o := range ops {
+		sw = append(sw, &api.StorageObject{
+			Collection:      o.Object.Collection,
+			Key:             o.Object.Key,
+			UserId:          o.OwnerID,
+			Value:           o.Object.Value,
+			Version:         acks[i].Version,
+			PermissionRead:  o.Object.PermissionRead.GetValue(),
+			PermissionWrite: o.Object.PermissionRead.GetValue(),
+			CreateTime:      acks[i].CreateTime,
+			UpdateTime:      acks[i].UpdateTime,
+		})
+	}
+
+	storageIndex.Write(ctx, sw)
 }

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -6117,6 +6117,7 @@ func (n *RuntimeLuaNakamaModule) storageDelete(l *lua.LState) int {
 // @summary Update account, storage, and wallet information simultaneously.
 // @param accountUpdates(type=table) List of account information to be updated.
 // @param storageWrites(type=table) List of storage objects to be updated.
+// @param storageDeletes(type=table) A list of storage objects to be deleted.
 // @param walletUpdates(type=table) List of wallet updates to be made.
 // @param updateLedger(type=bool, optional=true, default=false) Whether to record this wallet update in the ledger.
 // @return storageWriteAcks(table) A list of acks with the version of the written objects.
@@ -6377,9 +6378,111 @@ func (n *RuntimeLuaNakamaModule) multiUpdate(l *lua.LState) int {
 		}
 	}
 
+	// Process storage delete inputs.
+	var storageDeleteOps StorageOpDeletes
+	storageDeleteTable := l.OptTable(3, nil)
+	if storageDeleteTable != nil {
+		size := storageDeleteTable.Len()
+		storageDeleteOps = make(StorageOpDeletes, 0, size)
+		conversionError := false
+		storageDeleteTable.ForEach(func(k, v lua.LValue) {
+			if conversionError {
+				return
+			}
+
+			dataTable, ok := v.(*lua.LTable)
+			if !ok {
+				conversionError = true
+				l.ArgError(3, "expects a valid set of storage data")
+				return
+			}
+
+			var userID uuid.UUID
+			d := &api.DeleteStorageObjectId{}
+			dataTable.ForEach(func(k, v lua.LValue) {
+				if conversionError {
+					return
+				}
+
+				switch k.String() {
+				case "collection":
+					if v.Type() != lua.LTString {
+						conversionError = true
+						l.ArgError(3, "expects collection to be string")
+						return
+					}
+					d.Collection = v.String()
+					if d.Collection == "" {
+						conversionError = true
+						l.ArgError(3, "expects collection to be a non-empty string")
+						return
+					}
+				case "key":
+					if v.Type() != lua.LTString {
+						conversionError = true
+						l.ArgError(3, "expects key to be string")
+						return
+					}
+					d.Key = v.String()
+					if d.Key == "" {
+						conversionError = true
+						l.ArgError(3, "expects key to be a non-empty string")
+						return
+					}
+				case "user_id":
+					if v.Type() != lua.LTString {
+						conversionError = true
+						l.ArgError(3, "expects user_id to be string")
+						return
+					}
+					var err error
+					if userID, err = uuid.FromString(v.String()); err != nil {
+						conversionError = true
+						l.ArgError(3, "expects user_id to be a valid ID")
+						return
+					}
+				case "version":
+					if v.Type() != lua.LTString {
+						conversionError = true
+						l.ArgError(3, "expects version to be string")
+						return
+					}
+					d.Version = v.String()
+					if d.Version == "" {
+						conversionError = true
+						l.ArgError(3, "expects version to be a non-empty string")
+						return
+					}
+				}
+			})
+
+			if conversionError {
+				return
+			}
+
+			if d.Collection == "" {
+				conversionError = true
+				l.ArgError(3, "expects collection to be supplied")
+				return
+			} else if d.Key == "" {
+				conversionError = true
+				l.ArgError(3, "expects key to be supplied")
+				return
+			}
+
+			storageDeleteOps = append(storageDeleteOps, &StorageOpDelete{
+				OwnerID:  userID.String(),
+				ObjectID: d,
+			})
+		})
+		if conversionError {
+			return 0
+		}
+	}
+
 	// Process wallet update inputs.
 	var walletUpdates []*walletUpdate
-	walletTable := l.OptTable(3, nil)
+	walletTable := l.OptTable(4, nil)
 	if walletTable != nil {
 		size := walletTable.Len()
 		walletUpdates = make([]*walletUpdate, 0, size)
@@ -6392,7 +6495,7 @@ func (n *RuntimeLuaNakamaModule) multiUpdate(l *lua.LState) int {
 			updateTable, ok := v.(*lua.LTable)
 			if !ok {
 				conversionError = true
-				l.ArgError(3, "expects a valid set of updates")
+				l.ArgError(4, "expects a valid set of updates")
 				return
 			}
 
@@ -6406,20 +6509,20 @@ func (n *RuntimeLuaNakamaModule) multiUpdate(l *lua.LState) int {
 				case "user_id":
 					if v.Type() != lua.LTString {
 						conversionError = true
-						l.ArgError(3, "expects user_id to be string")
+						l.ArgError(4, "expects user_id to be string")
 						return
 					}
 					uid, err := uuid.FromString(v.String())
 					if err != nil {
 						conversionError = true
-						l.ArgError(3, "expects user_id to be a valid ID")
+						l.ArgError(4, "expects user_id to be a valid ID")
 						return
 					}
 					update.UserID = uid
 				case "changeset":
 					if v.Type() != lua.LTTable {
 						conversionError = true
-						l.ArgError(3, "expects changeset to be table")
+						l.ArgError(4, "expects changeset to be table")
 						return
 					}
 					changeset := RuntimeLuaConvertLuaTable(v.(*lua.LTable))
@@ -6428,7 +6531,7 @@ func (n *RuntimeLuaNakamaModule) multiUpdate(l *lua.LState) int {
 						cvi, ok := cv.(int64)
 						if !ok {
 							conversionError = true
-							l.ArgError(3, "expects changeset values to be whole numbers")
+							l.ArgError(4, "expects changeset values to be whole numbers")
 							return
 						}
 						update.Changeset[ck] = cvi
@@ -6436,14 +6539,14 @@ func (n *RuntimeLuaNakamaModule) multiUpdate(l *lua.LState) int {
 				case "metadata":
 					if v.Type() != lua.LTTable {
 						conversionError = true
-						l.ArgError(3, "expects metadata to be table")
+						l.ArgError(4, "expects metadata to be table")
 						return
 					}
 					metadataMap := RuntimeLuaConvertLuaTable(v.(*lua.LTable))
 					metadataBytes, err := json.Marshal(metadataMap)
 					if err != nil {
 						conversionError = true
-						l.ArgError(3, fmt.Sprintf("failed to convert metadata: %s", err.Error()))
+						l.ArgError(4, fmt.Sprintf("failed to convert metadata: %s", err.Error()))
 						return
 					}
 					update.Metadata = string(metadataBytes)
@@ -6461,7 +6564,7 @@ func (n *RuntimeLuaNakamaModule) multiUpdate(l *lua.LState) int {
 
 			if update.Changeset == nil {
 				conversionError = true
-				l.ArgError(3, "expects changeset to be supplied")
+				l.ArgError(4, "expects changeset to be supplied")
 				return
 			}
 
@@ -6472,9 +6575,9 @@ func (n *RuntimeLuaNakamaModule) multiUpdate(l *lua.LState) int {
 		}
 	}
 
-	updateLedger := l.OptBool(4, false)
+	updateLedger := l.OptBool(5, false)
 
-	acks, results, err := MultiUpdate(l.Context(), n.logger, n.db, n.metrics, accountUpdates, storageWriteOps, walletUpdates, updateLedger)
+	acks, results, err := MultiUpdate(l.Context(), n.logger, n.db, n.metrics, accountUpdates, storageWriteOps, storageDeleteOps, n.storageIndex, walletUpdates, updateLedger)
 	if err != nil {
 		l.RaiseError("error running multi update: %v", err.Error())
 		return 0

--- a/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
+++ b/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
@@ -1080,7 +1080,7 @@ type NakamaModule interface {
 	StorageDelete(ctx context.Context, deletes []*StorageDelete) error
 	StorageIndexList(ctx context.Context, callerID, indexName, query string, limit int) (*api.StorageObjects, error)
 
-	MultiUpdate(ctx context.Context, accountUpdates []*AccountUpdate, storageWrites []*StorageWrite, walletUpdates []*WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*WalletUpdateResult, error)
+	MultiUpdate(ctx context.Context, accountUpdates []*AccountUpdate, storageWrites []*StorageWrite, storageDeletes []*StorageDelete, walletUpdates []*WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*WalletUpdateResult, error)
 
 	LeaderboardCreate(ctx context.Context, id string, authoritative bool, sortOrder, operator, resetSchedule string, metadata map[string]interface{}) error
 	LeaderboardDelete(ctx context.Context, id string) error

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -147,7 +147,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopena
 github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options
 github.com/grpc-ecosystem/grpc-gateway/v2/runtime
 github.com/grpc-ecosystem/grpc-gateway/v2/utilities
-# github.com/heroiclabs/nakama-common v1.30.2-0.20240207201555-08682d86735e => ../nakama-common
+# github.com/heroiclabs/nakama-common v1.30.2-0.20240312140147-3a509c052c10
 ## explicit; go 1.19
 github.com/heroiclabs/nakama-common/api
 github.com/heroiclabs/nakama-common/rtapi
@@ -438,4 +438,3 @@ gopkg.in/natefinch/lumberjack.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# github.com/heroiclabs/nakama-common => ../nakama-common

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -147,7 +147,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopena
 github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options
 github.com/grpc-ecosystem/grpc-gateway/v2/runtime
 github.com/grpc-ecosystem/grpc-gateway/v2/utilities
-# github.com/heroiclabs/nakama-common v1.30.2-0.20240207201555-08682d86735e
+# github.com/heroiclabs/nakama-common v1.30.2-0.20240207201555-08682d86735e => ../nakama-common
 ## explicit; go 1.19
 github.com/heroiclabs/nakama-common/api
 github.com/heroiclabs/nakama-common/rtapi
@@ -438,3 +438,4 @@ gopkg.in/natefinch/lumberjack.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/heroiclabs/nakama-common => ../nakama-common


### PR DESCRIPTION
- Add storage deletes to the `multiUpdate` runtime function
- Assemble and write objects to storage index in the order they were written to storage (sorted)
- Add missing storage index write to `multiUpdate`

`nakama-common` PR: https://github.com/heroiclabs/nakama-common/pull/140

Closes #1173