### PR TITLE
Allow Satori FlagsList to return default flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 ### Changed
 - Change FB Limited Login validation Keys URL.
 - Update FB Graph API to v22.
+- Enable Satori FlagsList to return all default flags.
 
 ### Fixed
 - Fix chat message listing pagination issue.

--- a/internal/satori/satori.go
+++ b/internal/satori/satori.go
@@ -593,7 +593,7 @@ type flagCacheEntry struct {
 // @group satori
 // @summary List flags.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param id(type=string) The identifier of the identity.
+// @param id(type=string) The identifier of the identity. Set to empty string to fetch all default flag values.
 // @param names(type=[]string, optional=true, default=[]) Optional list of flag names to filter.
 // @return flags(*runtime.FlagList) The flag list.
 // @return error(error) An optional error value if an error occurred.
@@ -609,16 +609,20 @@ func (s *SatoriClient) FlagsList(ctx context.Context, id string, names ...string
 	if !found {
 		url := s.url.String() + "/v1/flag"
 
-		sessionToken, err := s.generateToken(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", sessionToken))
+
+		if id != "" {
+			sessionToken, err := s.generateToken(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", sessionToken))
+		} else {
+			req.SetBasicAuth(s.apiKey, "")
+		}
 
 		if len(names) > 0 {
 			q := req.URL.Query()

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -9131,7 +9131,7 @@ func (n *RuntimeJavascriptNakamaModule) satoriExperimentsList(r *goja.Runtime) f
 
 // @group satori
 // @summary List flags.
-// @param id(type=string) The identifier of the identity.
+// @param id(type=string) The identifier of the identity. Set to empty string to fetch all default flag values.
 // @param names(type=string[], optional=true, default=[]) Optional list of flag names to filter.
 // @return flags(*nkruntime.Flag[]) The flag list.
 // @return error(error) An optional error value if an error occurred.

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -11220,7 +11220,7 @@ func (n *RuntimeLuaNakamaModule) satoriExperimentsList(l *lua.LState) int {
 
 // @group satori
 // @summary List flags.
-// @param id(type=string) The identifier of the identity.
+// @param id(type=string) The identifier of the identity. Set to empty string to fetch all default flag values.
 // @param names(type=table, optional=true, default=[]) Optional list of flag names to filter.
 // @return flags(table) The flag list.
 // @return error(error) An optional error value if an error occurred.


### PR DESCRIPTION
If FlagsList identity is empty string, use Satori key to set basic auth header instead of generating auth token and return all default flags.