### PR TITLE
Add owner records in response when haystack without cursor

### DIFF
--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -21,10 +21,11 @@ import (
 	"encoding/base64"
 	"encoding/gob"
 	"errors"
-	"github.com/heroiclabs/nakama-common/runtime"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/heroiclabs/nakama-common/runtime"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/api"
@@ -904,7 +905,10 @@ func getLeaderboardRecordsHaystack(ctx context.Context, logger *zap.Logger, db *
 			}
 		}
 
-		return &api.LeaderboardRecordList{Records: records, PrevCursor: prevCursorStr, NextCursor: nextCursorStr, RankCount: rankCount}, nil
+		ownerRecords := make([]*api.LeaderboardRecord, 0)
+		ownerRecords = append(ownerRecords, ownerRecord)
+
+		return &api.LeaderboardRecordList{Records: records, OwnerRecords: ownerRecords, PrevCursor: prevCursorStr, NextCursor: nextCursorStr, RankCount: rankCount}, nil
 	} else {
 		// If a cursor is passed, then this becomes a regular record listing operation.
 		return LeaderboardRecordsList(ctx, logger, db, leaderboardCache, rankCache, leaderboardId, wrapperspb.Int32(int32(limit)), cursor, nil, expiryTime.Unix())


### PR DESCRIPTION
It's weird when I call _client.ListLeaderboardRecordsAroundOwnerAsync from the client and the response only contains Records, not OwnerRecords, even if the player has them. I have to do a foreach in this case to find my record.

https://github.com/heroiclabs/nakama/blob/master/server/core_leaderboard.go#L910