### PR TITLE
Remove usages of io/ioutil

### DIFF
--- a/console/openapi-gen-angular/main.go
+++ b/console/openapi-gen-angular/main.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -335,7 +334,7 @@ func main() {
 		"exists":          func(s string) bool { return s != "" },
 	}
 
-	content, err := ioutil.ReadFile(*input)
+	content, err := os.ReadFile(*input)
 	if err != nil {
 		fmt.Printf("Unable to read file: %s\n", err)
 		return

--- a/internal/gopher-lua/auxlib_test.go
+++ b/internal/gopher-lua/auxlib_test.go
@@ -1,7 +1,6 @@
 package lua
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -298,10 +297,10 @@ func TestOptChannel(t *testing.T) {
 }
 
 func TestLoadFileForShebang(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	errorIfNotNil(t, err)
 
-	err = ioutil.WriteFile(tmpFile.Name(), []byte(`#!/path/to/lua
+	err = os.WriteFile(tmpFile.Name(), []byte(`#!/path/to/lua
 print("hello")
 `), 0644)
 	errorIfNotNil(t, err)
@@ -319,7 +318,7 @@ print("hello")
 }
 
 func TestLoadFileForEmptyFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	errorIfNotNil(t, err)
 
 	defer func() {

--- a/internal/gopher-lua/iolib.go
+++ b/internal/gopher-lua/iolib.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"syscall"
@@ -373,7 +372,7 @@ func fileReadAux(L *LState, file *lFile, idx int) int {
 					L.Push(v)
 				case 'a':
 					var buf []byte
-					buf, err = ioutil.ReadAll(file.reader)
+					buf, err = io.ReadAll(file.reader)
 					if err == io.EOF {
 						L.Push(emptyLString)
 						goto normalreturn
@@ -701,7 +700,7 @@ func ioType(L *LState) int {
 }
 
 func ioTmpFile(L *LState) int {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		L.Push(LNil)
 		L.Push(LString(err.Error()))

--- a/internal/gopher-lua/oslib.go
+++ b/internal/gopher-lua/oslib.go
@@ -1,7 +1,6 @@
 package lua
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -219,7 +218,7 @@ func osTime(L *LState) int {
 }
 
 func osTmpname(L *LState) int {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		L.RaiseError("unable to generate a unique filename")
 	}


### PR DESCRIPTION
Package [io/ioutil](https://pkg.go.dev/io/ioutil) deprecated [since Go 1.16](https://go.dev/doc/go1.16#ioutil)

There are some `io/ioutil` usages left in `internal/gopher-lua` which I've sent upstream (plus some test speedups) https://github.com/yuin/gopher-lua/pull/498