### PR TITLE
Modify summary for ListLeaderboardRecordsAroundOwner

### DIFF
--- a/apigrpc/apigrpc.proto
+++ b/apigrpc/apigrpc.proto
@@ -494,7 +494,7 @@ service Nakama {
     option (google.api.http).get = "/v2/leaderboard/{leaderboard_id}";
   }
 
-  // List leaderboard records that belong to a user.
+  // List leaderboard records around the target ownerId.
   rpc ListLeaderboardRecordsAroundOwner (api.ListLeaderboardRecordsAroundOwnerRequest) returns (api.LeaderboardRecordList) {
     option (google.api.http).get = "/v2/leaderboard/{leaderboard_id}/owner/{owner_id}";
   }

--- a/apigrpc/apigrpc.swagger.json
+++ b/apigrpc/apigrpc.swagger.json
@@ -2641,7 +2641,7 @@
     },
     "/v2/leaderboard/{leaderboardId}/owner/{ownerId}": {
       "get": {
-        "summary": "List leaderboard records that belong to a user.",
+        "summary": "List leaderboard records around the target ownerId.",
         "operationId": "Nakama_ListLeaderboardRecordsAroundOwner",
         "responses": {
           "200": {

--- a/apigrpc/apigrpc_grpc.pb.go
+++ b/apigrpc/apigrpc_grpc.pb.go
@@ -227,7 +227,7 @@ type NakamaClient interface {
 	ListGroupUsers(ctx context.Context, in *api.ListGroupUsersRequest, opts ...grpc.CallOption) (*api.GroupUserList, error)
 	// List leaderboard records.
 	ListLeaderboardRecords(ctx context.Context, in *api.ListLeaderboardRecordsRequest, opts ...grpc.CallOption) (*api.LeaderboardRecordList, error)
-	// List leaderboard records that belong to a user.
+	// List leaderboard records around the target ownerId.
 	ListLeaderboardRecordsAroundOwner(ctx context.Context, in *api.ListLeaderboardRecordsAroundOwnerRequest, opts ...grpc.CallOption) (*api.LeaderboardRecordList, error)
 	// Fetch list of running matches.
 	ListMatches(ctx context.Context, in *api.ListMatchesRequest, opts ...grpc.CallOption) (*api.MatchList, error)
@@ -1154,7 +1154,7 @@ type NakamaServer interface {
 	ListGroupUsers(context.Context, *api.ListGroupUsersRequest) (*api.GroupUserList, error)
 	// List leaderboard records.
 	ListLeaderboardRecords(context.Context, *api.ListLeaderboardRecordsRequest) (*api.LeaderboardRecordList, error)
-	// List leaderboard records that belong to a user.
+	// List leaderboard records around the target ownerId.
 	ListLeaderboardRecordsAroundOwner(context.Context, *api.ListLeaderboardRecordsAroundOwnerRequest) (*api.LeaderboardRecordList, error)
 	// Fetch list of running matches.
 	ListMatches(context.Context, *api.ListMatchesRequest) (*api.MatchList, error)


### PR DESCRIPTION
Hey there!

I recently started my journey as maintainer for the [Dart SDK](https://github.com/heroiclabs/nakama-dart).

While investigating [this open issue](https://github.com/heroiclabs/nakama-dart/issues/122), I dug deeper into leaderboards and realized that the summary used across [all the generated SDKs](https://github.com/search?q=org%3Aheroiclabs+%22List+leaderboard+records+that+belong+to+a+user%22&type=code) might be misleading.

The summary wording in my proposed change comes from a [comment](https://forum.heroiclabs.com/t/listleaderboardrecords-aroundownerasync-or-listtournamentrecords-aroundownerasync-support-bucket/5362/3) @sesposito made in the forum.