### PR TITLE
Correctly filter purchases in console account view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 ### Fixed
 - Ensure matchmaker stats behave correctly if matchmaker becomes fully empty and idle.
 - Correctly clear rank cache entries on account deletion.
+- Only display owned purchases in the console account tab.
 
 ## [3.23.0] - 2024-07-27
 ### Added

--- a/server/core_purchase.go
+++ b/server/core_purchase.go
@@ -535,7 +535,7 @@ LIMIT $4`
 		if userID == "" {
 			query += " ORDER BY purchase_time DESC, user_id DESC, transaction_id DESC LIMIT $1"
 		} else {
-			query += "WHERE user_id = $1 ORDER BY purchase_time DESC, user_id DESC, transaction_id DESC LIMIT $2"
+			query += " WHERE user_id = $1 ORDER BY purchase_time DESC, user_id DESC, transaction_id DESC LIMIT $2"
 			params = append(params, userID)
 		}
 	}

--- a/server/core_purchase.go
+++ b/server/core_purchase.go
@@ -532,7 +532,12 @@ LIMIT $4`
 		}
 		params = append(params, incomingCursor.PurchaseTime.AsTime(), incomingCursor.UserId, incomingCursor.TransactionId)
 	} else {
-		query += " ORDER BY purchase_time DESC, user_id DESC, transaction_id DESC LIMIT $1"
+		if userID == "" {
+			query += " ORDER BY purchase_time DESC, user_id DESC, transaction_id DESC LIMIT $1"
+		} else {
+			query += "WHERE user_id = $1 ORDER BY purchase_time DESC, user_id DESC, transaction_id DESC LIMIT $2"
+			params = append(params, userID)
+		}
 	}
 
 	if limit > 0 {


### PR DESCRIPTION
Only display purchases owned by the account being viewed.