### PR TITLE
server: update log level to error when checking apple token validity

### DIFF
--- a/server/core_link.go
+++ b/server/core_link.go
@@ -41,7 +41,7 @@ func LinkApple(ctx context.Context, logger *zap.Logger, db *sql.DB, config Confi
 
 	profile, err := socialClient.CheckAppleToken(ctx, config.GetSocial().Apple.BundleId, token)
 	if err != nil {
-		logger.Info("Could not authenticate Apple profile.", zap.Error(err))
+		logger.Error("Could not authenticate Apple profile.", zap.Error(err))
 		return status.Error(codes.Unauthenticated, "Could not authenticate Apple profile.")
 	}
 


### PR DESCRIPTION
I'm seeing errors related to this check. In our deployment, log level was set to error. I think it would be nice to see the error from this method.