### PR TITLE
Change rank cache delete condition

### DIFF
--- a/server/leaderboard_cache.go
+++ b/server/leaderboard_cache.go
@@ -803,7 +803,7 @@ func (l *LocalLeaderboardCache) Delete(ctx context.Context, rankCache Leaderboar
 
 	scheduler.Update()
 
-	if expiryUnix > now.Unix() {
+	if expiryUnix > now.Unix() || expiryUnix == 0 {
 		// Clear any cached ranks that have not yet expired.
 		rankCache.DeleteLeaderboard(id, expiryUnix)
 	}


### PR DESCRIPTION
For case when leaderboard is created without reset schedule and you want to delete leaderboard you also need to remove rank cache

If you don't delete rank cache after leaderboard deletion and create leaderboard with same id you will get wrong rank values for owner