### PR TITLE
Correctly remove rank cache entries on account delete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 
 ### Fixed
 - Ensure matchmaker stats behave correctly if matchmaker becomes fully empty and idle.
+- Correctly clear rank cache entries on account deletion.
 
 ## [3.23.0] - 2024-07-27
 ### Added

--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -636,7 +636,7 @@ func LeaderboardRecordsDeleteAll(ctx context.Context, logger *zap.Logger, leader
 		}
 
 		expiryUnix := expiryTime.Time.Unix()
-		if expiryUnix <= currentTime {
+		if expiryUnix != 0 && expiryUnix <= currentTime {
 			// Expired ranks are handled by the rank cache itself.
 			continue
 		}


### PR DESCRIPTION
Ranks cache entries for leaderboards with no expiry are now correctly removed on account delete.