### PR TITLE
Docker Compose v1 was removed from GHA runner images on July 29th

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,8 +12,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run tests
-        run: docker-compose -f ./docker-compose-tests.yml up --build --abort-on-container-exit
+        run: docker compose -f ./docker-compose-tests.yml up --build --abort-on-container-exit
 
       - name: Cleanup
         if: always()
-        run: docker-compose -f ./docker-compose-tests.yml down -v
+        run: docker compose -f ./docker-compose-tests.yml down -v


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/9692

This is why the build for https://github.com/heroiclabs/nakama/pull/1259 failed.