### PR TITLE
HandleRPC does not panic anymore on an untagged gRPC call

### DIFF
--- a/server/metrics_grpc_handler.go
+++ b/server/metrics_grpc_handler.go
@@ -57,7 +57,9 @@ func (m *MetricsGrpcHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 			m.MetricsFn(data.fullMethodName, rs.EndTime.Sub(rs.BeginTime), data.recvBytes, data.sentBytes, rs.Error != nil)
 		}
 	} else {
-		m.Metrics.CountUntaggedGrpcStatsCalls(1)
+		if m != nil && m.Metrics != nil {
+			m.Metrics.CountUntaggedGrpcStatsCalls(1)
+		}
 	}
 }
 


### PR DESCRIPTION
The fix applied to v3.22.0 does not completely solve the problem of untagged gRPCs, with the panic now moved to a nil dereference to `m.Metrics.CountUntaggedGrpcStatsCalls(1)`.

I applied a simple fix by wrapping it in a double check for non-nil, this makes it work again for us.