### PR TITLE
Fix group listing with open and count filters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - Return correct tournament details in console API leaderboard details endpoint.
 - Do not report invalid http RPC ids to prometheus counts.
 - Fix Lua runtime short day format option.
+- Fix group listing with open and count filters.
 
 ## [3.25.0] - 2024-11-25
 ### Added

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -1772,7 +1772,7 @@ SELECT id, creator_id, name, description, avatar_url, state, edge_count, lang_ta
 FROM groups
 WHERE disable_time = '1970-01-01 00:00:00 UTC'
 AND state = $2
-AND edge_count = $3`
+AND edge_count <= $3`
 		if cursor != nil {
 			params = append(params, cursor.GetState(), cursor.EdgeCount, cursor.Lang, cursor.ID)
 			query += " AND (disable_time, state, edge_count, lang_tag, id) < ('1970-01-01 00:00:00 UTC', $4, $5, $6, $7)"


### PR DESCRIPTION
Return groups with <= edge_count instead of exact match.

Resolves #1313 