### PR TITLE
Fix chat listing pagination issues.

### DIFF
--- a/.github/workflows/golanci-lint.yaml
+++ b/.github/workflows/golanci-lint.yaml
@@ -20,6 +20,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.61
+          version: v1.64
           only-new-issues: true
           args: --timeout=10m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 - Change FB Limited Login validation Keys URL.
 - Update FB Graph API to v22.
 
+### Fixed
+- Fix chat message listing pagination issue.
+
 ## [3.26.0] - 2025-01-25
 ### Added
 - Allow account filtering by email in the Console.

--- a/server/core_channel.go
+++ b/server/core_channel.go
@@ -133,7 +133,7 @@ WHERE stream_mode = $1 AND stream_subject = $2::UUID AND stream_descriptor = $3:
 	query += " LIMIT $5"
 	params := []interface{}{stream.Mode, stream.Subject, stream.Subcontext, stream.Label, limit + 1}
 	if incomingCursor != nil {
-		params = append(params, time.Unix(incomingCursor.CreateTime, 0).UTC(), incomingCursor.Id)
+		params = append(params, time.Unix(0, incomingCursor.CreateTime).UTC(), incomingCursor.Id)
 	}
 
 	rows, err := db.QueryContext(ctx, query, params...)
@@ -162,7 +162,7 @@ WHERE stream_mode = $1 AND stream_subject = $2::UUID AND stream_descriptor = $3:
 				StreamSubject:    stream.Subject.String(),
 				StreamSubcontext: stream.Subcontext.String(),
 				StreamLabel:      stream.Label,
-				CreateTime:       dbCreateTime.Time.Unix(),
+				CreateTime:       dbCreateTime.Time.UnixNano(),
 				Id:               dbID,
 				Forward:          forward,
 				IsNext:           true,
@@ -184,8 +184,8 @@ WHERE stream_mode = $1 AND stream_subject = $2::UUID AND stream_descriptor = $3:
 			SenderId:   dbSenderID,
 			Username:   dbUsername,
 			Content:    dbContent,
-			CreateTime: &timestamppb.Timestamp{Seconds: dbCreateTime.Time.Unix()},
-			UpdateTime: &timestamppb.Timestamp{Seconds: dbUpdateTime.Time.Unix()},
+			CreateTime: &timestamppb.Timestamp{Seconds: dbCreateTime.Time.UnixNano()},
+			UpdateTime: &timestamppb.Timestamp{Seconds: dbUpdateTime.Time.UnixNano()},
 			Persistent: &wrapperspb.BoolValue{Value: true},
 		}
 		switch stream.Mode {
@@ -207,7 +207,7 @@ WHERE stream_mode = $1 AND stream_subject = $2::UUID AND stream_descriptor = $3:
 				StreamSubject:    stream.Subject.String(),
 				StreamSubcontext: stream.Subcontext.String(),
 				StreamLabel:      stream.Label,
-				CreateTime:       dbCreateTime.Time.Unix(),
+				CreateTime:       dbCreateTime.Time.UnixNano(),
 				Id:               dbID,
 				Forward:          forward,
 				IsNext:           false,
@@ -239,7 +239,7 @@ WHERE stream_mode = $1 AND stream_subject = $2::UUID AND stream_descriptor = $3:
 			StreamSubject:    stream.Subject.String(),
 			StreamSubcontext: stream.Subcontext.String(),
 			StreamLabel:      stream.Label,
-			CreateTime:       messages[l-1].CreateTime.Seconds,
+			CreateTime:       messages[l-1].CreateTime.AsTime().UnixNano(),
 			Id:               messages[l-1].MessageId,
 			Forward:          true,
 			IsNext:           true,


### PR DESCRIPTION
Use ns instead of s for cursor create_time value.
This will correctly disambiguate which row to start seeking from in case there's multiple messages within the same second.