### PR TITLE
Ignore Steam import friends unauthorized errors

### DIFF
--- a/server/core_authenticate.go
+++ b/server/core_authenticate.go
@@ -830,7 +830,9 @@ func importSteamFriends(ctx context.Context, logger *zap.Logger, db *sql.DB, tra
 	logger = logger.With(zap.String("userID", userID.String()))
 
 	steamProfiles, err := client.GetSteamFriends(ctx, publisherKey, steamId)
-	if err != nil {
+	var unauthorizedErr *social.UnauthorizedError
+	if err != nil && !errors.As(err, &unauthorizedErr) {
+		// If error is unauthorized it means the profile or friends is private, ignore.
 		logger.Error("Could not import Steam friends.", zap.Error(err))
 		return status.Error(codes.Unauthenticated, "Could not authenticate Steam profile.")
 	}

--- a/social/social.go
+++ b/social/social.go
@@ -974,9 +974,17 @@ func (c *Client) requestRaw(ctx context.Context, provider, path string, headers 
 	case 200:
 		return body, nil
 	case 401:
-		return nil, fmt.Errorf("%v error url %v, status code %v, body %s", provider, path, resp.StatusCode, body)
+		return nil, &UnauthorizedError{Err: fmt.Errorf("%v url: %q, status code: %q, body: %q", provider, path, resp.StatusCode, body)}
 	default:
 		c.logger.Warn("error response code from social request", zap.String("provider", provider), zap.Int("code", resp.StatusCode), zap.String("body", string(body)))
-		return nil, fmt.Errorf("%v error url %v, status code %v, body %s", provider, path, resp.StatusCode, body)
+		return nil, fmt.Errorf("%v url: %q, status code: %q, body: %q", provider, path, resp.StatusCode, body)
 	}
 }
+
+type UnauthorizedError struct {
+	Err error
+}
+
+func (e *UnauthorizedError) Error() string { return e.Err.Error() }
+
+func (e *UnauthorizedError) Unwrap() error { return e.Err }


### PR DESCRIPTION
Do not log Steam friend import API unauthorized errors. The error indicates that the Steam account is private or friends are only shared with other friends.