### PR TITLE
Removed some unnecessary fallthrough statements

### DIFF
--- a/console/openapi-gen-angular/main.go
+++ b/console/openapi-gen-angular/main.go
@@ -382,9 +382,7 @@ func convertType(prefixesToRemove []string, convertRefToClassName func(string) s
 		switch prop.Type {
 		case "string":
 			return "string"
-		case "integer":
-			fallthrough
-		case "number":
+		case "integer", "number":
 			return "number"
 		case "boolean":
 			return "boolean"
@@ -392,9 +390,7 @@ func convertType(prefixesToRemove []string, convertRefToClassName func(string) s
 			switch prop.Items.Type {
 			case "string":
 				return "Array<string>"
-			case "integer":
-				fallthrough
-			case "number":
+			case "integer", "number":
 				return "Array<number>"
 			case "boolean":
 				return "Array<boolean>"
@@ -405,9 +401,7 @@ func convertType(prefixesToRemove []string, convertRefToClassName func(string) s
 			switch prop.AdditionalProperties.Type {
 			case "string":
 				return "Map<string, string>"
-			case "integer":
-				fallthrough
-			case "number":
+			case "integer", "number":
 				return "Map<string, number>"
 			case "boolean":
 				return "Map<string, boolean>"

--- a/iap/iap.go
+++ b/iap/iap.go
@@ -217,14 +217,7 @@ func ValidateReceiptAppleWithUrl(ctx context.Context, httpc *http.Client, url, r
 			return sort.StringsAreSorted([]string{out.LatestReceiptInfo[j].ExpiresDateMs, out.LatestReceiptInfo[i].ExpiresDateMs})
 		})
 
-		switch out.Status {
-		case AppleReceiptIsFromTestSandbox:
-			fallthrough
-		case AppleReceiptIsValid:
-			fallthrough
-		default:
-			return &out, buf, nil
-		}
+		return &out, buf, nil
 	default:
 		return nil, nil, &ValidationError{
 			Err:        ErrNon200ServiceApple,

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -215,9 +215,7 @@ func (ms *migrationService) parseParams(logger *zap.Logger, cmd, loggerFormat st
 
 	ms.loggerFormat = server.JSONFormat
 	switch strings.ToLower(loggerFormat) {
-	case "":
-		fallthrough
-	case "json":
+	case "", "json":
 		ms.loggerFormat = server.JSONFormat
 	case "stackdriver":
 		ms.loggerFormat = server.StackdriverFormat

--- a/server/logger.go
+++ b/server/logger.go
@@ -50,9 +50,7 @@ func SetupLogging(tmpLogger *zap.Logger, config Config) (*zap.Logger, *zap.Logge
 
 	format := JSONFormat
 	switch strings.ToLower(config.GetLogger().Format) {
-	case "":
-		fallthrough
-	case "json":
+	case "", "json":
 		format = JSONFormat
 	case "stackdriver":
 		format = StackdriverFormat

--- a/server/socket_ws.go
+++ b/server/socket_ws.go
@@ -43,12 +43,10 @@ func NewSocketWsAcceptor(logger *zap.Logger, config Config, sessionRegistry Sess
 		// Check format.
 		var format SessionFormat
 		switch r.URL.Query().Get("format") {
+		case "", "json":
+			format = SessionFormatJson
 		case "protobuf":
 			format = SessionFormatProtobuf
-		case "json":
-			fallthrough
-		case "":
-			format = SessionFormatJson
 		default:
 			// Invalid values are rejected.
 			http.Error(w, "Invalid format parameter", 400)

--- a/social/social.go
+++ b/social/social.go
@@ -886,9 +886,7 @@ func (c *Client) CheckFacebookLimitedLoginToken(ctx context.Context, appId strin
 
 		// Verify the issuer.
 		switch iss, _ := claims["iss"].(string); iss {
-		case "https://www.facebook.com":
-			fallthrough
-		case "https://facebook.com":
+		case "https://www.facebook.com", "https://facebook.com":
 			break
 		default:
 			return nil, fmt.Errorf("unexpected issuer: %v", claims["iss"])


### PR DESCRIPTION
There are still 29 non-vendor `fallthrough` usages left, which make sense (most of them are specific `case`s that should behave as the `default` case). So no need to touch those.

The most weird one is the one on `iap/iap.go` which was actually not doing anything at all (besides listing two possible statuses?).