### PR TITLE
Read Console credentials from environment variables first

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -977,8 +977,8 @@ func NewConsoleConfig() *ConsoleConfig {
 		ReadTimeoutMs:       10 * 1000,
 		WriteTimeoutMs:      60 * 1000,
 		IdleTimeoutMs:       300 * 1000,
-		Username:            "admin",
-		Password:            "password",
+		Username:            getEnvOr("NAKAMA_CONSOLE_USERNAME", "admin"),
+		Password:            getEnvOr("NAKAMA_CONSOLE_PASSWORD", "password"),
 		TokenExpirySec:      86400,
 		SigningKey:          "defaultsigningkey",
 	}
@@ -1115,4 +1115,12 @@ type StorageConfig struct {
 
 func NewStorageConfig() *StorageConfig {
 	return &StorageConfig{}
+}
+
+func getEnvOr(key, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
 }


### PR DESCRIPTION
New contributor, I couldn't find any issues talking about this so I went for it directly.

I'll add whatever is missing/required.

The fact that the default credentials are known and always set is not very good from a security standpoint.

Having to mess around with config files and the entrypoint of the container seems a bit too tedious for something that could be resolved via, at most, two environment variables.

Other solutions:
- Some people might not like `getEnvOr` existing in `server/config.go`, if at all, we could not set a fallback value by just using `os.Getenv` instead and modify all the Dockerfiles in `build/` folder to set the default value(s) there, although that adds chore tasks for new architectures or updates happening in said files.
- Modify [nakama/flags](https://pkg.go.dev/github.com/heroiclabs/nakama/v3/flags) to support reading from env vars if some struct tag is set (something like `env:"KEY_NAME"`).