### PR TITLE
fix race/inconsistency in leadboard rank cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 ## [Unreleased]
 ### Changes
 - Reduce number of memory allocations in leaderboard cache.
-- Fix leaderboard rank cache insonsistency/race that could arise under heavy load.
+- Fix leaderboard rank cache inconsistencies/race that could arise under heavy load.
 
 ### Fixed
 - Prevent players from requesting duplicate joins to the same party.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 
 ## [Unreleased]
 ### Changes
-- Reduce number of memory allocations in leaderboard cache
+- Reduce number of memory allocations in leaderboard cache.
+- Fix leaderboard rank cache insonsistency/race that could arise under heavy load.
 
 ### Fixed
 - Prevent players from requesting duplicate joins to the same party.

--- a/internal/skiplist/skiplist_chaos_test.go
+++ b/internal/skiplist/skiplist_chaos_test.go
@@ -1,0 +1,109 @@
+package skiplist
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func randString(t *testing.T, rnd *rand.Rand) string {
+	b := make([]byte, 16)
+	_, err := rnd.Read(b)
+	require.NoError(t, err)
+
+	return fmt.Sprintf("%X-%X-%X-%X-%X", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+type testInterface struct {
+	id  string
+	val int
+}
+
+func (ti testInterface) Less(other interface{}) bool {
+	otherTi := other.(testInterface)
+
+	if ti.val < otherTi.val {
+		return true
+	}
+
+	if ti.val > otherTi.val {
+		return false
+	}
+
+	return ti.id < otherTi.id
+}
+
+func TestSkiplistChaos(t *testing.T) {
+	rnd := rand.New(rand.NewSource(0))
+	iterations := 20
+
+	for i := 0; i < iterations; i++ {
+		numUsers := rnd.Intn(2000) + 100
+		users := make([]string, numUsers)
+
+		for j := 0; j < numUsers; j++ {
+			users[j] = randString(t, rnd)
+		}
+
+		numOps := rnd.Intn(100_000) + 100
+		ops := make([]testInterface, numOps)
+
+		for j := 0; j < numOps; j++ {
+			id := users[rnd.Intn(numUsers)]
+			ops[j] = testInterface{
+				id:  id,
+				val: rnd.Intn(999) + 1,
+			}
+		}
+
+		numLists := rnd.Intn(47) + 3
+		lists := make([]*SkipList, numLists)
+		userOps := make([]map[string]testInterface, numLists)
+
+		fmt.Printf("** iteration=%v, users=%v, ops=%v, lists=%v\n", i, numUsers, numOps, numLists)
+
+		// Populate lists
+		for j := 0; j < numLists; j++ {
+			rnd.Shuffle(len(ops), func(i, j int) {
+				ops[i], ops[j] = ops[j], ops[i]
+			})
+
+			userOps[j] = make(map[string]testInterface, numUsers)
+
+			lists[j] = New()
+			for _, op := range ops {
+				oldOp, ok := userOps[j][op.id]
+				if ok {
+					lists[j].Delete(oldOp)
+					op.val += oldOp.val
+				}
+
+				lists[j].Insert(op)
+				userOps[j][op.id] = op
+			}
+		}
+
+		// Now verify
+		for j, sl := range lists {
+			listOps := make([]testInterface, 0, len(ops))
+
+			for _, op := range userOps[j] {
+				listOps = append(listOps, op)
+			}
+
+			sort.Slice(listOps, func(i, j int) bool {
+				return listOps[i].Less(listOps[j])
+			})
+
+			for idx, op := range listOps {
+				rank := idx + 1
+
+				listRank := sl.GetRank(op)
+				require.Equal(t, rank, listRank, "list %d, unexpected rank for op %+v", j, op)
+			}
+		}
+	}
+}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -150,8 +150,8 @@ func NewConsoleLogger(output *os.File, verbose bool) *zap.Logger {
 }
 
 func NewDB(t *testing.T) *sql.DB {
-	db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
-	//db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
+	//db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
+	db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
 	if err != nil {
 		t.Fatal("Error connecting to database", err)
 	}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -150,8 +150,8 @@ func NewConsoleLogger(output *os.File, verbose bool) *zap.Logger {
 }
 
 func NewDB(t *testing.T) *sql.DB {
-	//db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
-	db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
+	db, err := sql.Open("pgx", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
+	//db, err := sql.Open("pgx", "postgresql://postgres@127.0.0.1:5432/nakama?sslmode=disable")
 	if err != nil {
 		t.Fatal("Error connecting to database", err)
 	}

--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -366,7 +366,7 @@ WHERE leaderboard_id = $1 AND expiry_time = $2 AND owner_id = ANY($3)`
 	sort.Slice(ownerRecords, sortFn)
 
 	// Bulk fill in the ranks of any owner records requested.
-	rankCount := rankCache.Fill(leaderboardId, leaderboard.SortOrder, expiryTime, ownerRecords)
+	rankCount := rankCache.Fill(leaderboardId, expiryTime, ownerRecords)
 
 	return &api.LeaderboardRecordList{
 		Records:      records,
@@ -491,7 +491,7 @@ func LeaderboardRecordWrite(ctx context.Context, logger *zap.Logger, db *sql.DB,
             VALUES ($1, $2, $3, $4, $5, COALESCE($6, '{}'::JSONB), $7)
             ON CONFLICT (owner_id, leaderboard_id, expiry_time)
             DO UPDATE SET ` + opSQL + `, num_score = leaderboard_record.num_score + 1, metadata = COALESCE($6, leaderboard_record.metadata), username = COALESCE($3, leaderboard_record.username), update_time = now()` + filterSQL + `
-            RETURNING username, score, subscore, num_score, max_num_score, metadata, create_time, update_time, (SELECT (score,subscore) FROM leaderboard_record WHERE leaderboard_id=$1 AND owner_id=$2 AND expiry_time=$7)`
+            RETURNING username, score, subscore, num_score, max_num_score, metadata, create_time, update_time`
 
 	params := make([]interface{}, 0, 9)
 	params = append(params, leaderboardId, ownerID)
@@ -517,14 +517,15 @@ func LeaderboardRecordWrite(ctx context.Context, logger *zap.Logger, db *sql.DB,
 	var dbUsername sql.NullString
 	var dbScore int64
 	var dbSubscore int64
-	var dbOldScores int64Tuple
 	var dbNumScore int32
 	var dbMaxNumScore int32
 	var dbMetadata string
 	var dbCreateTime pgtype.Timestamptz
 	var dbUpdateTime pgtype.Timestamptz
 
-	if err := db.QueryRowContext(ctx, query, params...).Scan(&dbUsername, &dbScore, &dbSubscore, &dbNumScore, &dbMaxNumScore, &dbMetadata, &dbCreateTime, &dbUpdateTime, &dbOldScores); err != nil {
+	err := db.QueryRowContext(ctx, query, params...).Scan(&dbUsername, &dbScore, &dbSubscore, &dbNumScore, &dbMaxNumScore, &dbMetadata, &dbCreateTime, &dbUpdateTime)
+
+	if err != nil {
 		var pgErr *pgconn.PgError
 		if err != sql.ErrNoRows && !(errors.As(err, &pgErr) && pgErr.Code == dbErrorUniqueViolation && strings.Contains(pgErr.Message, "leaderboard_record_pkey")) {
 			logger.Error("Error writing leaderboard record", zap.Error(err))
@@ -547,18 +548,10 @@ func LeaderboardRecordWrite(ctx context.Context, logger *zap.Logger, db *sql.DB,
 
 	var rank int64
 	if unchanged {
-		rank = rankCache.Get(leaderboardId, leaderboard.SortOrder, dbScore, dbSubscore, expiryTime, uuid.Must(uuid.FromString(ownerID)))
+		rank = rankCache.Get(leaderboardId, expiryTime, uuid.Must(uuid.FromString(ownerID)))
 	} else {
-		var oldScore *int64
-		var oldSubscore *int64
-
-		if dbOldScores.Valid && len(dbOldScores.Tuple) == 2 {
-			oldScore = &dbOldScores.Tuple[0]
-			oldSubscore = &dbOldScores.Tuple[1]
-		}
-
 		// Ensure we have the latest dbscore, dbsubscore if there was an update.
-		rank = rankCache.Insert(leaderboardId, leaderboard.SortOrder, dbScore, dbSubscore, oldScore, oldSubscore, expiryTime, uuid.Must(uuid.FromString(ownerID)))
+		rank = rankCache.Insert(leaderboardId, leaderboard.SortOrder, dbScore, dbSubscore, dbNumScore, expiryTime, uuid.Must(uuid.FromString(ownerID)))
 	}
 
 	record := &api.LeaderboardRecord{
@@ -598,22 +591,15 @@ func LeaderboardRecordDelete(ctx context.Context, logger *zap.Logger, db *sql.DB
 		expiryTime = leaderboard.ResetSchedule.Next(time.Now().UTC()).UTC().Unix()
 	}
 
-	var score sql.NullInt64
-	var subscore sql.NullInt64
-
-	query := "DELETE FROM leaderboard_record WHERE leaderboard_id = $1 AND owner_id = $2 AND expiry_time = $3 RETURNING score, subscore"
-	err := db.QueryRowContext(
-		ctx, query, leaderboardId, ownerID, time.Unix(expiryTime, 0).UTC()).
-		Scan(&score, &subscore)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	query := "DELETE FROM leaderboard_record WHERE leaderboard_id = $1 AND owner_id = $2 AND expiry_time = $3"
+	_, err := db.ExecContext(
+		ctx, query, leaderboardId, ownerID, time.Unix(expiryTime, 0).UTC())
+	if err != nil {
 		logger.Error("Error deleting leaderboard record", zap.Error(err))
 		return err
 	}
 
-	if score.Valid && subscore.Valid {
-		rankCache.Delete(leaderboardId, leaderboard.SortOrder,
-			score.Int64, subscore.Int64, expiryTime, uuid.Must(uuid.FromString(ownerID)))
-	}
+	rankCache.Delete(leaderboardId, expiryTime, uuid.Must(uuid.FromString(ownerID)))
 
 	return nil
 }
@@ -631,7 +617,7 @@ func LeaderboardRecordReadAll(ctx context.Context, logger *zap.Logger, db *sql.D
 }
 
 func LeaderboardRecordsDeleteAll(ctx context.Context, logger *zap.Logger, leaderboardCache LeaderboardCache, leaderboardRankCache LeaderboardRankCache, tx *sql.Tx, userID uuid.UUID, currentTime int64) error {
-	query := "DELETE FROM leaderboard_record WHERE owner_id = $1 RETURNING leaderboard_id, expiry_time, score, subscore"
+	query := "DELETE FROM leaderboard_record WHERE owner_id = $1 RETURNING leaderboard_id, expiry_time"
 	rows, err := tx.QueryContext(ctx, query, userID.String())
 	if err != nil {
 		logger.Error("Error deleting all leaderboard records for user", zap.String("user_id", userID.String()), zap.Error(err))
@@ -640,10 +626,8 @@ func LeaderboardRecordsDeleteAll(ctx context.Context, logger *zap.Logger, leader
 
 	var leaderboardId string
 	var expiryTime pgtype.Timestamptz
-	var score int64
-	var subscore int64
 	for rows.Next() {
-		if err := rows.Scan(&leaderboardId, &expiryTime, &score, &subscore); err != nil {
+		if err := rows.Scan(&leaderboardId, &expiryTime); err != nil {
 			_ = rows.Close()
 			logger.Error("Error deleting all leaderboard records for user, failed to scan", zap.String("user_id", userID.String()), zap.Error(err))
 			return err
@@ -655,13 +639,7 @@ func LeaderboardRecordsDeleteAll(ctx context.Context, logger *zap.Logger, leader
 			continue
 		}
 
-		leaderboard := leaderboardCache.Get(leaderboardId)
-		if leaderboard == nil {
-			continue
-		}
-
-		leaderboardRankCache.Delete(
-			leaderboardId, leaderboard.SortOrder, score, subscore, expiryUnix, userID)
+		leaderboardRankCache.Delete(leaderboardId, expiryUnix, userID)
 	}
 	_ = rows.Close()
 
@@ -877,7 +855,7 @@ func getLeaderboardRecordsHaystack(ctx context.Context, logger *zap.Logger, db *
 		}
 
 		records = records[start:end]
-		rankCount := rankCache.Fill(leaderboardId, sortOrder, expiryTime.Unix(), records)
+		rankCount := rankCache.Fill(leaderboardId, expiryTime.Unix(), records)
 
 		var prevCursorStr string
 		if setPrevCursor {

--- a/server/leaderboard_rank_cache_test.go
+++ b/server/leaderboard_rank_cache_test.go
@@ -37,17 +37,17 @@ func TestLocalLeaderboardRankCache_Insert_Ascending(t *testing.T) {
 
 	order := LeaderboardSortOrderAscending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 0, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 0, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 0, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 0, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 0, u5)
+	cache.Insert("lid", order, 33, 34, 0, 0, u3)
+	cache.Insert("lid", order, 22, 23, 0, 0, u2)
+	cache.Insert("lid", order, 44, 45, 0, 0, u4)
+	cache.Insert("lid", order, 11, 12, 0, 0, u1)
+	cache.Insert("lid", order, 55, 56, 0, 0, u5)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 11, 12, 0, u1))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 22, 23, 0, u2))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 55, 56, 0, u5))
+	assert.EqualValues(t, 1, cache.Get("lid", 0, u1))
+	assert.EqualValues(t, 2, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 3, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 4, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 5, cache.Get("lid", 0, u5))
 }
 
 func TestLocalLeaderboardRankCache_Insert_Descending(t *testing.T) {
@@ -66,19 +66,19 @@ func TestLocalLeaderboardRankCache_Insert_Descending(t *testing.T) {
 
 	order := LeaderboardSortOrderDescending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 0, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 0, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 0, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 0, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 0, u5)
-	cache.Insert("lid", order, 55, 57, nil, nil, 0, u5_1)
+	cache.Insert("lid", order, 33, 34, 0, 0, u3)
+	cache.Insert("lid", order, 22, 23, 0, 0, u2)
+	cache.Insert("lid", order, 44, 45, 0, 0, u4)
+	cache.Insert("lid", order, 11, 12, 0, 0, u1)
+	cache.Insert("lid", order, 55, 56, 0, 0, u5)
+	cache.Insert("lid", order, 55, 57, 0, 0, u5_1)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 57, 0, u5_1))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 55, 56, 0, u5))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 22, 23, 0, u2))
-	assert.EqualValues(t, 6, cache.Get("lid", order, 11, 12, 0, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 0, u5_1))
+	assert.EqualValues(t, 2, cache.Get("lid", 0, u5))
+	assert.EqualValues(t, 3, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 4, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 5, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 6, cache.Get("lid", 0, u1))
 }
 
 func TestLocalLeaderboardRankCache_Insert_Existing(t *testing.T) {
@@ -99,18 +99,18 @@ func TestLocalLeaderboardRankCache_Insert_Existing(t *testing.T) {
 	origScore, origSubscore := int64(22), int64(23)
 	overrideScore, overrideSubscore := int64(55), int64(57)
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 0, u3)
-	cache.Insert("lid", order, origScore, origSubscore, nil, nil, 0, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 0, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 0, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 0, u5)
-	cache.Insert("lid", order, overrideScore, overrideSubscore, &origScore, &origSubscore, 0, u2)
+	cache.Insert("lid", order, 33, 34, 0, 0, u3)
+	cache.Insert("lid", order, origScore, origSubscore, 0, 0, u2)
+	cache.Insert("lid", order, 44, 45, 0, 0, u4)
+	cache.Insert("lid", order, 11, 12, 0, 0, u1)
+	cache.Insert("lid", order, 55, 56, 0, 0, u5)
+	cache.Insert("lid", order, overrideScore, overrideSubscore, 1, 0, u2)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, overrideScore, overrideSubscore, 0, u2))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 55, 56, 0, u5))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 11, 12, 0, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 2, cache.Get("lid", 0, u5))
+	assert.EqualValues(t, 3, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 4, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 5, cache.Get("lid", 0, u1))
 }
 
 func TestLocalLeaderboardRankCache_TrimExpired(t *testing.T) {
@@ -128,25 +128,25 @@ func TestLocalLeaderboardRankCache_TrimExpired(t *testing.T) {
 
 	order := LeaderboardSortOrderDescending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 1, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 1, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 1, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 1, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 1, u5)
+	cache.Insert("lid", order, 33, 34, 0, 1, u3)
+	cache.Insert("lid", order, 22, 23, 0, 1, u2)
+	cache.Insert("lid", order, 44, 45, 0, 1, u4)
+	cache.Insert("lid", order, 11, 12, 0, 1, u1)
+	cache.Insert("lid", order, 55, 56, 0, 1, u5)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 56, 1, u5))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 44, 45, 1, u4))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 33, 34, 1, u3))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 22, 23, 1, u2))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 11, 12, 1, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 1, u5))
+	assert.EqualValues(t, 2, cache.Get("lid", 1, u4))
+	assert.EqualValues(t, 3, cache.Get("lid", 1, u3))
+	assert.EqualValues(t, 4, cache.Get("lid", 1, u2))
+	assert.EqualValues(t, 5, cache.Get("lid", 1, u1))
 
 	cache.TrimExpired(1)
 
-	assert.EqualValues(t, 0, cache.Get("lid", order, 55, 56, 1, u5))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 44, 45, 1, u4))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 33, 34, 1, u3))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 22, 23, 1, u2))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 11, 12, 1, u1))
+	assert.EqualValues(t, 0, cache.Get("lid", 1, u5))
+	assert.EqualValues(t, 0, cache.Get("lid", 1, u4))
+	assert.EqualValues(t, 0, cache.Get("lid", 1, u3))
+	assert.EqualValues(t, 0, cache.Get("lid", 1, u2))
+	assert.EqualValues(t, 0, cache.Get("lid", 1, u1))
 }
 
 func TestLocalLeaderboardRankCache_ExpirySeparation(t *testing.T) {
@@ -164,23 +164,23 @@ func TestLocalLeaderboardRankCache_ExpirySeparation(t *testing.T) {
 
 	order := LeaderboardSortOrderDescending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 1, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 1, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 1, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 1, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 1, u5)
+	cache.Insert("lid", order, 33, 34, 0, 1, u3)
+	cache.Insert("lid", order, 22, 23, 0, 1, u2)
+	cache.Insert("lid", order, 44, 45, 0, 1, u4)
+	cache.Insert("lid", order, 11, 12, 0, 1, u1)
+	cache.Insert("lid", order, 55, 56, 0, 1, u5)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 56, 1, u5))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 44, 45, 1, u4))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 33, 34, 1, u3))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 22, 23, 1, u2))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 11, 12, 1, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 1, u5))
+	assert.EqualValues(t, 2, cache.Get("lid", 1, u4))
+	assert.EqualValues(t, 3, cache.Get("lid", 1, u3))
+	assert.EqualValues(t, 4, cache.Get("lid", 1, u2))
+	assert.EqualValues(t, 5, cache.Get("lid", 1, u1))
 
-	assert.EqualValues(t, 0, cache.Get("lid", order, 55, 56, 2, u5))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 44, 45, 2, u4))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 33, 34, 2, u3))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 22, 23, 2, u2))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 11, 12, 2, u1))
+	assert.EqualValues(t, 0, cache.Get("lid", 2, u5))
+	assert.EqualValues(t, 0, cache.Get("lid", 2, u4))
+	assert.EqualValues(t, 0, cache.Get("lid", 2, u3))
+	assert.EqualValues(t, 0, cache.Get("lid", 2, u2))
+	assert.EqualValues(t, 0, cache.Get("lid", 2, u1))
 }
 
 func TestLocalLeaderboardRankCache_LeaderboardSeparation(t *testing.T) {
@@ -198,23 +198,23 @@ func TestLocalLeaderboardRankCache_LeaderboardSeparation(t *testing.T) {
 
 	order := LeaderboardSortOrderDescending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 1, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 1, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 1, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 1, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 1, u5)
+	cache.Insert("lid", order, 33, 34, 0, 1, u3)
+	cache.Insert("lid", order, 22, 23, 0, 1, u2)
+	cache.Insert("lid", order, 44, 45, 0, 1, u4)
+	cache.Insert("lid", order, 11, 12, 0, 1, u1)
+	cache.Insert("lid", order, 55, 56, 0, 1, u5)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 56, 1, u5))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 44, 45, 1, u4))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 33, 34, 1, u3))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 22, 23, 1, u2))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 11, 12, 1, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 1, u5))
+	assert.EqualValues(t, 2, cache.Get("lid", 1, u4))
+	assert.EqualValues(t, 3, cache.Get("lid", 1, u3))
+	assert.EqualValues(t, 4, cache.Get("lid", 1, u2))
+	assert.EqualValues(t, 5, cache.Get("lid", 1, u1))
 
-	assert.EqualValues(t, 0, cache.Get("foo", order, 55, 56, 1, u5))
-	assert.EqualValues(t, 0, cache.Get("foo", order, 44, 45, 1, u4))
-	assert.EqualValues(t, 0, cache.Get("foo", order, 33, 34, 1, u3))
-	assert.EqualValues(t, 0, cache.Get("foo", order, 22, 23, 1, u2))
-	assert.EqualValues(t, 0, cache.Get("foo", order, 11, 12, 1, u1))
+	assert.EqualValues(t, 0, cache.Get("foo", 1, u5))
+	assert.EqualValues(t, 0, cache.Get("foo", 1, u4))
+	assert.EqualValues(t, 0, cache.Get("foo", 1, u3))
+	assert.EqualValues(t, 0, cache.Get("foo", 1, u2))
+	assert.EqualValues(t, 0, cache.Get("foo", 1, u1))
 }
 
 func TestLocalLeaderboardRankCache_Delete(t *testing.T) {
@@ -232,25 +232,25 @@ func TestLocalLeaderboardRankCache_Delete(t *testing.T) {
 
 	order := LeaderboardSortOrderDescending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 0, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 0, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 0, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 0, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 0, u5)
+	cache.Insert("lid", order, 33, 34, 0, 0, u3)
+	cache.Insert("lid", order, 22, 23, 0, 0, u2)
+	cache.Insert("lid", order, 44, 45, 0, 0, u4)
+	cache.Insert("lid", order, 11, 12, 0, 0, u1)
+	cache.Insert("lid", order, 55, 56, 0, 0, u5)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 56, 0, u5))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 22, 23, 0, u2))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 11, 12, 0, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 0, u5))
+	assert.EqualValues(t, 2, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 3, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 4, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 5, cache.Get("lid", 0, u1))
 
-	cache.Delete("lid", order, 44, 45, 0, u4)
+	cache.Delete("lid", 0, u4)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 56, 0, u5))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 22, 23, 0, u2))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 11, 12, 0, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 0, u5))
+	assert.EqualValues(t, 0, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 2, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 3, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 4, cache.Get("lid", 0, u1))
 }
 
 func TestLocalLeaderboardRankCache_DeleteLeaderboard(t *testing.T) {
@@ -268,25 +268,25 @@ func TestLocalLeaderboardRankCache_DeleteLeaderboard(t *testing.T) {
 
 	order := LeaderboardSortOrderDescending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 0, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 0, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 0, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 0, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 0, u5)
+	cache.Insert("lid", order, 33, 34, 0, 0, u3)
+	cache.Insert("lid", order, 22, 23, 0, 0, u2)
+	cache.Insert("lid", order, 44, 45, 0, 0, u4)
+	cache.Insert("lid", order, 11, 12, 0, 0, u1)
+	cache.Insert("lid", order, 55, 56, 0, 0, u5)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 56, 0, u5))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 22, 23, 0, u2))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 11, 12, 0, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 0, u5))
+	assert.EqualValues(t, 2, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 3, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 4, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 5, cache.Get("lid", 0, u1))
 
 	cache.DeleteLeaderboard("lid", 0)
 
-	assert.EqualValues(t, 0, cache.Get("lid", order, 55, 56, 0, u5))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 22, 23, 0, u2))
-	assert.EqualValues(t, 0, cache.Get("lid", order, 11, 12, 0, u1))
+	assert.EqualValues(t, 0, cache.Get("lid", 0, u5))
+	assert.EqualValues(t, 0, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 0, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 0, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 0, cache.Get("lid", 0, u1))
 }
 
 func TestLocalLeaderboardRankCache_Fill(t *testing.T) {
@@ -304,17 +304,17 @@ func TestLocalLeaderboardRankCache_Fill(t *testing.T) {
 
 	order := LeaderboardSortOrderDescending
 
-	cache.Insert("lid", order, 33, 34, nil, nil, 0, u3)
-	cache.Insert("lid", order, 22, 23, nil, nil, 0, u2)
-	cache.Insert("lid", order, 44, 45, nil, nil, 0, u4)
-	cache.Insert("lid", order, 11, 12, nil, nil, 0, u1)
-	cache.Insert("lid", order, 55, 56, nil, nil, 0, u5)
+	cache.Insert("lid", order, 33, 34, 0, 0, u3)
+	cache.Insert("lid", order, 22, 23, 0, 0, u2)
+	cache.Insert("lid", order, 44, 45, 0, 0, u4)
+	cache.Insert("lid", order, 11, 12, 0, 0, u1)
+	cache.Insert("lid", order, 55, 56, 0, 0, u5)
 
-	assert.EqualValues(t, 1, cache.Get("lid", order, 55, 56, 0, u5))
-	assert.EqualValues(t, 2, cache.Get("lid", order, 44, 45, 0, u4))
-	assert.EqualValues(t, 3, cache.Get("lid", order, 33, 34, 0, u3))
-	assert.EqualValues(t, 4, cache.Get("lid", order, 22, 23, 0, u2))
-	assert.EqualValues(t, 5, cache.Get("lid", order, 11, 12, 0, u1))
+	assert.EqualValues(t, 1, cache.Get("lid", 0, u5))
+	assert.EqualValues(t, 2, cache.Get("lid", 0, u4))
+	assert.EqualValues(t, 3, cache.Get("lid", 0, u3))
+	assert.EqualValues(t, 4, cache.Get("lid", 0, u2))
+	assert.EqualValues(t, 5, cache.Get("lid", 0, u1))
 
 	records := []*api.LeaderboardRecord{
 		{OwnerId: u3.String(), Score: 33, Subscore: 34},
@@ -324,7 +324,7 @@ func TestLocalLeaderboardRankCache_Fill(t *testing.T) {
 		{OwnerId: u4.String(), Score: 44, Subscore: 45},
 	}
 
-	cache.Fill("lid", order, 0, records)
+	cache.Fill("lid", 0, records)
 
 	assert.EqualValues(t, 3, records[0].Rank)
 	assert.EqualValues(t, 5, records[1].Rank)


### PR DESCRIPTION
https://github.com/heroiclabs/nakama/pull/1050 inadvertently introduced a possibility for a race under heavy concurrent writes for the same leaderboard owner.
This PR restores the owner -> last record map to fix this but also fixes a deeper issue which existed before by leveraging the existing `num_score` field from the db as a logical clock to enforce the casual history.