### PR TITLE
Fix annotations for docs parser

### DIFF
--- a/internal/satori/satori.go
+++ b/internal/satori/satori.go
@@ -256,11 +256,11 @@ type authenticateBody struct {
 // @summary Create a new identity.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The identifier of the identity.
-// @param default(type=map[string]string, optional=true, default=nil) Default properties to update with this call. Set to nil to leave them as they are on the server.
-// @param custom(type=map[string]string, optional=true, default=nil) Custom properties to update with this call. Set to nil to leave them as they are on the server.
+// @param defaultProperties(type=map[string]string, optional=true, default=nil) Default properties to update with this call. Set to nil to leave them as they are on the server.
+// @param customProperties(type=map[string]string, optional=true, default=nil) Custom properties to update with this call. Set to nil to leave them as they are on the server.
 // @param noSession(type=bool) Whether authenticate should skip session duration tracking.
 // @param ipAddress(type=string, optional=true, default="") An optional client IP address to pass on to Satori for geo-IP lookup.
-// @return properties(*runtime.Properties)
+// @return properties(*runtime.Properties) The identity properties.
 // @return error(error) An optional error value if an error occurred.
 func (s *SatoriClient) Authenticate(ctx context.Context, id string, defaultProperties, customProperties map[string]string, noSession bool, ipAddress ...string) (*runtime.Properties, error) {
 	if s.invalidConfig {

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -425,7 +425,7 @@ func (n *RuntimeGoNakamaModule) AuthenticateTokenGenerate(userID, username strin
 
 	tokenId := uuid.Must(uuid.NewV4()).String()
 	tokenIssuedAt := time.Now().Unix()
-	token, expiresAt := generateTokenWithExpiry(n.config.GetSession().EncryptionKey, tokenId, tokenIssuedAt, userID, username, vars, exp)
+	token, expiresAt := generateTokenWithExpiry(n.config.GetSession().EncryptionKey, tokenId, tokenIssuedAt, userID, username, vars, expiresAt)
 	n.sessionCache.Add(uid, expiresAt, tokenId, 0, "")
 	return token, expiresAt, nil
 }

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -237,7 +237,7 @@ func (n *RuntimeGoNakamaModule) AuthenticateEmail(ctx context.Context, email, pa
 // @summary Authenticate user and create a session token using a Facebook account token.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
-// @param import(type=bool) Whether to automatically import Facebook friends after authentication.
+// @param importFriends(type=bool) Whether to automatically import Facebook friends after authentication.
 // @param username(type=string, optional=true) The user's username. If left empty, one is generated.
 // @param create(type=bool) Create user if one didn't exist previously.
 // @return userID(string) The user ID of the authenticated user.
@@ -269,7 +269,7 @@ func (n *RuntimeGoNakamaModule) AuthenticateFacebook(ctx context.Context, token 
 // @group authenticate
 // @summary Authenticate user and create a session token using a Facebook Instant Game.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param playerInfo(type=string) Facebook Player info.
+// @param signedPlayerInfo(type=string) Facebook Player info.
 // @param username(type=string, optional=true) The user's username. If left empty, one is generated.
 // @param create(type=bool) Create user if one didn't exist previously.
 // @return userID(string) The user ID of the authenticated user.
@@ -295,8 +295,8 @@ func (n *RuntimeGoNakamaModule) AuthenticateFacebookInstantGame(ctx context.Cont
 // @group authenticate
 // @summary Authenticate user and create a session token using Apple Game Center credentials.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param playerId(type=string) PlayerId provided by GameCenter.
-// @param bundleId(type=string) BundleId of your app on iTunesConnect.
+// @param playerID(type=string) PlayerId provided by GameCenter.
+// @param bundleID(type=string) BundleId of your app on iTunesConnect.
 // @param timestamp(type=int64) Timestamp at which Game Center authenticated the client and issued a signature.
 // @param salt(type=string) A random string returned by Game Center authentication on client.
 // @param signature(type=string) A signature returned by Game Center authentication on client.
@@ -398,9 +398,9 @@ func (n *RuntimeGoNakamaModule) AuthenticateSteam(ctx context.Context, token, us
 
 // @group authenticate
 // @summary Generate a Nakama session token from a user ID.
-// @param userId(type=string) User ID to use to generate the token.
+// @param userID(type=string) User ID to use to generate the token.
 // @param username(type=string, optional=true) The user's username. If left empty, one is generated.
-// @param expiresAt(type=int64, optional=true) UTC time in seconds when the token must expire. Defaults to server configured expiry time.
+// @param exp(type=int64, optional=true) UTC time in seconds when the token must expire. Defaults to server configured expiry time.
 // @param vars(type=map[string]string, optional=true) Extra information that will be bundled in the session token.
 // @return token(string) The Nakama session token.
 // @return validity(int64) The period for which the token remains valid.
@@ -433,7 +433,7 @@ func (n *RuntimeGoNakamaModule) AuthenticateTokenGenerate(userID, username strin
 // @group accounts
 // @summary Fetch account information by user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) User ID to fetch information for. Must be valid UUID.
+// @param userID(type=string) User ID to fetch information for. Must be valid UUID.
 // @return account(*api.Account) All account information including wallet, device IDs and more.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) AccountGetId(ctx context.Context, userID string) (*api.Account, error) {
@@ -453,7 +453,7 @@ func (n *RuntimeGoNakamaModule) AccountGetId(ctx context.Context, userID string)
 // @group accounts
 // @summary Fetch information for multiple accounts by user IDs.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userIds(type=[]string) Array of user IDs to fetch information for. Must be valid UUID.
+// @param userIDs(type=[]string) Array of user IDs to fetch information for. Must be valid UUID.
 // @return account([]*api.Account) An array of accounts.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) AccountsGetId(ctx context.Context, userIDs []string) ([]*api.Account, error) {
@@ -473,13 +473,13 @@ func (n *RuntimeGoNakamaModule) AccountsGetId(ctx context.Context, userIDs []str
 // @group accounts
 // @summary Update an account by user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) User ID for which the information is to be updated. Must be valid UUID.
+// @param userID(type=string) User ID for which the information is to be updated. Must be valid UUID.
 // @param metadata(type=map[string]interface{}) The metadata to update for this account.
 // @param username(type=string) Username to be set. Must be unique. Use "" if it is not being updated.
 // @param displayName(type=string) Display name to be updated. Use "" if it is not being updated.
 // @param timezone(type=string) Timezone to be updated. Use "" if it is not being updated.
 // @param location(type=string) Location to be updated. Use "" if it is not being updated.
-// @param language(type=string) Lang tag to be updated. Use "" if it is not being updated.
+// @param langTag(type=string) Lang tag to be updated. Use "" if it is not being updated.
 // @param avatarUrl(type=string) User's avatar URL. Use "" if it is not being updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) AccountUpdateId(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error {
@@ -533,7 +533,7 @@ func (n *RuntimeGoNakamaModule) AccountUpdateId(ctx context.Context, userID, use
 // @group accounts
 // @summary Delete an account by user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) User ID for the account to be deleted. Must be valid UUID.
+// @param userID(type=string) User ID for the account to be deleted. Must be valid UUID.
 // @param recorded(type=bool, default=false) Whether to record this deletion in the database.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) AccountDeleteId(ctx context.Context, userID string, recorded bool) error {
@@ -548,7 +548,7 @@ func (n *RuntimeGoNakamaModule) AccountDeleteId(ctx context.Context, userID stri
 // @group accounts
 // @summary Export account information for a specified user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) User ID for the account to be exported. Must be valid UUID.
+// @param userID(type=string) User ID for the account to be exported. Must be valid UUID.
 // @return export(string) Account information for the provided user ID, in JSON format.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) AccountExportId(ctx context.Context, userID string) (string, error) {
@@ -573,7 +573,8 @@ func (n *RuntimeGoNakamaModule) AccountExportId(ctx context.Context, userID stri
 // @group users
 // @summary Fetch one or more users by ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userIds(type=[]string) An array of user IDs to fetch.
+// @param userIDs(type=[]string) An array of user IDs to fetch.
+// @param facebookIDs(type=[]string) An array of Facebook IDs to fetch.
 // @return users([]*api.User) A list of user record objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UsersGetId(ctx context.Context, userIDs []string, facebookIDs []string) ([]*api.User, error) {
@@ -623,7 +624,7 @@ func (n *RuntimeGoNakamaModule) UsersGetUsername(ctx context.Context, usernames 
 // @group users
 // @summary Get user's friend status information for a list of target users.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userID (type=string) The current user ID.
+// @param userID(type=string) The current user ID.
 // @param userIDs(type=[]string) An array of target user IDs.
 // @return friends([]*api.Friend) A list of user friends objects.
 // @return error(error) An optional error value if an error occurred.
@@ -666,7 +667,7 @@ func (n *RuntimeGoNakamaModule) UsersGetRandom(ctx context.Context, count int) (
 // @group users
 // @summary Ban one or more users by ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userIds(type=[]string) An array of user IDs to ban.
+// @param userIDs(type=[]string) An array of user IDs to ban.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UsersBanId(ctx context.Context, userIDs []string) error {
 	if len(userIDs) == 0 {
@@ -688,7 +689,7 @@ func (n *RuntimeGoNakamaModule) UsersBanId(ctx context.Context, userIDs []string
 // @group users
 // @summary Unban one or more users by ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userIds(type=[]string) An array of user IDs to unban.
+// @param userIDs(type=[]string) An array of user IDs to unban.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UsersUnbanId(ctx context.Context, userIDs []string) error {
 	if len(userIDs) == 0 {
@@ -710,7 +711,7 @@ func (n *RuntimeGoNakamaModule) UsersUnbanId(ctx context.Context, userIDs []stri
 // @group authenticate
 // @summary Link Apple authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param token(type=string) Apple sign in token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) LinkApple(ctx context.Context, userID, token string) error {
@@ -725,8 +726,8 @@ func (n *RuntimeGoNakamaModule) LinkApple(ctx context.Context, userID, token str
 // @group authenticate
 // @summary Link custom authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
-// @param customId(type=string) Custom ID to be linked to the user.
+// @param userID(type=string) The user ID to be linked.
+// @param customID(type=string) Custom ID to be linked to the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) LinkCustom(ctx context.Context, userID, customID string) error {
 	id, err := uuid.FromString(userID)
@@ -740,8 +741,8 @@ func (n *RuntimeGoNakamaModule) LinkCustom(ctx context.Context, userID, customID
 // @group authenticate
 // @summary Link device authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
-// @param deviceId(type=string) Device ID to be linked to the user.
+// @param userID(type=string) The user ID to be linked.
+// @param deviceID(type=string) Device ID to be linked to the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) LinkDevice(ctx context.Context, userID, deviceID string) error {
 	id, err := uuid.FromString(userID)
@@ -755,7 +756,7 @@ func (n *RuntimeGoNakamaModule) LinkDevice(ctx context.Context, userID, deviceID
 // @group authenticate
 // @summary Link email authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param email(type=string) Authentication email to be linked to the user.
 // @param password(type=string) Password to set. Must be longer than 8 characters.
 // @return error(error) An optional error value if an error occurred.
@@ -771,7 +772,7 @@ func (n *RuntimeGoNakamaModule) LinkEmail(ctx context.Context, userID, email, pa
 // @group authenticate
 // @summary Link Facebook authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param username(type=string, optional=true) If left empty, one is generated.
 // @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
 // @param importFriends(type=bool) Whether to automatically import Facebook friends after authentication.
@@ -788,7 +789,7 @@ func (n *RuntimeGoNakamaModule) LinkFacebook(ctx context.Context, userID, userna
 // @group authenticate
 // @summary Link Facebook Instant Game authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param signedPlayerInfo(type=string) Facebook player info.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) LinkFacebookInstantGame(ctx context.Context, userID, signedPlayerInfo string) error {
@@ -803,9 +804,9 @@ func (n *RuntimeGoNakamaModule) LinkFacebookInstantGame(ctx context.Context, use
 // @group authenticate
 // @summary Link Apple Game Center authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
-// @param playerId(type=string) Player ID provided by Game Center.
-// @param bundleId(type=string) Bundle ID of your app on iTunesConnect.
+// @param userID(type=string) The user ID to be linked.
+// @param playerID(type=string) Player ID provided by Game Center.
+// @param bundleID(type=string) Bundle ID of your app on iTunesConnect.
 // @param timestamp(type=int64) Timestamp at which Game Center authenticated the client and issued a signature.
 // @param salt(type=string) A random string returned by Game Center authentication on client.
 // @param signature(type=string) A signature returned by Game Center authentication on client.
@@ -823,7 +824,7 @@ func (n *RuntimeGoNakamaModule) LinkGameCenter(ctx context.Context, userID, play
 // @group authenticate
 // @summary Link Google authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param token(type=string) Google OAuth access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) LinkGoogle(ctx context.Context, userID, token string) error {
@@ -838,7 +839,7 @@ func (n *RuntimeGoNakamaModule) LinkGoogle(ctx context.Context, userID, token st
 // @group authenticate
 // @summary Link Steam authentication to a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param username(type=string, optional=true) If left empty, one is generated.
 // @param token(type=string) Steam access token.
 // @param importFriends(type=bool) Whether to automatically import Steam friends after authentication.
@@ -902,7 +903,7 @@ func (n *RuntimeGoNakamaModule) ReadFile(relPath string) (*os.File, error) {
 // @group authenticate
 // @summary Unlink Apple authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string) Apple sign in token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkApple(ctx context.Context, userID, token string) error {
@@ -917,8 +918,8 @@ func (n *RuntimeGoNakamaModule) UnlinkApple(ctx context.Context, userID, token s
 // @group authenticate
 // @summary Unlink custom authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
-// @param customId(type=string) Custom ID to be unlinked from the user.
+// @param userID(type=string) The user ID to be unlinked.
+// @param customID(type=string) Custom ID to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkCustom(ctx context.Context, userID, customID string) error {
 	id, err := uuid.FromString(userID)
@@ -932,8 +933,8 @@ func (n *RuntimeGoNakamaModule) UnlinkCustom(ctx context.Context, userID, custom
 // @group authenticate
 // @summary Unlink device authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
-// @param deviceId(type=string) Device ID to be unlinked from the user.
+// @param userID(type=string) The user ID to be unlinked.
+// @param deviceID(type=string) Device ID to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkDevice(ctx context.Context, userID, deviceID string) error {
 	id, err := uuid.FromString(userID)
@@ -947,7 +948,7 @@ func (n *RuntimeGoNakamaModule) UnlinkDevice(ctx context.Context, userID, device
 // @group authenticate
 // @summary Unlink email authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param email(type=string) Email to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkEmail(ctx context.Context, userID, email string) error {
@@ -962,7 +963,7 @@ func (n *RuntimeGoNakamaModule) UnlinkEmail(ctx context.Context, userID, email s
 // @group authenticate
 // @summary Unlink Facebook authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkFacebook(ctx context.Context, userID, token string) error {
@@ -977,8 +978,8 @@ func (n *RuntimeGoNakamaModule) UnlinkFacebook(ctx context.Context, userID, toke
 // @group authenticate
 // @summary Unlink Facebook Instant Game authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
-// @param playerInfo(type=string) Facebook player info.
+// @param userID(type=string) The user ID to be unlinked.
+// @param signedPlayerInfo(type=string) Facebook player info.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkFacebookInstantGame(ctx context.Context, userID, signedPlayerInfo string) error {
 	id, err := uuid.FromString(userID)
@@ -992,9 +993,9 @@ func (n *RuntimeGoNakamaModule) UnlinkFacebookInstantGame(ctx context.Context, u
 // @group authenticate
 // @summary Unlink Apple Game Center authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
-// @param playerId(type=string) Player ID provided by Game Center.
-// @param bundleId(type=string) Bundle ID of your app on iTunesConnect.
+// @param userID(type=string) The user ID to be unlinked.
+// @param playerID(type=string) Player ID provided by Game Center.
+// @param bundleID(type=string) Bundle ID of your app on iTunesConnect.
 // @param timestamp(type=int64) Timestamp at which Game Center authenticated the client and issued a signature.
 // @param salt(type=string) A random string returned by Game Center authentication on client.
 // @param signature(type=string) A signature returned by Game Center authentication on client.
@@ -1012,7 +1013,7 @@ func (n *RuntimeGoNakamaModule) UnlinkGameCenter(ctx context.Context, userID, pl
 // @group authenticate
 // @summary Unlink Google authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string) Google OAuth access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkGoogle(ctx context.Context, userID, token string) error {
@@ -1027,7 +1028,7 @@ func (n *RuntimeGoNakamaModule) UnlinkGoogle(ctx context.Context, userID, token 
 // @group authenticate
 // @summary Unlink Steam authentication from a user ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string) Steam access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) UnlinkSteam(ctx context.Context, userID, token string) error {
@@ -1082,8 +1083,8 @@ func (n *RuntimeGoNakamaModule) StreamUserList(mode uint8, subject, subcontext, 
 // @param subject(type=string) The primary stream subject, typically a user ID.
 // @param subcontext(type=string) A secondary subject, for example for direct chat between two users.
 // @param label(type=string) Meta-information about the stream, for example a chat room name.
-// @param userId(type=string) The user ID to fetch information for.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to fetch information for.
+// @param sessionID(type=string) The current session ID for the user.
 // @return meta(runtime.PresenceMeta) Presence and metadata for the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) StreamUserGet(mode uint8, subject, subcontext, label, userID, sessionID string) (runtime.PresenceMeta, error) {
@@ -1126,8 +1127,8 @@ func (n *RuntimeGoNakamaModule) StreamUserGet(mode uint8, subject, subcontext, l
 // @param subject(type=string) The primary stream subject, typically a user ID.
 // @param subcontext(type=string) A secondary subject, for example for direct chat between two users.
 // @param label(type=string) Meta-information about the stream, for example a chat room name.
-// @param userId(type=string) The user ID to be added.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to be added.
+// @param sessionID(type=string) The current session ID for the user.
 // @param hidden(type=bool) Whether the user will be marked as hidden.
 // @param persistence(type=bool) Whether message data should be stored in the database.
 // @param status(type=string) User status message.
@@ -1178,8 +1179,8 @@ func (n *RuntimeGoNakamaModule) StreamUserJoin(mode uint8, subject, subcontext, 
 // @param subject(type=string) The primary stream subject, typically a user ID.
 // @param subcontext(type=string) A secondary subject, for example for direct chat between two users.
 // @param label(type=string) Meta-information about the stream, for example a chat room name.
-// @param userId(type=string) The user ID to be updated.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to be updated.
+// @param sessionID(type=string) The current session ID for the user.
 // @param hidden(type=bool) Whether the user will be marked as hidden.
 // @param persistence(type=bool) Whether message data should be stored in the database.
 // @param status(type=string) User status message.
@@ -1229,8 +1230,8 @@ func (n *RuntimeGoNakamaModule) StreamUserUpdate(mode uint8, subject, subcontext
 // @param subject(type=string) The primary stream subject, typically a user ID.
 // @param subcontext(type=string) A secondary subject, for example for direct chat between two users.
 // @param label(type=string) Meta-information about the stream, for example a chat room name.
-// @param userId(type=string) The user ID to be removed.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to be removed.
+// @param sessionID(type=string) The current session ID for the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) StreamUserLeave(mode uint8, subject, subcontext, label, userID, sessionID string) error {
 	uid, err := uuid.FromString(userID)
@@ -1506,7 +1507,7 @@ func (n *RuntimeGoNakamaModule) StreamSendRaw(mode uint8, subject, subcontext, l
 // @group sessions
 // @summary Disconnect a session.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param sessionId(type=string) The ID of the session to be disconnected.
+// @param sessionID(type=string) The ID of the session to be disconnected.
 // @param reason(type=runtime.PresenceReason, optional=true) The reason for the session disconnect.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) SessionDisconnect(ctx context.Context, sessionID string, reason ...runtime.PresenceReason) error {
@@ -1520,7 +1521,7 @@ func (n *RuntimeGoNakamaModule) SessionDisconnect(ctx context.Context, sessionID
 
 // @group sessions
 // @summary Log out a user from their current session.
-// @param userId(type=string) The ID of the user to be logged out.
+// @param userID(type=string) The ID of the user to be logged out.
 // @param token(type=string, optional=true) The current session authentication token. If the current auth and refresh tokens are not provided, all user sessions will be logged out.
 // @param refreshToken(type=string, optional=true) The current session refresh token. If the current auth and refresh tokens are not provided, all user sessions will be logged out.
 // @return error(error) An optional error value if an error occurred.
@@ -1611,7 +1612,7 @@ func (n *RuntimeGoNakamaModule) MatchSignal(ctx context.Context, id string, data
 // @group notifications
 // @summary Send one in-app notification to a user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID of the user to be sent the notification.
+// @param userID(type=string) The user ID of the user to be sent the notification.
 // @param subject(type=string) Notification subject.
 // @param content(type=map[string]interface{}) Notification content. Must be set but can be an struct.
 // @param code(type=int) Notification code to use. Must be equal or greater than 0.
@@ -1848,7 +1849,7 @@ func (n *RuntimeGoNakamaModule) NotificationsDeleteId(ctx context.Context, userI
 // @group notifications
 // @summary Update notifications by their id.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param updates(type=[]runtime.NotificationUpdate)
+// @param updates(type=[]runtime.NotificationUpdate) A list of notifications to be updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) NotificationsUpdate(ctx context.Context, updates ...runtime.NotificationUpdate) error {
 	nUpdates := make([]notificationUpdate, 0, len(updates))
@@ -1873,7 +1874,7 @@ func (n *RuntimeGoNakamaModule) NotificationsUpdate(ctx context.Context, updates
 // @group wallets
 // @summary Update a user's wallet with the given changeset.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user whose wallet to update.
+// @param userID(type=string) The ID of the user whose wallet to update.
 // @param changeset(type=map[string]int64) The set of wallet operations to apply.
 // @param metadata(type=map[string]interface{}) Additional metadata to tag the wallet update with.
 // @param updateLedger(type=bool, default=false) Whether to record this update in the ledger.
@@ -1956,7 +1957,7 @@ func (n *RuntimeGoNakamaModule) WalletsUpdate(ctx context.Context, updates []*ru
 // @group wallets
 // @summary Update the metadata for a particular wallet update in a user's wallet ledger history. Useful when adding a note to a transaction for example.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param itemId(type=string) The ID of the wallet ledger item to update.
+// @param itemID(type=string) The ID of the wallet ledger item to update.
 // @param metadata(type=map[string]interface{}) The new metadata to set on the wallet ledger item.
 // @return updateWalletLedger(runtime.WalletLedgerItem) The updated wallet ledger item.
 // @return error(error) An optional error value if an error occurred.
@@ -1977,7 +1978,7 @@ func (n *RuntimeGoNakamaModule) WalletLedgerUpdate(ctx context.Context, itemID s
 // @group wallets
 // @summary List all wallet updates for a particular user from oldest to newest.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user to list wallet updates for.
+// @param userID(type=string) The ID of the user to list wallet updates for.
 // @param limit(type=int, optional=true, default=100) Limit number of results.
 // @param cursor(type=string, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return runtimeItems([]runtime.WalletLedgerItem) A Go slice containing wallet entries with Id, UserId, CreateTime, UpdateTime, Changeset, Metadata parameters.
@@ -2065,8 +2066,8 @@ func (n *RuntimeGoNakamaModule) StatusUnfollow(sessionID string, userIDs []strin
 // @group storage
 // @summary List records in a collection and page through results. The records returned can be filtered to those owned by the user or "" for public records.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
-// @param userId(type=string) User ID to list records for or "" (empty string) for public records.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
+// @param userID(type=string) User ID to list records for or "" (empty string) for public records.
 // @param collection(type=string) Collection to list data from.
 // @param limit(type=int, optional=true, default=100) Limit number of records retrieved.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
@@ -2107,17 +2108,17 @@ func (n *RuntimeGoNakamaModule) StorageList(ctx context.Context, callerID, userI
 // @group storage
 // @summary Fetch one or more records by their bucket/collection/keyname and optional user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param objectIds(type=[]*runtime.StorageRead) An array of object identifiers to be fetched.
+// @param objectIDs(type=[]*runtime.StorageRead) An array of object identifiers to be fetched.
 // @return objects([]*api.StorageObject) A list of storage objects matching the parameters criteria.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, reads []*runtime.StorageRead) ([]*api.StorageObject, error) {
-	size := len(reads)
+func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*runtime.StorageRead) ([]*api.StorageObject, error) {
+	size := len(objectIDs)
 	if size == 0 {
 		return make([]*api.StorageObject, 0), nil
 	}
-	objectIDs := make([]*api.ReadStorageObjectId, size)
+	reads := make([]*api.ReadStorageObjectId, size)
 
-	for i, read := range reads {
+	for i, read := range objectIDs {
 		if read.Collection == "" {
 			return nil, errors.New("expects collection to be a non-empty string")
 		}
@@ -2133,14 +2134,14 @@ func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, reads []*runtim
 			}
 		}
 
-		objectIDs[i] = &api.ReadStorageObjectId{
+		reads[i] = &api.ReadStorageObjectId{
 			Collection: read.Collection,
 			Key:        read.Key,
 			UserId:     uid.String(),
 		}
 	}
 
-	objects, err := StorageReadObjects(ctx, n.logger, n.db, uuid.Nil, objectIDs)
+	objects, err := StorageReadObjects(ctx, n.logger, n.db, uuid.Nil, reads)
 	if err != nil {
 		return nil, err
 	}
@@ -2151,18 +2152,18 @@ func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, reads []*runtim
 // @group storage
 // @summary Write one or more objects by their collection/keyname and optional user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param objectIds(type=[]*runtime.StorageWrite) An array of object identifiers to be written.
+// @param objectIDs(type=[]*runtime.StorageWrite) An array of object identifiers to be written.
 // @return acks([]*api.StorageObjectAck) A list of acks with the version of the written objects.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
-	size := len(writes)
+func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, objectIDs []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	size := len(objectIDs)
 	if size == 0 {
 		return make([]*api.StorageObjectAck, 0), nil
 	}
 
 	ops := make(StorageOpWrites, 0, size)
 
-	for _, write := range writes {
+	for _, write := range objectIDs {
 		if write.Collection == "" {
 			return nil, errors.New("expects collection to be a non-empty string")
 		}
@@ -2208,17 +2209,17 @@ func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, writes []*runt
 // @group storage
 // @summary Remove one or more objects by their collection/keyname and optional user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param objectIds(type=[]*runtime.StorageDelete) An array of object identifiers to be deleted.
+// @param objectIDs(type=[]*runtime.StorageDelete) An array of object identifiers to be deleted.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, deletes []*runtime.StorageDelete) error {
-	size := len(deletes)
+func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, objectIDs []*runtime.StorageDelete) error {
+	size := len(objectIDs)
 	if size == 0 {
 		return nil
 	}
 
 	ops := make(StorageOpDeletes, 0, size)
 
-	for _, del := range deletes {
+	for _, del := range objectIDs {
 		if del.Collection == "" {
 			return errors.New("expects collection to be a non-empty string")
 		}
@@ -2254,9 +2255,10 @@ func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, deletes []*ru
 
 // @group storage
 // @summary List storage index entries
+// @param ctx(type=context.Context) The context object represents information about the server and requester.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty, defaults to system user and permissions are bypassed.
 // @param indexName(type=string) Name of the index to list entries from.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty, defaults to system user and permissions are bypassed.
-// @param queryString(type=string) Query to filter index entries.
+// @param query(type=string) Query to filter index entries.
 // @param limit(type=int) Maximum number of results to be returned.
 // @param order(type=[]string, optional=true) The storage object fields to sort the query results by. The prefix '-' before a field name indicates descending order. All specified fields must be indexed and sortable.
 // @param cursor(type=string) A cursor to fetch the next page of results.
@@ -2441,7 +2443,7 @@ func (n *RuntimeGoNakamaModule) MultiUpdate(ctx context.Context, accountUpdates 
 }
 
 // @group leaderboards
-// @summary Setup a new dynamic leaderboard with the specified ID and various configuration settings. The leaderboard will be created if it doesn't already exist, otherwise its configuration will not be updated.
+// @summary Set up a new dynamic leaderboard with the specified ID and various configuration settings. The leaderboard will be created if it doesn't already exist, otherwise its configuration will not be updated.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param leaderboardID(type=string) The unique identifier for the new leaderboard. This is used by clients to submit scores.
 // @param authoritative(type=bool, default=false) Mark the leaderboard as authoritative which ensures updates can only be made via the Go runtime. No client can submit a score directly.
@@ -2451,8 +2453,8 @@ func (n *RuntimeGoNakamaModule) MultiUpdate(ctx context.Context, accountUpdates 
 // @param metadata(type=map[string]interface{}) The metadata you want associated to the leaderboard. Some good examples are weather conditions for a racing game.
 // @param enableRanks(type=bool) Whether to enable rank values for the leaderboard.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) LeaderboardCreate(ctx context.Context, id string, authoritative bool, sortOrder, operator, resetSchedule string, metadata map[string]interface{}, enableRanks bool) error {
-	if id == "" {
+func (n *RuntimeGoNakamaModule) LeaderboardCreate(ctx context.Context, leaderboardID string, authoritative bool, sortOrder, operator, resetSchedule string, metadata map[string]interface{}, enableRanks bool) error {
+	if leaderboardID == "" {
 		return errors.New("expects a leaderboard ID string")
 	}
 
@@ -2495,7 +2497,7 @@ func (n *RuntimeGoNakamaModule) LeaderboardCreate(ctx context.Context, id string
 		metadataStr = string(metadataBytes)
 	}
 
-	_, created, err := n.leaderboardCache.Create(ctx, id, authoritative, sort, oper, resetSchedule, metadataStr, enableRanks)
+	_, created, err := n.leaderboardCache.Create(ctx, leaderboardID, authoritative, sort, oper, resetSchedule, metadataStr, enableRanks)
 	if err != nil {
 		return err
 	}
@@ -2565,10 +2567,10 @@ func (n *RuntimeGoNakamaModule) LeaderboardRanksDisable(ctx context.Context, id 
 // @summary List records on the specified leaderboard, optionally filtering to only a subset of records by their owners. Records will be listed in the preconfigured leaderboard sort order.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The unique identifier for the leaderboard to list.
-// @param owners(type=[]string) Array of owners to filter to.
+// @param ownerIDs(type=[]string) Array of owners to filter to.
 // @param limit(type=int) The maximum number of records to return (Max 10,000).
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
-// @param overrideExpiry(type=int) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
+// @param expiry(type=int) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
 // @return records([]*api.LeaderboardRecord) A page of leaderboard records.
 // @return ownerRecords([]*api.LeaderboardRecord) A list of owner leaderboard records (empty if the owners input parameter is not set).
 // @return nextCursor(string) An optional next page cursor that can be used to retrieve the next page of records (if any).
@@ -2608,11 +2610,11 @@ func (n *RuntimeGoNakamaModule) LeaderboardRecordsList(ctx context.Context, id s
 // @summary Build a cursor to be used with leaderboardRecordsList to fetch records starting at a given rank. Only available if rank cache is not disabled for the leaderboard.
 // @param leaderboardID(type=string) The unique identifier of the leaderboard.
 // @param rank(type=int64) The rank to start listing leaderboard records from.
-// @param overrideExpiry(type=int64) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
+// @param expiry(type=int64) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
 // @return leaderboardListCursor(string) A string cursor to be used with leaderboardRecordsList.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) LeaderboardRecordsListCursorFromRank(id string, rank, expiry int64) (string, error) {
-	if id == "" {
+func (n *RuntimeGoNakamaModule) LeaderboardRecordsListCursorFromRank(leaderboardID string, rank, expiry int64) (string, error) {
+	if leaderboardID == "" {
 		return "", errors.New("invalid leaderboard id")
 	}
 
@@ -2624,7 +2626,7 @@ func (n *RuntimeGoNakamaModule) LeaderboardRecordsListCursorFromRank(id string, 
 		return "", errors.New("expects expiry to equal or greater than 0")
 	}
 
-	l := n.leaderboardCache.Get(id)
+	l := n.leaderboardCache.Get(leaderboardID)
 	if l == nil {
 		return "", ErrLeaderboardNotFound
 	}
@@ -2639,14 +2641,14 @@ func (n *RuntimeGoNakamaModule) LeaderboardRecordsListCursorFromRank(id string, 
 		return "", nil
 	}
 
-	ownerId, score, subscore, err := n.leaderboardRankCache.GetDataByRank(id, expiryTime, l.SortOrder, rank)
+	ownerId, score, subscore, err := n.leaderboardRankCache.GetDataByRank(leaderboardID, expiryTime, l.SortOrder, rank)
 	if err != nil {
 		return "", fmt.Errorf("failed to get cursor from rank: %s", err.Error())
 	}
 
 	cursor := &leaderboardRecordListCursor{
 		IsNext:        true,
-		LeaderboardId: id,
+		LeaderboardId: leaderboardID,
 		ExpiryTime:    expiryTime,
 		Score:         score,
 		Subscore:      subscore,
@@ -2666,7 +2668,7 @@ func (n *RuntimeGoNakamaModule) LeaderboardRecordsListCursorFromRank(id string, 
 // @summary Use the preconfigured operator for the given leaderboard to submit a score for a particular user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The unique identifier for the leaderboard to submit to.
-// @param owner(type=string) The owner of this score submission.
+// @param ownerID(type=string) The owner of this score submission.
 // @param username(type=string) The owner username of this score submission, if it's a user.
 // @param score(type=int64) The score to submit.
 // @param subscore(type=int64, optional=true) A secondary subscore parameter for the submission.
@@ -2716,7 +2718,7 @@ func (n *RuntimeGoNakamaModule) LeaderboardRecordWrite(ctx context.Context, id, 
 // @summary Remove an owner's record from a leaderboard, if one exists.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The unique identifier for the leaderboard to delete from.
-// @param owner(type=string) The owner of the score to delete.
+// @param ownerID(type=string) The owner of the score to delete.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) LeaderboardRecordDelete(ctx context.Context, id, ownerID string) error {
 	if id == "" {
@@ -2734,7 +2736,7 @@ func (n *RuntimeGoNakamaModule) LeaderboardRecordDelete(ctx context.Context, id,
 // @summary Fetch the list of leaderboard records around the owner.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The ID of the leaderboard to list records for.
-// @param ownerId(type=string) The owner ID around which to show records.
+// @param ownerID(type=string) The owner ID around which to show records.
 // @param limit(type=int) Return only the required number of leaderboard records denoted by this limit value. Between 1-100.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param expiry(type=int64) Time since epoch in seconds. Must be greater than 0.
@@ -2763,7 +2765,8 @@ func (n *RuntimeGoNakamaModule) LeaderboardRecordsHaystack(ctx context.Context, 
 
 // @group leaderboards
 // @summary Fetch one or more leaderboards by ID.
-// @param ids(type=[]string) The table array of leaderboard ids.
+// @param ctx(type=context.Context) The context object represents information about the server and requester.
+// @param IDs(type=[]string) The table array of leaderboard ids.
 // @return leaderboardsGet([]*api.Leaderboard) The leaderboard records according to ID.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) LeaderboardsGetId(ctx context.Context, IDs []string) ([]*api.Leaderboard, error) {
@@ -2876,7 +2879,7 @@ func (n *RuntimeGoNakamaModule) TournamentDelete(ctx context.Context, id string)
 // @summary Add additional score attempts to the owner's tournament record. This overrides the max number of score attempts allowed in the tournament for this specific owner.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The unique identifier for the tournament to update.
-// @param owner(type=string) The owner of the records to increment the count for.
+// @param ownerID(type=string) The owner of the records to increment the count for.
 // @param count(type=int) The number of attempt counts to increment. Can be negative to decrease count.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) TournamentAddAttempt(ctx context.Context, id, ownerID string, count int) error {
@@ -2901,7 +2904,7 @@ func (n *RuntimeGoNakamaModule) TournamentAddAttempt(ctx context.Context, id, ow
 // @summary A tournament may need to be joined before the owner can submit scores. This operation is idempotent and will always succeed for the owner even if they have already joined the tournament.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The unique identifier for the tournament to join.
-// @param ownerId(type=string) The owner of the record.
+// @param ownerID(type=string) The owner of the record.
 // @param username(type=string) The username of the record owner.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) TournamentJoin(ctx context.Context, id, ownerID, username string) error {
@@ -2927,7 +2930,7 @@ func (n *RuntimeGoNakamaModule) TournamentJoin(ctx context.Context, id, ownerID,
 // @group tournaments
 // @summary Fetch one or more tournaments by ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param ids(type=[]string) The table array of tournament ids.
+// @param tournamentIDs(type=[]string) The table array of tournament ids.
 // @return result([]*api.Tournament) Array of tournament records.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) TournamentsGetId(ctx context.Context, tournamentIDs []string) ([]*api.Tournament, error) {
@@ -2998,7 +3001,7 @@ func (n *RuntimeGoNakamaModule) TournamentRanksDisable(ctx context.Context, id s
 // @summary List records on the specified tournament, optionally filtering to only a subset of records by their owners. Records will be listed in the preconfigured tournament sort order.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param tournamentId(type=string) The ID of the tournament to list records for.
-// @param ownerIds(type=[]string) Array of owner IDs to filter results by.
+// @param ownerIDs(type=[]string) Array of owner IDs to filter results by.
 // @param limit(type=int) Return only the required number of tournament records denoted by this limit value. Max is 10000.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param overrideExpiry(type=int64) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
@@ -3039,7 +3042,7 @@ func (n *RuntimeGoNakamaModule) TournamentRecordsList(ctx context.Context, tourn
 // @summary Submit a score and optional subscore to a tournament leaderboard. If the tournament has been configured with join required this will fail unless the owner has already joined the tournament.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The unique identifier for the tournament leaderboard to submit to.
-// @param owner(type=string) The owner of this score submission.
+// @param ownerID(type=string) The owner of this score submission.
 // @param username(type=string) The owner username of this score submission, if it's a user.
 // @param score(type=int64) The score to submit.
 // @param subscore(type=int64, optional=true) A secondary subscore parameter for the submission.
@@ -3083,7 +3086,7 @@ func (n *RuntimeGoNakamaModule) TournamentRecordWrite(ctx context.Context, id, o
 // @summary Remove an owner's record from a tournament, if one exists.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The unique identifier for the tournament to delete from.
-// @param owner(type=string) The owner of the score to delete.
+// @param ownerID(type=string) The owner of the score to delete.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) TournamentRecordDelete(ctx context.Context, id, ownerID string) error {
 	if id == "" {
@@ -3101,7 +3104,7 @@ func (n *RuntimeGoNakamaModule) TournamentRecordDelete(ctx context.Context, id, 
 // @summary Fetch the list of tournament records around the owner.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The ID of the tournament to list records for.
-// @param ownerId(type=string) The owner ID around which to show records.
+// @param ownerID(type=string) The owner ID around which to show records.
 // @param limit(type=int) Return only the required number of tournament records denoted by this limit value. Between 1-100.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param expiry(type=int64) Time since epoch in seconds. Must be greater than 0.
@@ -3131,7 +3134,7 @@ func (n *RuntimeGoNakamaModule) TournamentRecordsHaystack(ctx context.Context, i
 // @group purchases
 // @summary Validates and stores the purchases present in an Apple App Store Receipt.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) Base-64 encoded receipt data returned by the purchase operation itself.
 // @param persist(type=bool) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @param passwordOverride(type=string, optional=true) Override the iap.apple.shared_password provided in your configuration.
@@ -3168,10 +3171,12 @@ func (n *RuntimeGoNakamaModule) PurchaseValidateApple(ctx context.Context, userI
 // @group purchases
 // @summary Validates and stores a purchase receipt from the Google Play Store.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) JSON encoded Google receipt.
 // @param persist(type=bool) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @param overrides(type=string, optional=true) Override the iap.google.client_email and iap.google.private_key provided in your configuration.
+// @param ClientEmail(type=string, optional=true) Override the iap.google.client_email provided in your configuration.
+// @param PrivateKey(type=string, optional=true) Override the iap.google.private_key provided in your configuration.
 // @return validation(*api.ValidatePurchaseResponse) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) PurchaseValidateGoogle(ctx context.Context, userID, receipt string, persist bool, overrides ...struct {
@@ -3221,13 +3226,13 @@ func (n *RuntimeGoNakamaModule) PurchaseValidateGoogle(ctx context.Context, user
 // @group purchases
 // @summary Validates and stores a purchase receipt from the Huawei App Gallery.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID of the owner of the receipt.
-// @param receipt(type=string) The Huawei receipt data.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param signature(type=string) The receipt signature.
+// @param receipt(type=string) The Huawei receipt data.
 // @param persist(type=bool) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @return validation(*api.ValidatePurchaseResponse) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) PurchaseValidateHuawei(ctx context.Context, userID, signature, inAppPurchaseData string, persist bool) (*api.ValidatePurchaseResponse, error) {
+func (n *RuntimeGoNakamaModule) PurchaseValidateHuawei(ctx context.Context, userID, signature, receipt string, persist bool) (*api.ValidatePurchaseResponse, error) {
 	if n.config.GetIAP().Huawei.ClientID == "" ||
 		n.config.GetIAP().Huawei.ClientSecret == "" ||
 		n.config.GetIAP().Huawei.PublicKey == "" {
@@ -3243,11 +3248,11 @@ func (n *RuntimeGoNakamaModule) PurchaseValidateHuawei(ctx context.Context, user
 		return nil, errors.New("signature cannot be empty string")
 	}
 
-	if len(inAppPurchaseData) < 1 {
-		return nil, errors.New("inAppPurchaseData cannot be empty string")
+	if len(receipt) < 1 {
+		return nil, errors.New("receipt cannot be empty string")
 	}
 
-	validation, err := ValidatePurchaseHuawei(ctx, n.logger, n.db, uid, n.config.GetIAP().Huawei, inAppPurchaseData, signature, persist)
+	validation, err := ValidatePurchaseHuawei(ctx, n.logger, n.db, uid, n.config.GetIAP().Huawei, receipt, signature, persist)
 	if err != nil {
 		return nil, err
 	}
@@ -3258,7 +3263,7 @@ func (n *RuntimeGoNakamaModule) PurchaseValidateHuawei(ctx context.Context, user
 // @group purchases
 // @summary Validates and stores a purchase receipt from Facebook Instant Games.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param signedRequest(type=string) The Facebook Instant signedRequest receipt data.
 // @param persist(type=bool) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @return validation(*api.ValidatePurchaseResponse) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
@@ -3288,7 +3293,7 @@ func (n *RuntimeGoNakamaModule) PurchaseValidateFacebookInstant(ctx context.Cont
 // @group purchases
 // @summary List stored validated purchase receipts.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) Filter by user ID. Can be an empty string to list purchases for all users.
+// @param userID(type=string) Filter by user ID. Can be an empty string to list purchases for all users.
 // @param limit(type=int, optional=true, default=100) Limit number of records retrieved.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return listPurchases(*api.PurchaseList) A page of stored validated purchases and possibly a cursor. If cursor is empty/nil there are no further results.
@@ -3310,7 +3315,7 @@ func (n *RuntimeGoNakamaModule) PurchasesList(ctx context.Context, userID string
 // @group purchases
 // @summary Look up a purchase receipt by transaction ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param transactionId(type=string) Transaction ID of the purchase to look up.
+// @param transactionID(type=string) Transaction ID of the purchase to look up.
 // @return purchase(*api.ValidatedPurchase) A validated purchase.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) PurchaseGetByTransactionId(ctx context.Context, transactionID string) (*api.ValidatedPurchase, error) {
@@ -3324,7 +3329,7 @@ func (n *RuntimeGoNakamaModule) PurchaseGetByTransactionId(ctx context.Context, 
 // @group subscriptions
 // @summary Validates and stores the subscription present in an Apple App Store Receipt.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) Base-64 encoded receipt data returned by the purchase operation itself.
 // @param persist(type=bool) Persist the subscription.
 // @param passwordOverride(type=string, optional=true) Override the iap.apple.shared_password provided in your configuration.
@@ -3361,10 +3366,12 @@ func (n *RuntimeGoNakamaModule) SubscriptionValidateApple(ctx context.Context, u
 // @group subscriptions
 // @summary Validates and stores a subscription receipt from the Google Play Store.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) JSON encoded Google receipt.
 // @param persist(type=bool) Persist the subscription.
 // @param overrides(type=string, optional=true) Override the iap.google.client_email and iap.google.private_key provided in your configuration.
+// @param ClientEmail(type=string, optional=true) Override the iap.google.client_email provided in your configuration.
+// @param PrivateKey(type=string, optional=true) Override the iap.google.private_key provided in your configuration.
 // @return validation(*api.ValidateSubscriptionResponse) The resulting successfully validated subscription.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) SubscriptionValidateGoogle(ctx context.Context, userID, receipt string, persist bool, overrides ...struct {
@@ -3414,7 +3421,7 @@ func (n *RuntimeGoNakamaModule) SubscriptionValidateGoogle(ctx context.Context, 
 // @group subscriptions
 // @summary List stored validated subscriptions.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) Filter by user ID. Can be an empty string to list purchases for all users.
+// @param userID(type=string) Filter by user ID. Can be an empty string to list purchases for all users.
 // @param limit(type=int, optional=true, default=100) Limit number of records retrieved.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return listSubscriptions(*api.SubscriptionList) A page of stored validated subscriptions and possibly a cursor. If cursor is empty/nil there are no further results.
@@ -3436,8 +3443,8 @@ func (n *RuntimeGoNakamaModule) SubscriptionsList(ctx context.Context, userID st
 // @group subscriptions
 // @summary Look up a subscription receipt by productID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) User ID of the subscription owner.
-// @param productId(type=string) Product ID of the subscription to look up.
+// @param userID(type=string) User ID of the subscription owner.
+// @param productID(type=string) Product ID of the subscription to look up.
 // @return subscription(*api.ValidatedSubscription) A validated subscription.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) SubscriptionGetByProductId(ctx context.Context, userID, productID string) (*api.ValidatedSubscription, error) {
@@ -3455,7 +3462,7 @@ func (n *RuntimeGoNakamaModule) SubscriptionGetByProductId(ctx context.Context, 
 // @group groups
 // @summary Fetch one or more groups by their ID.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param groupIds(type=[]string) An array of strings of the IDs for the groups to get.
+// @param groupIDs(type=[]string) An array of strings of the IDs for the groups to get.
 // @return getGroups([]*api.Group) An array of groups with their fields.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
@@ -3475,9 +3482,9 @@ func (n *RuntimeGoNakamaModule) GroupsGetId(ctx context.Context, groupIDs []stri
 // @group groups
 // @summary Setup a group with various configuration settings. The group will be created if they don't exist or fail if the group name is taken.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The user ID to be associated as the group superadmin.
+// @param userID(type=string) The user ID to be associated as the group superadmin.
 // @param name(type=string) Group name, must be unique.
-// @param creatorId(type=string, optional=true) The user ID to be associated as creator. If not set or nil/null, system user will be set.
+// @param creatorID(type=string, optional=true) The user ID to be associated as creator. If not set or nil/null, system user will be set.
 // @param langTag(type=string, optional=true, default="en") Group language.
 // @param description(type=string, optional=true) Group description, can be left empty as nil/null.
 // @param avatarUrl(type=string, optional=true) URL to the group avatar, can be left empty as nil/null.
@@ -3523,10 +3530,10 @@ func (n *RuntimeGoNakamaModule) GroupCreate(ctx context.Context, userID, name, c
 // @group groups
 // @summary Update a group with various configuration settings. The group which is updated can change some or all of its fields.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param groupId(type=string) The ID of the group to update.
-// @param userId(type=string) User ID calling the update operation for permission checking. Set as empty string to enact the changes as the system user.
+// @param groupID(type=string) The ID of the group to update.
+// @param userID(type=string) User ID calling the update operation for permission checking. Set as empty string to enact the changes as the system user.
 // @param name(type=string) Group name, can be empty if not changed.
-// @param creatorId(type=string) The user ID to be associated as creator. Can be empty if not changed.
+// @param creatorID(type=string) The user ID to be associated as creator. Can be empty if not changed.
 // @param langTag(type=string) Group language. Empty if not updated.
 // @param description(type=string) Group description, can be left empty if not updated.
 // @param avatarUrl(type=string) URL to the group avatar, can be left empty if not updated.
@@ -3534,8 +3541,8 @@ func (n *RuntimeGoNakamaModule) GroupCreate(ctx context.Context, userID, name, c
 // @param metadata(type=map[string]interface{}) Custom information to store for this group. Use nil if field is not being updated.
 // @param maxCount(type=int) Maximum number of members to have in the group. Use 0, nil/null if field is not being updated.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) GroupUpdate(ctx context.Context, id, userID, name, creatorID, langTag, description, avatarUrl string, open bool, metadata map[string]interface{}, maxCount int) error {
-	groupID, err := uuid.FromString(id)
+func (n *RuntimeGoNakamaModule) GroupUpdate(ctx context.Context, groupID, userID, name, creatorID, langTag, description, avatarUrl string, open bool, metadata map[string]interface{}, maxCount int) error {
+	group, err := uuid.FromString(groupID)
 	if err != nil {
 		return errors.New("expects group ID to be a valid identifier")
 	}
@@ -3590,28 +3597,28 @@ func (n *RuntimeGoNakamaModule) GroupUpdate(ctx context.Context, id, userID, nam
 		metadataWrapper = &wrapperspb.StringValue{Value: string(metadataBytes)}
 	}
 
-	return UpdateGroup(ctx, n.logger, n.db, groupID, uid, creator, nameWrapper, langTagWrapper, descriptionWrapper, avatarURLWrapper, metadataWrapper, openWrapper, maxCount)
+	return UpdateGroup(ctx, n.logger, n.db, group, uid, creator, nameWrapper, langTagWrapper, descriptionWrapper, avatarURLWrapper, metadataWrapper, openWrapper, maxCount)
 }
 
 // @group groups
 // @summary Delete a group.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param groupId(type=string) The ID of the group to delete.
+// @param groupID(type=string) The ID of the group to delete.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) GroupDelete(ctx context.Context, id string) error {
-	groupID, err := uuid.FromString(id)
+func (n *RuntimeGoNakamaModule) GroupDelete(ctx context.Context, groupID string) error {
+	group, err := uuid.FromString(groupID)
 	if err != nil {
 		return errors.New("expects group ID to be a valid identifier")
 	}
 
-	return DeleteGroup(ctx, n.logger, n.db, n.tracker, groupID, uuid.Nil)
+	return DeleteGroup(ctx, n.logger, n.db, n.tracker, group, uuid.Nil)
 }
 
 // @group groups
 // @summary Join a group for a particular user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param groupId(type=string) The ID of the group to join.
-// @param userId(type=string) The user ID to add to this group.
+// @param groupID(type=string) The ID of the group to join.
+// @param userID(type=string) The user ID to add to this group.
 // @param username(type=string) The username of the user to add to this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupUserJoin(ctx context.Context, groupID, userID, username string) error {
@@ -3635,8 +3642,8 @@ func (n *RuntimeGoNakamaModule) GroupUserJoin(ctx context.Context, groupID, user
 // @group groups
 // @summary Leave a group for a particular user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param groupId(type=string) The ID of the group to leave.
-// @param userId(type=string) The user ID to remove from this group.
+// @param groupID(type=string) The ID of the group to leave.
+// @param userID(type=string) The user ID to remove from this group.
 // @param username(type=string) The username of the user to remove from this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupUserLeave(ctx context.Context, groupID, userID, username string) error {
@@ -3660,9 +3667,9 @@ func (n *RuntimeGoNakamaModule) GroupUserLeave(ctx context.Context, groupID, use
 // @group groups
 // @summary Add users to a group.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
-// @param groupId(type=string) The ID of the group to add users to.
-// @param userIds(type=[]string) Table array of user IDs to add to this group.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
+// @param groupID(type=string) The ID of the group to add users to.
+// @param userIDs(type=[]string) Table array of user IDs to add to this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupUsersAdd(ctx context.Context, callerID, groupID string, userIDs []string) error {
 	caller := uuid.Nil
@@ -3700,9 +3707,9 @@ func (n *RuntimeGoNakamaModule) GroupUsersAdd(ctx context.Context, callerID, gro
 // @group groups
 // @summary Ban users from a group.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
-// @param groupId(type=string) The ID of the group to ban users from.
-// @param userIds(type=[]string) Table array of user IDs to ban from this group.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
+// @param groupID(type=string) The ID of the group to ban users from.
+// @param userIDs(type=[]string) Table array of user IDs to ban from this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupUsersBan(ctx context.Context, callerID, groupID string, userIDs []string) error {
 	caller := uuid.Nil
@@ -3740,9 +3747,9 @@ func (n *RuntimeGoNakamaModule) GroupUsersBan(ctx context.Context, callerID, gro
 // @group groups
 // @summary Kick users from a group.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
-// @param groupId(type=string) The ID of the group to kick users from.
-// @param userIds(type=[]string) Table array of user IDs to kick.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
+// @param groupID(type=string) The ID of the group to kick users from.
+// @param userIDs(type=[]string) Table array of user IDs to kick.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupUsersKick(ctx context.Context, callerID, groupID string, userIDs []string) error {
 	caller := uuid.Nil
@@ -3780,9 +3787,9 @@ func (n *RuntimeGoNakamaModule) GroupUsersKick(ctx context.Context, callerID, gr
 // @group groups
 // @summary Promote users in a group.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
-// @param groupId(type=string) The ID of the group whose members are being promoted.
-// @param userIds(type=[]string) Table array of user IDs to promote.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
+// @param groupID(type=string) The ID of the group whose members are being promoted.
+// @param userIDs(type=[]string) Table array of user IDs to promote.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupUsersPromote(ctx context.Context, callerID, groupID string, userIDs []string) error {
 	caller := uuid.Nil
@@ -3820,9 +3827,9 @@ func (n *RuntimeGoNakamaModule) GroupUsersPromote(ctx context.Context, callerID,
 // @group groups
 // @summary Demote users in a group.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
-// @param groupId(type=string) The ID of the group whose members are being demoted.
-// @param userIds(type=[]string) Table array of user IDs to demote.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permissions are bypassed.
+// @param groupID(type=string) The ID of the group whose members are being demoted.
+// @param userIDs(type=[]string) Table array of user IDs to demote.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) GroupUsersDemote(ctx context.Context, callerID, groupID string, userIDs []string) error {
 	caller := uuid.Nil
@@ -3860,14 +3867,14 @@ func (n *RuntimeGoNakamaModule) GroupUsersDemote(ctx context.Context, callerID, 
 // @group groups
 // @summary List all members, admins and superadmins which belong to a group. This also lists incoming join requests.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param groupId(type=string) The ID of the group to list members for.
+// @param groupID(type=string) The ID of the group to list members for.
 // @param limit(type=int) Return only the required number of users denoted by this limit value.
 // @param state(type=int) Return only the users matching this state value, '0' for superadmins for example.
 // @param cursor(type=string) Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return groupUsers([]*api.GroupUserList_GroupUser) The user information for members, admins and superadmins for the group. Also users who sent a join request.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) GroupUsersList(ctx context.Context, id string, limit int, state *int, cursor string) ([]*api.GroupUserList_GroupUser, string, error) {
-	groupID, err := uuid.FromString(id)
+func (n *RuntimeGoNakamaModule) GroupUsersList(ctx context.Context, groupID string, limit int, state *int, cursor string) ([]*api.GroupUserList_GroupUser, string, error) {
+	group, err := uuid.FromString(groupID)
 	if err != nil {
 		return nil, "", errors.New("expects group ID to be a valid identifier")
 	}
@@ -3885,7 +3892,7 @@ func (n *RuntimeGoNakamaModule) GroupUsersList(ctx context.Context, id string, l
 		stateWrapper = &wrapperspb.Int32Value{Value: int32(stateValue)}
 	}
 
-	users, err := ListGroupUsers(ctx, n.logger, n.db, n.statusRegistry, groupID, limit, stateWrapper, cursor)
+	users, err := ListGroupUsers(ctx, n.logger, n.db, n.statusRegistry, group, limit, stateWrapper, cursor)
 	if err != nil {
 		return nil, "", err
 	}
@@ -3948,7 +3955,7 @@ func (n *RuntimeGoNakamaModule) GroupsGetRandom(ctx context.Context, count int) 
 // @group groups
 // @summary List all groups which a user belongs to and whether they've been accepted or if it's an invite.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user to list groups for.
+// @param userID(type=string) The ID of the user to list groups for.
 // @param limit(type=int) The maximum number of entries in the listing.
 // @param state(type=int, optional=true) The state of the user within the group. If unspecified this returns users in all states.
 // @param cursor(type=string) Pagination cursor from previous result. Don't set to start fetching from the beginning.
@@ -4041,7 +4048,7 @@ func (n *RuntimeGoNakamaModule) MetricsTimerRecord(name string, tags map[string]
 // @group friends
 // @summary List all friends, invites, invited, and blocked which belong to a user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user whose friends, invites, invited, and blocked you want to list.
+// @param userID(type=string) The ID of the user whose friends, invites, invited, and blocked you want to list.
 // @param limit(type=int) The number of friends to retrieve in this page of results. No more than 100 limit allowed per result.
 // @param state(type=int, optional=true) The state of the friendship with the user. If unspecified this returns friends in all states for the user.
 // @param cursor(type=string) Pagination cursor from previous result. Set to "" to start fetching from the beginning.
@@ -4078,7 +4085,7 @@ func (n *RuntimeGoNakamaModule) FriendsList(ctx context.Context, userID string, 
 // @group friends
 // @summary List friends of friends.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user whose friends of friends you want to list.
+// @param userID(type=string) The ID of the user whose friends of friends you want to list.
 // @param limit(type=int) The number of friends of friends to retrieve in this page of results. No more than 100 limit allowed per result.
 // @param cursor(type=string) Pagination cursor from previous result. Set to "" to start fetching from the beginning.
 // @return friends([]*api.FriendsOfFriendsList_FriendOfFriend) The user information for users that are friends of friends the current user.
@@ -4105,10 +4112,11 @@ func (n *RuntimeGoNakamaModule) FriendsOfFriendsList(ctx context.Context, userID
 // @group friends
 // @summary Add friends to a user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user to whom you want to add friends.
+// @param userID(type=string) The ID of the user to whom you want to add friends.
 // @param username(type=string) The name of the user to whom you want to add friends.
 // @param ids(type=[]string) The IDs of the users you want to add as friends.
 // @param usernames(type=[]string) The usernames of the users you want to add as friends.
+// @param metadata(type=map[string]any) Custom information to store for this friend.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) FriendsAdd(ctx context.Context, userID string, username string, ids []string, usernames []string, metadata map[string]any) error {
 	userUUID, err := uuid.FromString(userID)
@@ -4173,7 +4181,7 @@ func (n *RuntimeGoNakamaModule) FriendsAdd(ctx context.Context, userID string, u
 // @group friends
 // @summary Delete friends from a user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user from whom you want to delete friends.
+// @param userID(type=string) The ID of the user from whom you want to delete friends.
 // @param username(type=string) The name of the user from whom you want to delete friends.
 // @param ids(type=[]string) The IDs of the users you want to delete as friends.
 // @param usernames(type=[]string) The usernames of the users you want to delete as friends.
@@ -4231,7 +4239,7 @@ func (n *RuntimeGoNakamaModule) FriendsDelete(ctx context.Context, userID string
 // @group friends
 // @summary Block friends for a user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
-// @param userId(type=string) The ID of the user for whom you want to block friends.
+// @param userID(type=string) The ID of the user for whom you want to block friends.
 // @param username(type=string) The name of the user for whom you want to block friends.
 // @param ids(type=[]string) The IDs of the users you want to block as friends.
 // @param usernames(type=[]string) The usernames of the users you want to block as friends.
@@ -4290,7 +4298,7 @@ func (n *RuntimeGoNakamaModule) FriendsBlock(ctx context.Context, userID string,
 // @summary Update friend metadata.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userId(type=string) The ID of the user.
-// @param userIdFriend(type=string) The ID of the friend of the user.
+// @param friendUserId(type=string) The ID of the friend of the user.
 // @param metadata(type=map[string]any) The custom metadata to set for the friend.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) FriendMetadataUpdate(ctx context.Context, userId, friendUserId string, metadata map[string]any) error {

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -358,10 +358,11 @@ func (n *RuntimeJavascriptNakamaModule) stringToBinary(r *goja.Runtime) func(goj
 // @group storage
 // @summary List storage index entries
 // @param indexName(type=string) Name of the index to list entries from.
-// @param queryString(type=string) Query to filter index entries.
+// @param query(type=string) Query to filter index entries.
 // @param limit(type=int) Maximum number of results to be returned.
 // @param order(type=[]string, optional=true) The storage object fields to sort the query results by. The prefix '-' before a field name indicates descending order. All specified fields must be indexed and sortable.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param cursor(type=string, optional=true) A cursor to fetch the next page of results.
 // @return objects(nkruntime.StorageIndexResult) A list of storage objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageIndexList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -1548,7 +1549,7 @@ func (n *RuntimeJavascriptNakamaModule) authenticateEmail(r *goja.Runtime) func(
 // @group authenticate
 // @summary Authenticate user and create a session token using a Facebook account token.
 // @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
-// @param import(type=bool, optional=true, default=true) Whether to automatically import Facebook friends after authentication.
+// @param importFriends(type=bool, optional=true, default=true) Whether to automatically import Facebook friends after authentication.
 // @param username(type=string, optional=true) The user's username. If left empty, one is generated.
 // @param create(type=bool, optional=true, default=true) Create user if one didn't exist previously.
 // @return userID(string) The user ID of the authenticated user.
@@ -1605,7 +1606,7 @@ func (n *RuntimeJavascriptNakamaModule) authenticateFacebook(r *goja.Runtime) fu
 
 // @group authenticate
 // @summary Authenticate user and create a session token using a Facebook Instant Game.
-// @param playerInfo(type=string) Facebook Player info.
+// @param signedPlayerInfo(type=string) Facebook Player info.
 // @param username(type=string, optional=true) The user's username. If left empty, one is generated.
 // @param create(type=bool, optional=true, default=true) Create user if one didn't exist previously.
 // @return userID(string) The user ID of the authenticated user.
@@ -1652,8 +1653,8 @@ func (n *RuntimeJavascriptNakamaModule) authenticateFacebookInstantGame(r *goja.
 
 // @group authenticate
 // @summary Authenticate user and create a session token using Apple Game Center credentials.
-// @param playerId(type=string) PlayerId provided by GameCenter.
-// @param bundleId(type=string) BundleId of your app on iTunesConnect.
+// @param playerID(type=string) PlayerId provided by GameCenter.
+// @param bundleID(type=string) BundleId of your app on iTunesConnect.
 // @param timestamp(type=int64) Timestamp at which Game Center authenticated the client and issued a signature.
 // @param salt(type=string) A random string returned by Game Center authentication on client.
 // @param signature(type=string) A signature returned by Game Center authentication on client.
@@ -1834,9 +1835,9 @@ func (n *RuntimeJavascriptNakamaModule) authenticateSteam(r *goja.Runtime) func(
 
 // @group authenticate
 // @summary Generate a Nakama session token from a user ID.
-// @param userId(type=string) User ID to use to generate the token.
+// @param userID(type=string) User ID to use to generate the token.
 // @param username(type=string, optional=true) The user's username. If left empty, one is generated.
-// @param expiresAt(type=number, optional=true) UTC time in seconds when the token must expire. Defaults to server configured expiry time.
+// @param exp(type=number, optional=true) UTC time in seconds when the token must expire. Defaults to server configured expiry time.
 // @param vars(type={[key:string]:string}, optional=true) Extra information that will be bundled in the session token.
 // @return token(string) The Nakama session token.
 // @return validity(number) The period for which the token remains valid.
@@ -1886,7 +1887,7 @@ func (n *RuntimeJavascriptNakamaModule) authenticateTokenGenerate(r *goja.Runtim
 
 // @group accounts
 // @summary Fetch account information by user ID.
-// @param userId(type=string) User ID to fetch information for. Must be valid UUID.
+// @param userID(type=string) User ID to fetch information for. Must be valid UUID.
 // @return account(nkruntime.Account) All account information including wallet, device IDs and more.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) accountGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -1916,7 +1917,7 @@ func (n *RuntimeJavascriptNakamaModule) accountGetId(r *goja.Runtime) func(goja.
 
 // @group accounts
 // @summary Fetch information for multiple accounts by user IDs.
-// @param userIds(type=[]string) Array of user IDs to fetch information for. Must be valid UUID.
+// @param userIDs(type=[]string) Array of user IDs to fetch information for. Must be valid UUID.
 // @return account(nkruntime.Account[]) Array of accounts.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) accountsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -1956,13 +1957,13 @@ func (n *RuntimeJavascriptNakamaModule) accountsGetId(r *goja.Runtime) func(goja
 
 // @group accounts
 // @summary Update an account by user ID.
-// @param userId(type=string) User ID for which the information is to be updated. Must be valid UUID.
+// @param userID(type=string) User ID for which the information is to be updated. Must be valid UUID.
 // @param metadata(type=object, optional=true) The metadata to update for this account.
 // @param username(type=string, optional=true) Username to be set. Must be unique. Use null if it is not being updated.
 // @param displayName(type=string, optional=true) Display name to be updated. Use null if it is not being updated.
 // @param timezone(type=string, optional=true) Timezone to be updated. Use null if it is not being updated.
 // @param location(type=string, optional=true) Location to be updated. Use null if it is not being updated.
-// @param language(type=string, optional=true) Lang tag to be updated. Use null if it is not being updated.
+// @param langTag(type=string, optional=true) Lang tag to be updated. Use null if it is not being updated.
 // @param avatarUrl(type=string, optional=true) User's avatar URL. Use null if it is not being updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) accountUpdateId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2034,7 +2035,7 @@ func (n *RuntimeJavascriptNakamaModule) accountUpdateId(r *goja.Runtime) func(go
 
 // @group accounts
 // @summary Delete an account by user ID.
-// @param userId(type=string) User ID for the account to be deleted. Must be valid UUID.
+// @param userID(type=string) User ID for the account to be deleted. Must be valid UUID.
 // @param recorded(type=bool, optional=true, default=false) Whether to record this deletion in the database.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) accountDeleteId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2059,7 +2060,7 @@ func (n *RuntimeJavascriptNakamaModule) accountDeleteId(r *goja.Runtime) func(go
 
 // @group accounts
 // @summary Export account information for a specified user ID.
-// @param userId(type=string) User ID for the account to be exported. Must be valid UUID.
+// @param userID(type=string) User ID for the account to be exported. Must be valid UUID.
 // @return export(string) Account information for the provided user ID, in JSON format.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) accountExportId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2085,7 +2086,8 @@ func (n *RuntimeJavascriptNakamaModule) accountExportId(r *goja.Runtime) func(go
 
 // @group users
 // @summary Fetch one or more users by ID.
-// @param userIds(type=[]string) An array of user IDs to fetch.
+// @param userIDs(type=[]string) An array of user IDs to fetch.
+// @param facebookIDs(type=[]string) An array of Facebook IDs to fetch.
 // @return users(nkruntime.User[]) A list of user record objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) usersGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2174,7 +2176,7 @@ func (n *RuntimeJavascriptNakamaModule) usersGetUsername(r *goja.Runtime) func(g
 
 // @group users
 // @summary Get user's friend status information for a list of target users.
-// @param userID (type=string) The current user ID.
+// @param userID(type=string) The current user ID.
 // @param userIDs(type=string[]) An array of target user IDs.
 // @return friends(nkruntime.Friend[]) A list of user friends objects.
 // @return error(error) An optional error value if an error occurred.
@@ -2266,7 +2268,7 @@ func (n *RuntimeJavascriptNakamaModule) usersGetRandom(r *goja.Runtime) func(goj
 
 // @group users
 // @summary Ban one or more users by ID.
-// @param userIds(type=string[]) An array of user IDs to ban.
+// @param userIDs(type=string[]) An array of user IDs to ban.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) usersBanId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2299,7 +2301,7 @@ func (n *RuntimeJavascriptNakamaModule) usersBanId(r *goja.Runtime) func(goja.Fu
 
 // @group users
 // @summary Unban one or more users by ID.
-// @param userIds(type=string[]) An array of user IDs to unban.
+// @param userIDs(type=string[]) An array of user IDs to unban.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) usersUnbanId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2332,7 +2334,7 @@ func (n *RuntimeJavascriptNakamaModule) usersUnbanId(r *goja.Runtime) func(goja.
 
 // @group authenticate
 // @summary Link Apple authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param token(type=string) Apple sign in token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) linkApple(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2358,8 +2360,8 @@ func (n *RuntimeJavascriptNakamaModule) linkApple(r *goja.Runtime) func(goja.Fun
 
 // @group authenticate
 // @summary Link custom authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
-// @param customId(type=string) Custom ID to be linked to the user.
+// @param userID(type=string) The user ID to be linked.
+// @param customID(type=string) Custom ID to be linked to the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) linkCustom(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2384,8 +2386,8 @@ func (n *RuntimeJavascriptNakamaModule) linkCustom(r *goja.Runtime) func(goja.Fu
 
 // @group authenticate
 // @summary Link device authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
-// @param deviceId(type=string) Device ID to be linked to the user.
+// @param userID(type=string) The user ID to be linked.
+// @param deviceID(type=string) Device ID to be linked to the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) linkDevice(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2410,7 +2412,7 @@ func (n *RuntimeJavascriptNakamaModule) linkDevice(r *goja.Runtime) func(goja.Fu
 
 // @group authenticate
 // @summary Link email authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param email(type=string) Authentication email to be linked to the user.
 // @param password(type=string) Password to set. Must be longer than 8 characters.
 // @return error(error) An optional error value if an error occurred.
@@ -2441,7 +2443,7 @@ func (n *RuntimeJavascriptNakamaModule) linkEmail(r *goja.Runtime) func(goja.Fun
 
 // @group authenticate
 // @summary Link Facebook authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param username(type=string, optional=true) If left empty, one is generated.
 // @param token(type=string) Facebook OAuth or Limited Login (JWT) access token.
 // @param importFriends(type=bool, optional=true, default=true) Whether to automatically import Facebook friends after authentication.
@@ -2477,7 +2479,7 @@ func (n *RuntimeJavascriptNakamaModule) linkFacebook(r *goja.Runtime) func(goja.
 
 // @group authenticate
 // @summary Link Facebook Instant Game authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param playerInfo(type=string) Facebook player info.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) linkFacebookInstantGame(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2503,9 +2505,9 @@ func (n *RuntimeJavascriptNakamaModule) linkFacebookInstantGame(r *goja.Runtime)
 
 // @group authenticate
 // @summary Link Apple Game Center authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
-// @param playerId(type=string) Player ID provided by Game Center.
-// @param bundleId(type=string) Bundle ID of your app on iTunesConnect.
+// @param userID(type=string) The user ID to be linked.
+// @param playerID(type=string) Player ID provided by Game Center.
+// @param bundleID(type=string) Bundle ID of your app on iTunesConnect.
 // @param timestamp(type=int64) Timestamp at which Game Center authenticated the client and issued a signature.
 // @param salt(type=string) A random string returned by Game Center authentication on client.
 // @param signature(type=string) A signature returned by Game Center authentication on client.
@@ -2554,7 +2556,7 @@ func (n *RuntimeJavascriptNakamaModule) linkGameCenter(r *goja.Runtime) func(goj
 
 // @group authenticate
 // @summary Link Google authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param token(type=string) Google OAuth access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) linkGoogle(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2580,7 +2582,7 @@ func (n *RuntimeJavascriptNakamaModule) linkGoogle(r *goja.Runtime) func(goja.Fu
 
 // @group authenticate
 // @summary Link Steam authentication to a user ID.
-// @param userId(type=string) The user ID to be linked.
+// @param userID(type=string) The user ID to be linked.
 // @param username(type=string, optional=true) If left empty, one is generated.
 // @param token(type=string) Steam access token.
 // @param importFriends(type=bool, optional=true, default=true) Whether to automatically import Steam friends after authentication.
@@ -2616,7 +2618,7 @@ func (n *RuntimeJavascriptNakamaModule) linkSteam(r *goja.Runtime) func(goja.Fun
 
 // @group authenticate
 // @summary Unlink Apple authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string) Apple sign in token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkApple(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2642,8 +2644,8 @@ func (n *RuntimeJavascriptNakamaModule) unlinkApple(r *goja.Runtime) func(goja.F
 
 // @group authenticate
 // @summary Unlink custom authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
-// @param customId(type=string, optional=true) Custom ID to be unlinked from the user.
+// @param userID(type=string) The user ID to be unlinked.
+// @param customID(type=string, optional=true) Custom ID to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkCustom(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2668,8 +2670,8 @@ func (n *RuntimeJavascriptNakamaModule) unlinkCustom(r *goja.Runtime) func(goja.
 
 // @group authenticate
 // @summary Unlink device authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
-// @param deviceId(type=string) Device ID to be unlinked to the user.
+// @param userID(type=string) The user ID to be unlinked.
+// @param deviceID(type=string) Device ID to be unlinked to the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkDevice(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2694,7 +2696,7 @@ func (n *RuntimeJavascriptNakamaModule) unlinkDevice(r *goja.Runtime) func(goja.
 
 // @group authenticate
 // @summary Unlink email authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param email(type=string, optional=true) Email to be unlinked from the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkEmail(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2720,7 +2722,7 @@ func (n *RuntimeJavascriptNakamaModule) unlinkEmail(r *goja.Runtime) func(goja.F
 
 // @group authenticate
 // @summary Unlink Facebook authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string, optional=true) Facebook OAuth or Limited Login (JWT) access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkFacebook(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2746,8 +2748,8 @@ func (n *RuntimeJavascriptNakamaModule) unlinkFacebook(r *goja.Runtime) func(goj
 
 // @group authenticate
 // @summary Unlink Facebook Instant Game authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
-// @param playerInfo(type=string, optional=true) Facebook player info.
+// @param userID(type=string) The user ID to be unlinked.
+// @param signedPlayerInfo(type=string, optional=true) Facebook player info.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkFacebookInstantGame(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -2772,9 +2774,9 @@ func (n *RuntimeJavascriptNakamaModule) unlinkFacebookInstantGame(r *goja.Runtim
 
 // @group authenticate
 // @summary Unlink Apple Game Center authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
-// @param playerId(type=string) Player ID provided by Game Center.
-// @param bundleId(type=string) Bundle ID of your app on iTunesConnect.
+// @param userID(type=string) The user ID to be unlinked.
+// @param playerID(type=string) Player ID provided by Game Center.
+// @param bundleID(type=string) Bundle ID of your app on iTunesConnect.
 // @param timestamp(type=int64) Timestamp at which Game Center authenticated the client and issued a signature.
 // @param salt(type=string) A random string returned by Game Center authentication on client.
 // @param signature(type=string) A signature returned by Game Center authentication on client.
@@ -2823,7 +2825,7 @@ func (n *RuntimeJavascriptNakamaModule) unlinkGameCenter(r *goja.Runtime) func(g
 
 // @group authenticate
 // @summary Unlink Google authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string, optional=true) Google OAuth access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkGoogle(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2849,7 +2851,7 @@ func (n *RuntimeJavascriptNakamaModule) unlinkGoogle(r *goja.Runtime) func(goja.
 
 // @group authenticate
 // @summary Unlink Steam authentication from a user ID.
-// @param userId(type=string) The user ID to be unlinked.
+// @param userID(type=string) The user ID to be unlinked.
 // @param token(type=string, optional=true) Steam access token.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) unlinkSteam(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -2922,8 +2924,8 @@ func (n *RuntimeJavascriptNakamaModule) streamUserList(r *goja.Runtime) func(goj
 
 // @group streams
 // @summary Retrieve a stream presence and metadata by user ID.
-// @param userId(type=string) The user ID to fetch information for.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to fetch information for.
+// @param sessionID(type=string) The current session ID for the user.
 // @param stream(type=nkruntime.Stream) A stream object.
 // @return meta(nkruntime.Presence) Presence for the user.
 // @return error(error) An optional error value if an error occurred.
@@ -2974,8 +2976,8 @@ func (n *RuntimeJavascriptNakamaModule) streamUserGet(r *goja.Runtime) func(goja
 
 // @group streams
 // @summary Add a user to a stream.
-// @param userId(type=string) The user ID to be added.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to be added.
+// @param sessionID(type=string) The current session ID for the user.
 // @param stream(type=nkruntime.Stream) A stream object.
 // @param hidden(type=bool) Whether the user will be marked as hidden.
 // @param persistence(type=bool) Whether message data should be stored in the database.
@@ -3046,8 +3048,8 @@ func (n *RuntimeJavascriptNakamaModule) streamUserJoin(r *goja.Runtime) func(goj
 
 // @group streams
 // @summary Update a stream user by ID.
-// @param userId(type=string) The user ID to be updated.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to be updated.
+// @param sessionID(type=string) The current session ID for the user.
 // @param stream(type=nkruntime.Stream) A stream object.
 // @param hidden(type=bool) Whether the user will be marked as hidden.
 // @param persistence(type=bool) Whether message data should be stored in the database.
@@ -3117,8 +3119,8 @@ func (n *RuntimeJavascriptNakamaModule) streamUserUpdate(r *goja.Runtime) func(g
 
 // @group streams
 // @summary Remove a user from a stream.
-// @param userId(type=string) The user ID to be removed.
-// @param sessionId(type=string) The current session ID for the user.
+// @param userID(type=string) The user ID to be removed.
+// @param sessionID(type=string) The current session ID for the user.
 // @param stream(type=nkruntime.Stream) A stream object.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamUserLeave(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -3473,7 +3475,7 @@ func (n *RuntimeJavascriptNakamaModule) streamSendRaw(r *goja.Runtime) func(goja
 
 // @group sessions
 // @summary Disconnect a session.
-// @param sessionId(type=string) The ID of the session to be disconnected.
+// @param sessionID(type=string) The ID of the session to be disconnected.
 // @param reason(type=nkruntime.PresenceReason) The reason for the session disconnect.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) sessionDisconnect(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -3506,7 +3508,7 @@ func (n *RuntimeJavascriptNakamaModule) sessionDisconnect(r *goja.Runtime) func(
 
 // @group sessions
 // @summary Log out a user from their current session.
-// @param userId(type=string) The ID of the user to be logged out.
+// @param userID(type=string) The ID of the user to be logged out.
 // @param token(type=string, optional=true) The current session authentication token. If the current auth and refresh tokens are not provided, all user sessions will be logged out.
 // @param refreshToken(type=string, optional=true) The current session refresh token. If the current auth and refresh tokens are not provided, all user sessions will be logged out.
 // @return error(error) An optional error value if an error occurred.
@@ -3709,7 +3711,7 @@ func (n *RuntimeJavascriptNakamaModule) matchSignal(r *goja.Runtime) func(goja.F
 
 // @group notifications
 // @summary Send one in-app notification to a user.
-// @param userId(type=string) The user ID of the user to be sent the notification.
+// @param userID(type=string) The user ID of the user to be sent the notification.
 // @param subject(type=string) Notification subject.
 // @param content(type=object) Notification content. Must be set but can be empty object.
 // @param code(type=number) Notification code to use. Must be equal or greater than 0.
@@ -4086,7 +4088,7 @@ func (n *RuntimeJavascriptNakamaModule) notificationsDelete(r *goja.Runtime) fun
 
 // @group notifications
 // @summary Update notifications by their id.
-// @param updates(type=nkruntime.NotificationUpdate[])
+// @param updates(type=nkruntime.NotificationUpdate[]) A list of notifications to be updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationsUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -4255,7 +4257,7 @@ func (n *RuntimeJavascriptNakamaModule) notificationsDeleteId(r *goja.Runtime) f
 
 // @group wallets
 // @summary Update a user's wallet with the given changeset.
-// @param userId(type=string) The ID of the user whose wallet to update.
+// @param userID(type=string) The ID of the user whose wallet to update.
 // @param changeset(type={[key: string]: number}) The set of wallet operations to apply.
 // @param metadata(type=object, optional=true) Additional metadata to tag the wallet update with.
 // @param updateLedger(type=bool, optional=true, default=false) Whether to record this update in the ledger.
@@ -4417,7 +4419,7 @@ func (n *RuntimeJavascriptNakamaModule) walletsUpdate(r *goja.Runtime) func(goja
 
 // @group wallets
 // @summary Update the metadata for a particular wallet update in a user's wallet ledger history. Useful when adding a note to a transaction for example.
-// @param itemId(type=string) The ID of the wallet ledger item to update.
+// @param itemID(type=string) The ID of the wallet ledger item to update.
 // @param metadata(type=object) The new metadata to set on the wallet ledger item.
 // @return updateWalletLedger(nkruntime.WalletLedgerItem) The updated wallet ledger item.
 // @return error(error) An optional error value if an error occurred.
@@ -4539,7 +4541,7 @@ func (n *RuntimeJavascriptNakamaModule) statusUnfollow(r *goja.Runtime) func(goj
 
 // @group wallets
 // @summary List all wallet updates for a particular user from oldest to newest.
-// @param userId(type=string) The ID of the user to list wallet updates for.
+// @param userID(type=string) The ID of the user to list wallet updates for.
 // @param limit(type=number, optional=true, default=100) Limit number of results.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return runtimeItems(nkruntime.WalletLedgerItem[]) A JavaScript Object containing wallet entries with Id, UserId, CreateTime, UpdateTime, Changeset, Metadata parameters, and possibly a cursor. If cursor is empty/null there are no further results.
@@ -4597,10 +4599,11 @@ func (n *RuntimeJavascriptNakamaModule) walletLedgerList(r *goja.Runtime) func(g
 
 // @group storage
 // @summary List records in a collection and page through results. The records returned can be filtered to those owned by the user or "" for public records.
-// @param userId(type=string) User ID to list records for or "" (empty string) for public records.
+// @param userID(type=string) User ID to list records for or "" (empty string) for public records.
 // @param collection(type=string) Collection to list data from.
 // @param limit(type=number, optional=true, default=100) Limit number of records retrieved.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return objects(nkruntime.StorageObjectList) A list of storage objects.
 // @return cursor(string) Pagination cursor. Will be set to "" or null when fetching last available page.
 // @return error(error) An optional error value if an error occurred.
@@ -4691,7 +4694,7 @@ func (n *RuntimeJavascriptNakamaModule) storageList(r *goja.Runtime) func(goja.F
 
 // @group storage
 // @summary Fetch one or more records by their bucket/collection/keyname and optional user.
-// @param objectIds(type=nkruntime.StorageReadRequest[]) An array of object identifiers to be fetched.
+// @param objectIDs(type=nkruntime.StorageReadRequest[]) An array of object identifiers to be fetched.
 // @return objects(nkruntime.StorageObject[]) A list of storage records matching the parameters criteria.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -4792,7 +4795,7 @@ func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.F
 
 // @group storage
 // @summary Write one or more objects by their collection/keyname and optional user.
-// @param objectIds(type=nkruntime.StorageWriteRequest[]) An array of object identifiers to be written.
+// @param objectIDs(type=nkruntime.StorageWriteRequest[]) An array of object identifiers to be written.
 // @return acks(nkruntime.StorageWriteAck[]) A list of acks with the version of the written objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageWrite(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -4935,7 +4938,7 @@ func jsArrayToStorageOpWrites(dataSlice []map[string]any) (StorageOpWrites, erro
 
 // @group storage
 // @summary Remove one or more objects by their collection/keyname and optional user.
-// @param objectIds(type=nkruntime.StorageDeleteRequest[]) An array of object identifiers to be deleted.
+// @param objectIDs(type=nkruntime.StorageDeleteRequest[]) An array of object identifiers to be deleted.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -5405,7 +5408,7 @@ func (n *RuntimeJavascriptNakamaModule) multiUpdate(r *goja.Runtime) func(goja.F
 }
 
 // @group leaderboards
-// @summary Setup a new dynamic leaderboard with the specified ID and various configuration settings. The leaderboard will be created if it doesn't already exist, otherwise its configuration will not be updated.
+// @summary Set up a new dynamic leaderboard with the specified ID and various configuration settings. The leaderboard will be created if it doesn't already exist, otherwise its configuration will not be updated.
 // @param leaderboardID(type=string) The unique identifier for the new leaderboard. This is used by clients to submit scores.
 // @param authoritative(type=bool, optional=true, default=false) Mark the leaderboard as authoritative which ensures updates can only be made via the Go runtime. No client can submit a score directly.
 // @param sortOrder(type=string, optional=true, default="desc") The sort order for records in the leaderboard. Possible values are "asc" or "desc".
@@ -5416,8 +5419,8 @@ func (n *RuntimeJavascriptNakamaModule) multiUpdate(r *goja.Runtime) func(goja.F
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) leaderboardCreate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		id := getJsString(r, f.Argument(0))
-		if id == "" {
+		leaderboardID := getJsString(r, f.Argument(0))
+		if leaderboardID == "" {
 			panic(r.NewTypeError("expects a leaderboard ID string"))
 		}
 
@@ -5487,7 +5490,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardCreate(r *goja.Runtime) func(
 			enableRanks = getJsBool(r, f.Argument(6))
 		}
 
-		_, created, err := n.leaderboardCache.Create(n.ctx, id, authoritative, sortOrderNumber, operatorNumber, resetSchedule, metadataStr, enableRanks)
+		_, created, err := n.leaderboardCache.Create(n.ctx, leaderboardID, authoritative, sortOrderNumber, operatorNumber, resetSchedule, metadataStr, enableRanks)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error creating leaderboard: %v", err.Error())))
 		}
@@ -5598,10 +5601,10 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRanksDisable(r *goja.Runtime)
 // @group leaderboards
 // @summary List records on the specified leaderboard, optionally filtering to only a subset of records by their owners. Records will be listed in the preconfigured leaderboard sort order.
 // @param id(type=string) The unique identifier for the leaderboard to list. Mandatory field.
-// @param owners(type=string[]) Array of owners to filter to.
+// @param ownerIDs(type=string[]) Array of owners to filter to.
 // @param limit(type=number) The maximum number of records to return (Max 10,000).
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
-// @param overrideExpiry(type=int, optional=true) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
+// @param expiry(type=int, optional=true) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
 // @return records(nkruntime.LeaderboardRecord[]) A page of leaderboard records.
 // @return ownerRecords(nkruntime.LeaderboardRecord[]) A list of owner leaderboard records (empty if the owners input parameter is not set).
 // @return nextCursor(string) An optional next page cursor that can be used to retrieve the next page of records (if any). Will be set to "" or null when fetching last available page.
@@ -5662,15 +5665,15 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsList(r *goja.Runtime) 
 // @summary Build a cursor to be used with leaderboardRecordsList to fetch records starting at a given rank. Only available if rank cache is not disabled for the leaderboard.
 // @param leaderboardID(type=string) The unique identifier of the leaderboard.
 // @param rank(type=number) The rank to start listing leaderboard records from.
-// @param overrideExpiry(type=number, optional=true) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
+// @param expiry(type=number, optional=true) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
 // @return leaderboardListCursor(string) A string cursor to be used with leaderboardRecordsList.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsListCursorFromRank(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		leaderboardId := getJsString(r, f.Argument(0))
+		leaderboardID := getJsString(r, f.Argument(0))
 		rank := getJsInt(r, f.Argument(1))
 
-		if leaderboardId == "" {
+		if leaderboardID == "" {
 			panic(r.NewTypeError("invalid leaderboard id"))
 		}
 
@@ -5683,7 +5686,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsListCursorFromRank(r *
 			overrideExpiry = getJsInt(r, f.Argument(2))
 		}
 
-		l := n.leaderboardCache.Get(leaderboardId)
+		l := n.leaderboardCache.Get(leaderboardID)
 		if l == nil {
 			panic(r.NewTypeError(ErrLeaderboardNotFound.Error()))
 		}
@@ -5699,14 +5702,14 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsListCursorFromRank(r *
 			return r.ToValue("")
 		}
 
-		ownerId, score, subscore, err := n.rankCache.GetDataByRank(leaderboardId, expiryTime, l.SortOrder, rank)
+		ownerId, score, subscore, err := n.rankCache.GetDataByRank(leaderboardID, expiryTime, l.SortOrder, rank)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get cursor from rank: %s", err.Error())))
 		}
 
 		cursor := &leaderboardRecordListCursor{
 			IsNext:        true,
-			LeaderboardId: leaderboardId,
+			LeaderboardId: leaderboardID,
 			ExpiryTime:    expiryTime,
 			Score:         score,
 			Subscore:      subscore,
@@ -5726,7 +5729,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsListCursorFromRank(r *
 // @group leaderboards
 // @summary Use the preconfigured operator for the given leaderboard to submit a score for a particular user.
 // @param id(type=string) The unique identifier for the leaderboard to submit to.
-// @param owner(type=string) The owner of this score submission.
+// @param ownerID(type=string) The owner of this score submission.
 // @param username(type=string, optional=true) The owner username of this score submission, if it's a user.
 // @param score(type=number, optional=true, default=0) The score to submit.
 // @param subscore(type=number, optional=true, default=0) A secondary subscore parameter for the submission.
@@ -5804,7 +5807,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordWrite(r *goja.Runtime) 
 // @group leaderboards
 // @summary Remove an owner's record from a leaderboard, if one exists.
 // @param id(type=string) The unique identifier for the leaderboard to delete from.
-// @param owner(type=string) The owner of the score to delete. Mandatory field.
+// @param ownerID(type=string) The owner of the score to delete. Mandatory field.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) leaderboardRecordDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -5828,7 +5831,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordDelete(r *goja.Runtime)
 
 // @group leaderboards
 // @summary Fetch one or more leaderboards by ID.
-// @param ids(type=string[]) The array of leaderboard ids.
+// @param IDs(type=string[]) The array of leaderboard ids.
 // @return leaderboards(nkruntime.Leaderboard[]) The leaderboard records according to ID.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) leaderboardsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -5861,7 +5864,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardsGetId(r *goja.Runtime) func(
 // @group leaderboards
 // @summary Fetch the list of leaderboard records around the owner.
 // @param id(type=string) The unique identifier for the leaderboard.
-// @param owner(type=string) The owner of the score to list records around. Mandatory field.
+// @param ownerID(type=string) The owner of the score to list records around. Mandatory field.
 // @param limit(type=number) Return only the required number of leaderboard records denoted by this limit value.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param overrideExpiry(type=number, optional=true, default=0) Optionally retrieve records from previous resets by specifying the reset point in time in UTC seconds. Must be equal or greater than 0.
@@ -5909,7 +5912,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsHaystack(r *goja.Runti
 
 // @group purchases
 // @summary Validates and stores the purchases present in an Apple App Store Receipt.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) Base-64 encoded receipt data returned by the purchase operation itself.
 // @param persist(type=bool, optional=true, default=true) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @param passwordOverride(type=string, optional=true) Override the iap.apple.shared_password provided in your configuration.
@@ -5958,7 +5961,7 @@ func (n *RuntimeJavascriptNakamaModule) purchaseValidateApple(r *goja.Runtime) f
 
 // @group purchases
 // @summary Validates and stores a purchase receipt from the Google Play Store.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) JSON encoded Google receipt.
 // @param persist(type=bool, optional=true, default=true) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @return validation(nkruntime.ValidatePurchaseResponse) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
@@ -6010,7 +6013,7 @@ func (n *RuntimeJavascriptNakamaModule) purchaseValidateGoogle(r *goja.Runtime) 
 
 // @group purchases
 // @summary Validates and stores a purchase receipt from the Huawei App Gallery.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) The Huawei receipt data.
 // @param signature(type=string) The receipt signature.
 // @param persist(type=bool, optional=true, default=true) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
@@ -6061,7 +6064,7 @@ func (n *RuntimeJavascriptNakamaModule) purchaseValidateHuawei(r *goja.Runtime) 
 
 // @group purchases
 // @summary Validates and stores a purchase receipt from Facebook Instant Games.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param signedRequest(type=string) The Facebook Instant signedRequest receipt data.
 // @param persist(type=bool, optional=true, default=true) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @return validation(nkruntime.ValidatePurchaseResponse) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
@@ -6104,7 +6107,7 @@ func (n *RuntimeJavascriptNakamaModule) purchaseValidateFacebookInstant(r *goja.
 
 // @group purchases
 // @summary Look up a purchase receipt by transaction ID.
-// @param transactionId(type=string) Transaction ID of the purchase to look up.
+// @param transactionID(type=string) Transaction ID of the purchase to look up.
 // @return purchase(nkruntime.ValidatedPurchaseAroundOwner) A validated purchase.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) purchaseGetByTransactionId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -6125,7 +6128,7 @@ func (n *RuntimeJavascriptNakamaModule) purchaseGetByTransactionId(r *goja.Runti
 
 // @group purchases
 // @summary List stored validated purchase receipts.
-// @param userId(type=string, optional=true) Filter by user ID. Can be an empty string to list purchases for all users.
+// @param userID(type=string, optional=true) Filter by user ID. Can be an empty string to list purchases for all users.
 // @param limit(type=number, optional=true, default=100) Limit number of records retrieved.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return listPurchases(nkruntime.ValidatedPurchaseList) A page of stored validated purchases and possibly a cursor. If cursor is empty/null there are no further results.
@@ -6183,7 +6186,7 @@ func (n *RuntimeJavascriptNakamaModule) purchasesList(r *goja.Runtime) func(goja
 
 // @group subscriptions
 // @summary Validates and stores the subscription present in an Apple App Store Receipt.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) Base-64 encoded receipt data returned by the purchase operation itself.
 // @param persist(type=bool, optional=true, default=true) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
 // @param passwordOverride(type=string, optional=true) Override the iap.apple.shared_password provided in your configuration.
@@ -6232,7 +6235,7 @@ func (n *RuntimeJavascriptNakamaModule) subscriptionValidateApple(r *goja.Runtim
 
 // @group subscriptions
 // @summary Validates and stores a subscription purchase receipt from the Google Play Store.
-// @param userId(type=string) The user ID of the owner of the receipt.
+// @param userID(type=string) The user ID of the owner of the receipt.
 // @param receipt(type=string) JSON encoded Google receipt.
 // @param persist(type=bool, optional=true, default=true) Persist the subscription.
 // @return validation(nkruntime.ValidateSubscriptionResponse) The resulting successfully validated subscriptions.
@@ -6290,8 +6293,8 @@ func (n *RuntimeJavascriptNakamaModule) subscriptionValidateGoogle(r *goja.Runti
 
 // @group subscriptions
 // @summary Look up a subscription by product ID.
-// @param userId(type=string) The user ID of the subscription owner.
-// @param subscriptionId(type=string) Transaction ID of the purchase to look up.
+// @param userID(type=string) The user ID of the subscription owner.
+// @param subscriptionID(type=string) Transaction ID of the purchase to look up.
 // @return subscription(nkruntime.ValidatedSubscription) A validated subscription.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) subscriptionGetByProductId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -6321,7 +6324,7 @@ func (n *RuntimeJavascriptNakamaModule) subscriptionGetByProductId(r *goja.Runti
 
 // @group subscriptions
 // @summary List stored validated subscriptions.
-// @param userId(type=string, optional=true) Filter by user ID. Can be an empty string to list subscriptions for all users.
+// @param userID(type=string, optional=true) Filter by user ID. Can be an empty string to list subscriptions for all users.
 // @param limit(type=number, optional=true, default=100) Limit number of records retrieved.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return listSubscriptions(nkruntime.SubscriptionList) A page of stored validated subscriptions and possibly a cursor. If cursor is empty/null there are no further results.
@@ -6562,7 +6565,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentDelete(r *goja.Runtime) func(g
 // @group tournaments
 // @summary Add additional score attempts to the owner's tournament record. This overrides the max number of score attempts allowed in the tournament for this specific owner.
 // @param id(type=string) The unique identifier for the tournament to update.
-// @param owner(type=string) The owner of the records to increment the count for.
+// @param ownerID(type=string) The owner of the records to increment the count for.
 // @param count(type=number) The number of attempt counts to increment. Can be negative to decrease count.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) tournamentAddAttempt(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -6595,7 +6598,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentAddAttempt(r *goja.Runtime) fu
 // @group tournaments
 // @summary A tournament may need to be joined before the owner can submit scores. This operation is idempotent and will always succeed for the owner even if they have already joined the tournament.
 // @param id(type=string) The unique identifier for the tournament to join.
-// @param ownerId(type=string) The owner of the record.
+// @param ownerID(type=string) The owner of the record.
 // @param username(type=string) The username of the record owner.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) tournamentJoin(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -6629,7 +6632,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentJoin(r *goja.Runtime) func(goj
 
 // @group tournaments
 // @summary Fetch one or more tournaments by ID.
-// @param ids(type=string[]) The table array of tournament ids.
+// @param tournamentIDs(type=string[]) The table array of tournament ids.
 // @return result(nkruntime.Tournament[]) Array of tournament records.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) tournamentsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -6669,7 +6672,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentsGetId(r *goja.Runtime) func(g
 // @group tournaments
 // @summary List records on the specified tournament, optionally filtering to only a subset of records by their owners. Records will be listed in the preconfigured tournament sort order.
 // @param tournamentId(type=string) The ID of the tournament to list records for.
-// @param ownerIds(type=string[], optional=true) Array of owner IDs to filter results by. Optional.
+// @param ownerIDs(type=string[], optional=true) Array of owner IDs to filter results by. Optional.
 // @param limit(type=number, optional=true Return only the required number of tournament records denoted by this limit value. Max is 10000.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param overrideExpiry(type=number, optional=true, default=0) Optionally retrieve records from previous resets by specifying the reset point in time in UTC seconds. Must be equal or greater than 0.
@@ -6915,7 +6918,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRanksDisable(r *goja.Runtime) 
 // @group tournaments
 // @summary Submit a score and optional subscore to a tournament leaderboard. If the tournament has been configured with join required this will fail unless the owner has already joined the tournament.
 // @param id(type=string) The unique identifier for the tournament leaderboard to submit to.
-// @param owner(type=string) The owner of this score submission. Mandatory field.
+// @param ownerID(type=string) The owner of this score submission. Mandatory field.
 // @param username(type=string, optional=true) The owner username of this score submission, if it's a user.
 // @param score(type=number, optional=true, default=0) The score to submit.
 // @param subscore(type=number, optional=true, default=0) A secondary subscore parameter for the submission.
@@ -6985,7 +6988,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordWrite(r *goja.Runtime) f
 // @group tournaments
 // @summary Remove an owner's record from a tournament, if one exists.
 // @param id(type=string) The unique identifier for the tournament to delete from.
-// @param owner(type=string) The owner of the score to delete. Mandatory field.
+// @param ownerID(type=string) The owner of the score to delete. Mandatory field.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) tournamentRecordDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -7010,7 +7013,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordDelete(r *goja.Runtime) 
 // @group tournaments
 // @summary Fetch the list of tournament records around the owner.
 // @param id(type=string) The ID of the tournament to list records for.
-// @param ownerId(type=string) The owner ID around which to show records.
+// @param ownerID(type=string) The owner ID around which to show records.
 // @param limit(type=number, optional=true, default=10) Return only the required number of tournament records denoted by this limit value. Between 1-100.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param expiry(type=number, optional=true, default=0) Time since epoch in seconds. Must be greater than 0.
@@ -7061,7 +7064,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordsHaystack(r *goja.Runtim
 
 // @group groups
 // @summary Fetch one or more groups by their ID.
-// @param groupIds(type=string[]) An array of strings of the IDs for the groups to get.
+// @param groupIDs(type=string[]) An array of strings of the IDs for the groups to get.
 // @return getGroups(nkruntime.Group[]) An array of groups with their fields.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -7111,9 +7114,9 @@ func (n *RuntimeJavascriptNakamaModule) groupsGetId(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Setup a group with various configuration settings. The group will be created if they don't exist or fail if the group name is taken.
-// @param userId(type=string) The user ID to be associated as the group superadmin.
+// @param userID(type=string) The user ID to be associated as the group superadmin.
 // @param name(type=string) Group name, must be unique.
-// @param creatorId(type=string, optional=true) The user ID to be associated as creator. If not set or nil/null, system user will be set.
+// @param creatorID(type=string, optional=true) The user ID to be associated as creator. If not set or nil/null, system user will be set.
 // @param langTag(type=string, optional=true, default="en") Group language.
 // @param description(type=string, optional=true) Group description, can be left empty as nil/null.
 // @param avatarUrl(type=string, optional=true) URL to the group avatar, can be left empty as nil/null.
@@ -7220,10 +7223,10 @@ func (n *RuntimeJavascriptNakamaModule) groupCreate(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Update a group with various configuration settings. The group which is updated can change some or all of its fields.
-// @param groupId(type=string) The ID of the group to update.
-// @param userId(type=string) User ID calling the update operation for permission checking. Set as nil to enact the changes as the system user.
+// @param groupID(type=string) The ID of the group to update.
+// @param userID(type=string) User ID calling the update operation for permission checking. Set as nil to enact the changes as the system user.
 // @param name(type=string, optional=true) Group name, can be empty if not changed.
-// @param creatorId(type=string, optional=true) The user ID to be associated as creator. Can be empty if not changed.
+// @param creatorID(type=string, optional=true) The user ID to be associated as creator. Can be empty if not changed.
 // @param langTag(type=string, optional=true) Group language. Empty if not updated.
 // @param description(type=string, optional=true) Group description, can be left empty if not updated.
 // @param avatarUrl(type=string, optional=true) URL to the group avatar, can be left empty if not updated.
@@ -7315,7 +7318,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUpdate(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Delete a group.
-// @param groupId(type=string) The ID of the group to delete.
+// @param groupID(type=string) The ID of the group to delete.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -7335,9 +7338,9 @@ func (n *RuntimeJavascriptNakamaModule) groupDelete(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Kick users from a group.
-// @param groupId(type=string) The ID of the group to kick users from.
-// @param userIds(type=string[]) Table array of user IDs to kick.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group to kick users from.
+// @param userIDs(type=string[]) Table array of user IDs to kick.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersKick(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -7388,7 +7391,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersKick(r *goja.Runtime) func(goj
 
 // @group groups
 // @summary List all members, admins and superadmins which belong to a group. This also list incoming join requests.
-// @param groupId(type=string) The ID of the group to list members for.
+// @param groupID(type=string) The ID of the group to list members for.
 // @param limit(type=int, optional=true, default=100) The maximum number of entries in the listing.
 // @param state(type=int, optional=true, default=null) The state of the user within the group. If unspecified this returns users in all states.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
@@ -7496,7 +7499,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersList(r *goja.Runtime) func(goj
 
 // @group groups
 // @summary List all groups which a user belongs to and whether they've been accepted or if it's an invite.
-// @param userId(type=string) The ID of the user to list groups for.
+// @param userID(type=string) The ID of the user to list groups for.
 // @return userGroups(nkruntime.UserGroupList) A table of groups with their fields.
 // @return cursor(string) An optional next page cursor that can be used to retrieve the next page of records (if any).
 // @return error(error) An optional error value if an error occurred.
@@ -7584,7 +7587,7 @@ func (n *RuntimeJavascriptNakamaModule) userGroupsList(r *goja.Runtime) func(goj
 
 // @group friends
 // @summary List all friends, invites, invited, and blocked which belong to a user.
-// @param userId(type=string) The ID of the user whose friends, invites, invited, and blocked you want to list.
+// @param userID(type=string) The ID of the user whose friends, invites, invited, and blocked you want to list.
 // @param limit(type=number, optional=true, default=100) The number of friends to retrieve in this page of results. No more than 100 limit allowed per result.
 // @param state(type=number, optional=true) The state of the friendship with the user. If unspecified this returns friends in all states for the user.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
@@ -7665,7 +7668,7 @@ func (n *RuntimeJavascriptNakamaModule) friendsList(r *goja.Runtime) func(goja.F
 
 // @group friends
 // @summary List all friends of friends of a user.
-// @param userId(type=string) The ID of the user whose friends of friends you want to list.
+// @param userID(type=string) The ID of the user whose friends of friends you want to list.
 // @param limit(type=number, optional=true, default=10) The number of friends to retrieve in this page of results. No more than 100 limit allowed per result.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return friends(nkruntime.FriendsOfFriendsList) The user information for users that are friends of friends of the current user.
@@ -7731,6 +7734,7 @@ func (n *RuntimeJavascriptNakamaModule) friendsOfFriendsList(r *goja.Runtime) fu
 // @param username(type=string) The name of the user to whom you want to add friends.
 // @param ids(type=[]string) Table array of IDs of the users you want to add as friends.
 // @param usernames(type=[]string) Table array of usernames of the users you want to add as friends.
+// @param metadata(type=object, optional=true) Custom information to store for this friend. Use nil if field is not being updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) friendsAdd(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -7822,7 +7826,7 @@ func (n *RuntimeJavascriptNakamaModule) friendsAdd(r *goja.Runtime) func(goja.Fu
 
 // @group friends
 // @summary Delete friends from a user.
-// @param userId(type=string) The ID of the user from whom you want to delete friends.
+// @param userID(type=string) The ID of the user from whom you want to delete friends.
 // @param username(type=string) The name of the user from whom you want to delete friends.
 // @param ids(type=[]string) Table array of IDs of the users you want to delete as friends.
 // @param usernames(type=[]string) Table array of usernames of the users you want to delete as friends.
@@ -7901,7 +7905,7 @@ func (n *RuntimeJavascriptNakamaModule) friendsDelete(r *goja.Runtime) func(goja
 
 // @group friends
 // @summary Block friends for a user.
-// @param userId(type=string) The ID of the user for whom you want to block friends.
+// @param userID(type=string) The ID of the user for whom you want to block friends.
 // @param username(type=string) The name of the user for whom you want to block friends.
 // @param ids(type=[]string) Table array of IDs of the users you want to block as friends.
 // @param usernames(type=[]string) Table array of usernames of the users you want to block as friends.
@@ -7981,8 +7985,8 @@ func (n *RuntimeJavascriptNakamaModule) friendsBlock(r *goja.Runtime) func(goja.
 
 // @group friends
 // @summary Update friend metadata.
-// @param userId(type=string) The ID of the user.
-// @param userIdFriend(type=string) The ID of the friend of the user.
+// @param userID(type=string) The ID of the user.
+// @param friendUserId(type=string) The ID of the friend of the user.
 // @param metadata(type=object, optional=true) The custom metadata to set for the friend.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) friendMetadataUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -8012,8 +8016,8 @@ func (n *RuntimeJavascriptNakamaModule) friendMetadataUpdate(r *goja.Runtime) fu
 
 // @group groups
 // @summary Join a group for a particular user.
-// @param groupId(type=string) The ID of the group to join.
-// @param userId(type=string) The user ID to add to this group.
+// @param groupID(type=string) The ID of the group to join.
+// @param userID(type=string) The user ID to add to this group.
 // @param username(type=string) The username of the user to add to this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUserJoin(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -8051,8 +8055,8 @@ func (n *RuntimeJavascriptNakamaModule) groupUserJoin(r *goja.Runtime) func(goja
 
 // @group groups
 // @summary Leave a group for a particular user.
-// @param groupId(type=string) The ID of the group to leave.
-// @param userId(type=string) The user ID to remove from this group.
+// @param groupID(type=string) The ID of the group to leave.
+// @param userID(type=string) The user ID to remove from this group.
 // @param username(type=string) The username of the user to remove from this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUserLeave(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -8090,9 +8094,9 @@ func (n *RuntimeJavascriptNakamaModule) groupUserLeave(r *goja.Runtime) func(goj
 
 // @group groups
 // @summary Add users to a group.
-// @param groupId(type=string) The ID of the group to add users to.
-// @param userIds(type=string[]) Table array of user IDs to add to this group.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group to add users to.
+// @param userIDs(type=string[]) Table array of user IDs to add to this group.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersAdd(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -8149,9 +8153,9 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersAdd(r *goja.Runtime) func(goja
 
 // @group groups
 // @summary Ban users from a group.
-// @param groupId(string) The ID of the group to ban users from.
-// @param userIds(string[]) Table array of user IDs to ban from this group.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(string) The ID of the group to ban users from.
+// @param userIDs(string[]) Table array of user IDs to ban from this group.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersBan(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -8208,9 +8212,9 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersBan(r *goja.Runtime) func(goja
 
 // @group groups
 // @summary Promote users in a group.
-// @param groupId(type=string) The ID of the group whose members are being promoted.
-// @param userIds(type=string[]) Table array of user IDs to promote.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group whose members are being promoted.
+// @param userIDs(type=string[]) Table array of user IDs to promote.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersPromote(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -8267,9 +8271,9 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersPromote(r *goja.Runtime) func(
 
 // @group groups
 // @summary Demote users in a group.
-// @param groupId(type=string) The ID of the group whose members are being demoted.
-// @param userIds(type=string[]) Table array of user IDs to demote.
-// @param callerId(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group whose members are being demoted.
+// @param userIDs(type=string[]) Table array of user IDs to demote.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersDemote(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -8895,8 +8899,8 @@ func (n *RuntimeJavascriptNakamaModule) getSatori(r *goja.Object) func(goja.Func
 // @param id(type=string) The identifier of the identity.
 // @param properties(type=nkruntime.AuthPropertiesUpdate, optional=true, default=null) Opt. Properties to update.
 // @param noSession(type=bool, optional=true, default=true) Whether authenticate should skip session tracking.
-// @param ip(type=string, optional=true, default="") An optional client IP address to pass on to Satori for geo-IP lookup.
-// @return properties(nkruntime.Properties)
+// @param ipAddress(type=string, optional=true, default="") An optional client IP address to pass on to Satori for geo-IP lookup.
+// @return properties(nkruntime.Properties) Returned properties.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) satoriAuthenticate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -360,8 +360,8 @@ func (n *RuntimeJavascriptNakamaModule) stringToBinary(r *goja.Runtime) func(goj
 // @param indexName(type=string) Name of the index to list entries from.
 // @param query(type=string) Query to filter index entries.
 // @param limit(type=int) Maximum number of results to be returned.
-// @param orderIn(type=[]string, optional=true) The storage object fields to sort the query results by. The prefix '-' before a field name indicates descending order. All specified fields must be indexed and sortable.
-// @param callerIDString(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param order(type=[]string, optional=true) The storage object fields to sort the query results by. The prefix '-' before a field name indicates descending order. All specified fields must be indexed and sortable.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @param cursor(type=string, optional=true) A cursor to fetch the next page of results.
 // @return objects(nkruntime.StorageIndexResult) A list of storage objects.
 // @return error(error) An optional error value if an error occurred.
@@ -378,23 +378,23 @@ func (n *RuntimeJavascriptNakamaModule) storageIndexList(r *goja.Runtime) func(g
 		}
 
 		var err error
-		order := make([]string, 0)
-		orderIn := f.Argument(3)
-		if !goja.IsUndefined(orderIn) && !goja.IsNull(orderIn) {
-			order, err = exportToSlice[[]string](orderIn)
+		orderArray := make([]string, 0)
+		order := f.Argument(3)
+		if !goja.IsUndefined(order) && !goja.IsNull(order) {
+			orderArray, err = exportToSlice[[]string](order)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
 		}
 
-		callerID := uuid.Nil
+		callerIDValue := uuid.Nil
 		if !goja.IsUndefined(f.Argument(4)) && !goja.IsNull(f.Argument(4)) {
-			callerIDString := getJsString(r, f.Argument(4))
-			cid, err := uuid.FromString(callerIDString)
+			callerID := getJsString(r, f.Argument(4))
+			cid, err := uuid.FromString(callerID)
 			if err != nil {
 				panic(r.NewTypeError("expects caller id to be valid identifier"))
 			}
-			callerID = cid
+			callerIDValue = cid
 		}
 
 		var cursor string
@@ -402,7 +402,7 @@ func (n *RuntimeJavascriptNakamaModule) storageIndexList(r *goja.Runtime) func(g
 			cursor = getJsString(r, f.Argument(5))
 		}
 
-		objectList, newCursor, err := n.storageIndex.List(n.ctx, callerID, indexName, query, int(limit), order, cursor)
+		objectList, newCursor, err := n.storageIndex.List(n.ctx, callerIDValue, indexName, query, int(limit), orderArray, cursor)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to lookup storage index: %s", err.Error())))
 		}
@@ -450,7 +450,7 @@ func (n *RuntimeJavascriptNakamaModule) storageIndexList(r *goja.Runtime) func(g
 // @summary Generate an event.
 // @param eventName(type=string) The name of the event to be created.
 // @param properties(type=[]string) An array of event properties.
-// @param Seconds(type=int, optional=true) Timestamp in seconds for when event is created.
+// @param epoch(type=int, optional=true) Timestamp in seconds for when event is created.
 // @param external(type=bool, optional=true, default=false) Whether the event is external.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) event(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -459,7 +459,8 @@ func (n *RuntimeJavascriptNakamaModule) event(r *goja.Runtime) func(goja.Functio
 		properties := getJsStringMap(r, f.Argument(1))
 		ts := &timestamppb.Timestamp{}
 		if f.Argument(2) != goja.Undefined() && f.Argument(2) != goja.Null() {
-			ts.Seconds = getJsInt(r, f.Argument(2))
+			epoch := getJsInt(r, f.Argument(2))
+			ts.Seconds = epoch
 		} else {
 			ts.Seconds = time.Now().Unix()
 		}
@@ -977,21 +978,21 @@ func (n *RuntimeJavascriptNakamaModule) base16Decode(r *goja.Runtime) func(goja.
 
 // @group utils
 // @summary Generate a JSON Web Token.
-// @param signingMethodString(type=string) The signing method to be used, either HS256 or RS256.
+// @param signingMethod(type=string) The signing method to be used, either HS256 or RS256.
 // @param signingKey(type=string) The signing key to be used.
 // @param claims(type=[]string) The JWT payload.
 // @return signedToken(string) The newly generated JWT.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) jwtGenerate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		signingMethodString := getJsString(r, f.Argument(0))
+		signingMethod := getJsString(r, f.Argument(0))
 
-		var signingMethod jwt.SigningMethod
-		switch signingMethodString {
+		var signingMethodValue jwt.SigningMethod
+		switch signingMethod {
 		case "HS256":
-			signingMethod = jwt.SigningMethodHS256
+			signingMethodValue = jwt.SigningMethodHS256
 		case "RS256":
-			signingMethod = jwt.SigningMethodRS256
+			signingMethodValue = jwt.SigningMethodRS256
 		default:
 			panic(r.NewTypeError("unsupported algo type - only allowed 'HS256', 'RS256'."))
 		}
@@ -1015,7 +1016,7 @@ func (n *RuntimeJavascriptNakamaModule) jwtGenerate(r *goja.Runtime) func(goja.F
 		}
 
 		var pk interface{}
-		switch signingMethod {
+		switch signingMethodValue {
 		case jwt.SigningMethodRS256:
 			block, _ := pem.Decode([]byte(signingKey))
 			if block == nil {
@@ -1031,7 +1032,7 @@ func (n *RuntimeJavascriptNakamaModule) jwtGenerate(r *goja.Runtime) func(goja.F
 			pk = []byte(signingKey)
 		}
 
-		token := jwt.NewWithClaims(signingMethod, jwtClaims)
+		token := jwt.NewWithClaims(signingMethodValue, jwtClaims)
 		signedToken, err := token.SignedString(pk)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to sign token: %v", err.Error())))
@@ -1891,21 +1892,21 @@ func (n *RuntimeJavascriptNakamaModule) authenticateTokenGenerate(r *goja.Runtim
 
 // @group accounts
 // @summary Fetch account information by user ID.
-// @param userIDIn(type=string) User ID to fetch information for. Must be valid UUID.
+// @param userID(type=string) User ID to fetch information for. Must be valid UUID.
 // @return account(nkruntime.Account) All account information including wallet, device IDs and more.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) accountGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDIn := getJsString(r, f.Argument(0))
-		if userIDIn == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.NewTypeError("expects user id"))
 		}
-		userID, err := uuid.FromString(userIDIn)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		account, err := GetAccount(n.ctx, n.logger, n.db, n.statusRegistry, userID)
+		account, err := GetAccount(n.ctx, n.logger, n.db, n.statusRegistry, uid)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error getting account: %v", err.Error())))
 		}
@@ -1921,27 +1922,27 @@ func (n *RuntimeJavascriptNakamaModule) accountGetId(r *goja.Runtime) func(goja.
 
 // @group accounts
 // @summary Fetch information for multiple accounts by user IDs.
-// @param userIDsIn(type=[]string) Array of user IDs to fetch information for. Must be valid UUID.
+// @param userIDs(type=[]string) Array of user IDs to fetch information for. Must be valid UUID.
 // @return account(nkruntime.Account[]) Array of accounts.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) accountsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDsIn := f.Argument(0)
-		if userIDsIn == goja.Undefined() || userIDsIn == goja.Null() {
+		userIDs := f.Argument(0)
+		if userIDs == goja.Undefined() || userIDs == goja.Null() {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
 
-		userIDs, err := exportToSlice[[]string](userIDsIn)
+		uids, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
-		for _, uid := range userIDs {
+		for _, uid := range uids {
 			if _, err := uuid.FromString(uid); err != nil {
 				panic(r.NewTypeError(fmt.Sprintf("invalid user id: %s", uid)))
 			}
 		}
 
-		accounts, err := GetAccounts(n.ctx, n.logger, n.db, n.statusRegistry, userIDs)
+		accounts, err := GetAccounts(n.ctx, n.logger, n.db, n.statusRegistry, uids)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get accounts: %s", err.Error())))
 		}
@@ -2090,42 +2091,42 @@ func (n *RuntimeJavascriptNakamaModule) accountExportId(r *goja.Runtime) func(go
 
 // @group users
 // @summary Fetch one or more users by ID.
-// @param userIDsIn(type=[]string) An array of user IDs to fetch.
-// @param facebookIDsIn(type=[]string) An array of Facebook IDs to fetch.
+// @param userIDs(type=[]string) An array of user IDs to fetch.
+// @param facebookIDs(type=[]string) An array of Facebook IDs to fetch.
 // @return users(nkruntime.User[]) A list of user record objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) usersGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		var userIDs []string
-		userIDsIn := f.Argument(0)
-		if userIDsIn != goja.Undefined() && userIDsIn != goja.Null() {
+		var uids []string
+		userIDs := f.Argument(0)
+		if userIDs != goja.Undefined() && userIDs != goja.Null() {
 			var err error
-			userIDs, err = exportToSlice[[]string](userIDsIn)
+			uids, err = exportToSlice[[]string](userIDs)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
-			for _, userID := range userIDs {
+			for _, userID := range uids {
 				if _, err = uuid.FromString(userID); err != nil {
 					panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userID)))
 				}
 			}
 		}
 
-		var facebookIDs []string
-		facebookIDsIn := f.Argument(1)
-		if facebookIDsIn != goja.Undefined() && facebookIDsIn != goja.Null() {
+		var fids []string
+		facebookIDs := f.Argument(1)
+		if facebookIDs != goja.Undefined() && facebookIDs != goja.Null() {
 			var err error
-			facebookIDs, err = exportToSlice[[]string](facebookIDsIn)
+			fids, err = exportToSlice[[]string](facebookIDs)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
 		}
 
-		if userIDs == nil && facebookIDs == nil {
+		if userIDs == nil && fids == nil {
 			return r.ToValue(make([]string, 0))
 		}
 
-		users, err := GetUsers(n.ctx, n.logger, n.db, n.statusRegistry, userIDs, nil, facebookIDs)
+		users, err := GetUsers(n.ctx, n.logger, n.db, n.statusRegistry, uids, nil, fids)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get users: %s", err.Error())))
 		}
@@ -2145,22 +2146,22 @@ func (n *RuntimeJavascriptNakamaModule) usersGetId(r *goja.Runtime) func(goja.Fu
 
 // @group users
 // @summary Fetch one or more users by username.
-// @param usernamesIn(type=[]string) An array of usernames to fetch.
+// @param usernames(type=[]string) An array of usernames to fetch.
 // @return users(nkruntime.User[]) A list of user record objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) usersGetUsername(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		usernamesIn := f.Argument(0)
-		if usernamesIn == goja.Undefined() || usernamesIn == goja.Null() {
+		usernames := f.Argument(0)
+		if usernames == goja.Undefined() || usernames == goja.Null() {
 			panic(r.NewTypeError("expects an array of usernames"))
 		}
 
-		usernames, err := exportToSlice[[]string](usernamesIn)
+		usernamesArray, err := exportToSlice[[]string](usernames)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
 
-		users, err := GetUsers(n.ctx, n.logger, n.db, n.statusRegistry, nil, usernames, nil)
+		users, err := GetUsers(n.ctx, n.logger, n.db, n.statusRegistry, nil, usernamesArray, nil)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get users: %s", err.Error())))
 		}
@@ -2272,22 +2273,22 @@ func (n *RuntimeJavascriptNakamaModule) usersGetRandom(r *goja.Runtime) func(goj
 
 // @group users
 // @summary Ban one or more users by ID.
-// @param userIDsIn(type=string[]) An array of user IDs to ban.
+// @param userIDs(type=string[]) An array of user IDs to ban.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) usersBanId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDsIn := f.Argument(0)
-		if userIDsIn == goja.Undefined() || userIDsIn == goja.Null() {
+		userIDs := f.Argument(0)
+		if userIDs == goja.Undefined() || userIDs == goja.Null() {
 			panic(r.NewTypeError("expects array of user ids"))
 		}
 
-		userIDs, err := exportToSlice[[]string](userIDsIn)
+		userIDsArray, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
 
-		uids := make([]uuid.UUID, 0, len(userIDs))
-		for _, id := range userIDs {
+		uids := make([]uuid.UUID, 0, len(userIDsArray))
+		for _, id := range userIDsArray {
 			uid, err := uuid.FromString(id)
 			if err != nil {
 				panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", id)))
@@ -2305,22 +2306,22 @@ func (n *RuntimeJavascriptNakamaModule) usersBanId(r *goja.Runtime) func(goja.Fu
 
 // @group users
 // @summary Unban one or more users by ID.
-// @param userIDsIn(type=string[]) An array of user IDs to unban.
+// @param userIDs(type=string[]) An array of user IDs to unban.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) usersUnbanId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDsIn := f.Argument(0)
-		if userIDsIn == goja.Undefined() || userIDsIn == goja.Null() {
+		userIDs := f.Argument(0)
+		if userIDs == goja.Undefined() || userIDs == goja.Null() {
 			panic(r.NewTypeError("expects array of user ids"))
 		}
 
-		userIDs, err := exportToSlice[[]string](userIDsIn)
+		userIDsArray, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
 
-		uids := make([]uuid.UUID, 0, len(userIDs))
-		for _, id := range userIDs {
+		uids := make([]uuid.UUID, 0, len(userIDsArray))
+		for _, id := range userIDsArray {
 			uid, err := uuid.FromString(id)
 			if err != nil {
 				panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", id)))
@@ -2928,42 +2929,42 @@ func (n *RuntimeJavascriptNakamaModule) streamUserList(r *goja.Runtime) func(goj
 
 // @group streams
 // @summary Retrieve a stream presence and metadata by user ID.
-// @param userIDString(type=string) The user ID to fetch information for.
-// @param sessionIDString(type=string) The current session ID for the user.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param userID(type=string) The user ID to fetch information for.
+// @param sessionID(type=string) The current session ID for the user.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @return meta(nkruntime.Presence) Presence for the user.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamUserGet(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.ToValue(r.NewTypeError("expects user id")))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		sessionIDString := getJsString(r, f.Argument(1))
-		if sessionIDString == "" {
+		sessionID := getJsString(r, f.Argument(1))
+		if sessionID == "" {
 			panic(r.NewTypeError("expects session id"))
 		}
-		sessionID, err := uuid.FromString(sessionIDString)
+		sid, err := uuid.FromString(sessionID)
 		if err != nil {
 			panic(r.NewTypeError("invalid session id"))
 		}
 
-		streamIn := f.Argument(2)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(2)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
-		meta := n.tracker.GetLocalBySessionIDStreamUserID(sessionID, stream, userID)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
+		meta := n.tracker.GetLocalBySessionIDStreamUserID(sid, streamValue, uid)
 		if meta == nil {
 			return goja.Null()
 		}
@@ -2980,9 +2981,9 @@ func (n *RuntimeJavascriptNakamaModule) streamUserGet(r *goja.Runtime) func(goja
 
 // @group streams
 // @summary Add a user to a stream.
-// @param userIDString(type=string) The user ID to be added.
-// @param sessionIDString(type=string) The current session ID for the user.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param userID(type=string) The user ID to be added.
+// @param sessionID(type=string) The current session ID for the user.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @param hidden(type=bool) Whether the user will be marked as hidden.
 // @param persistence(type=bool) Whether message data should be stored in the database.
 // @param status(type=string) User status message.
@@ -2990,29 +2991,29 @@ func (n *RuntimeJavascriptNakamaModule) streamUserGet(r *goja.Runtime) func(goja
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamUserJoin(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.ToValue(r.NewTypeError("expects user id")))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		sessionIDString := getJsString(r, f.Argument(1))
-		if sessionIDString == "" {
+		sessionID := getJsString(r, f.Argument(1))
+		if sessionID == "" {
 			panic(r.NewTypeError("expects session id"))
 		}
-		sessionID, err := uuid.FromString(sessionIDString)
+		sid, err := uuid.FromString(sessionID)
 		if err != nil {
 			panic(r.NewTypeError("invalid session id"))
 		}
 
-		streamIn := f.Argument(2)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(2)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
@@ -3022,20 +3023,20 @@ func (n *RuntimeJavascriptNakamaModule) streamUserJoin(r *goja.Runtime) func(goj
 		if f.Argument(3) != goja.Undefined() {
 			hidden = getJsBool(r, f.Argument(3))
 		}
-		// By default persistence is enabled, if the stream supports it.
+		// By default, persistence is enabled, if the stream supports it.
 		persistence := true
 		if f.Argument(4) != goja.Undefined() {
 			persistence = getJsBool(r, f.Argument(4))
 		}
-		// By default no status is set.
+		// By default, no status is set.
 		status := ""
 		if f.Argument(5) != goja.Undefined() {
 			status = getJsString(r, f.Argument(5))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
-		success, newlyTracked, err := n.streamManager.UserJoin(stream, userID, sessionID, hidden, persistence, status)
+		success, newlyTracked, err := n.streamManager.UserJoin(streamValue, uid, sid, hidden, persistence, status)
 		if err != nil {
 			if err == ErrSessionNotFound {
 				panic(r.NewGoError(errors.New("session id does not exist")))
@@ -3052,38 +3053,38 @@ func (n *RuntimeJavascriptNakamaModule) streamUserJoin(r *goja.Runtime) func(goj
 
 // @group streams
 // @summary Update a stream user by ID.
-// @param userIDString(type=string) The user ID to be updated.
-// @param sessionIDString(type=string) The current session ID for the user.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param userID(type=string) The user ID to be updated.
+// @param sessionID(type=string) The current session ID for the user.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @param hidden(type=bool) Whether the user will be marked as hidden.
 // @param persistence(type=bool) Whether message data should be stored in the database.
 // @param status(type=string) User status message.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamUserUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.ToValue(r.NewTypeError("expects user id")))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		sessionIDString := getJsString(r, f.Argument(1))
-		if sessionIDString == "" {
+		sessionID := getJsString(r, f.Argument(1))
+		if sessionID == "" {
 			panic(r.NewTypeError("expects session id"))
 		}
-		sessionID, err := uuid.FromString(sessionIDString)
+		sid, err := uuid.FromString(sessionID)
 		if err != nil {
 			panic(r.NewTypeError("invalid session id"))
 		}
 
-		streamIn := f.Argument(2)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(2)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
@@ -3093,20 +3094,20 @@ func (n *RuntimeJavascriptNakamaModule) streamUserUpdate(r *goja.Runtime) func(g
 		if f.Argument(3) != goja.Undefined() {
 			hidden = getJsBool(r, f.Argument(3))
 		}
-		// By default persistence is enabled, if the stream supports it.
+		// By default, persistence is enabled, if the stream supports it.
 		persistence := true
 		if f.Argument(4) != goja.Undefined() {
 			persistence = getJsBool(r, f.Argument(4))
 		}
-		// By default no status is set.
+		// By default, no status is set.
 		status := ""
 		if f.Argument(5) != goja.Undefined() {
 			status = getJsString(r, f.Argument(5))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
-		success, err := n.streamManager.UserUpdate(stream, userID, sessionID, hidden, persistence, status)
+		success, err := n.streamManager.UserUpdate(streamValue, uid, sid, hidden, persistence, status)
 		if err != nil {
 			if err == ErrSessionNotFound {
 				panic(r.NewGoError(errors.New("session id does not exist")))
@@ -3123,42 +3124,42 @@ func (n *RuntimeJavascriptNakamaModule) streamUserUpdate(r *goja.Runtime) func(g
 
 // @group streams
 // @summary Remove a user from a stream.
-// @param userIDString(type=string) The user ID to be removed.
-// @param sessionIDString(type=string) The current session ID for the user.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param userID(type=string) The user ID to be removed.
+// @param sessionID(type=string) The current session ID for the user.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamUserLeave(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.ToValue(r.NewTypeError("expects user id")))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("invalid user id"))
 		}
 
-		sessionIDString := getJsString(r, f.Argument(1))
-		if sessionIDString == "" {
+		sessionID := getJsString(r, f.Argument(1))
+		if sessionID == "" {
 			panic(r.NewTypeError("expects session id"))
 		}
-		sessionID, err := uuid.FromString(sessionIDString)
+		sid, err := uuid.FromString(sessionID)
 		if err != nil {
 			panic(r.NewTypeError("invalid session id"))
 		}
 
-		streamIn := f.Argument(2)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(2)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
-		if err := n.streamManager.UserLeave(stream, userID, sessionID); err != nil {
+		if err := n.streamManager.UserLeave(streamValue, uid, sid); err != nil {
 			panic(r.NewGoError(fmt.Errorf("stream user leave failed: %v", err.Error())))
 		}
 
@@ -3168,16 +3169,16 @@ func (n *RuntimeJavascriptNakamaModule) streamUserLeave(r *goja.Runtime) func(go
 
 // @group streams
 // @summary Kick a user from a stream.
-// @param presenceIn(type=nkruntime.Presence) The presence to be kicked.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param presence(type=nkruntime.Presence) The presence to be kicked.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamUserKick(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		presenceIn := f.Argument(0)
-		if presenceIn == goja.Undefined() {
+		presence := f.Argument(0)
+		if presence == goja.Undefined() {
 			panic(r.NewTypeError("expects presence object"))
 		}
-		presence, ok := presenceIn.Export().(map[string]interface{})
+		presenceMap, ok := presence.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a presence object"))
 		}
@@ -3186,7 +3187,7 @@ func (n *RuntimeJavascriptNakamaModule) streamUserKick(r *goja.Runtime) func(goj
 		sessionID := uuid.Nil
 		node := n.node
 
-		userIDRaw, ok := presence["userId"]
+		userIDRaw, ok := presenceMap["userId"]
 		if ok {
 			userIDString, ok := userIDRaw.(string)
 			if !ok {
@@ -3199,7 +3200,7 @@ func (n *RuntimeJavascriptNakamaModule) streamUserKick(r *goja.Runtime) func(goj
 			userID = id
 		}
 
-		sessionIdRaw, ok := presence["sessionId"]
+		sessionIdRaw, ok := presenceMap["sessionId"]
 		if ok {
 			sessionIDString, ok := sessionIdRaw.(string)
 			if !ok {
@@ -3212,7 +3213,7 @@ func (n *RuntimeJavascriptNakamaModule) streamUserKick(r *goja.Runtime) func(goj
 			sessionID = id
 		}
 
-		nodeRaw, ok := presence["node"]
+		nodeRaw, ok := presenceMap["node"]
 		if ok {
 			nodeString, ok := nodeRaw.(string)
 			if !ok {
@@ -3225,18 +3226,18 @@ func (n *RuntimeJavascriptNakamaModule) streamUserKick(r *goja.Runtime) func(goj
 			panic(r.NewTypeError("expects each presence to have a valid userId, sessionId, and node"))
 		}
 
-		streamIn := f.Argument(1)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(1)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
-		if err := n.streamManager.UserLeave(stream, userID, sessionID); err != nil {
+		if err := n.streamManager.UserLeave(streamValue, userID, sessionID); err != nil {
 			panic(r.NewGoError(fmt.Errorf("stream user kick failed: %v", err.Error())))
 		}
 
@@ -3246,23 +3247,23 @@ func (n *RuntimeJavascriptNakamaModule) streamUserKick(r *goja.Runtime) func(goj
 
 // @group streams
 // @summary Get a count of stream presences.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @return countByStream(number) Number of current stream presences.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamCount(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		streamIn := f.Argument(0)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(0)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
-		count := n.tracker.CountByStream(stream)
+		count := n.tracker.CountByStream(streamValue)
 
 		return r.ToValue(count)
 	}
@@ -3270,22 +3271,22 @@ func (n *RuntimeJavascriptNakamaModule) streamCount(r *goja.Runtime) func(goja.F
 
 // @group streams
 // @summary Close a stream and remove all presences on it.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamClose(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		streamIn := f.Argument(0)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(0)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
-		n.tracker.UntrackByStream(stream)
+		n.tracker.UntrackByStream(streamValue)
 
 		return goja.Undefined()
 	}
@@ -3293,40 +3294,40 @@ func (n *RuntimeJavascriptNakamaModule) streamClose(r *goja.Runtime) func(goja.F
 
 // @group streams
 // @summary Send data to presences on a stream.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @param data(type=string) The data to send.
-// @param presencesIn(type=nkruntime.Presence[], optional=true, default=all) Array of presences to receive the sent data.
+// @param presences(type=nkruntime.Presence[], optional=true, default=all) Array of presences to receive the sent data.
 // @param reliable(type=bool, optional=true, default=true) Whether the sender has been validated prior.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamSend(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		streamIn := f.Argument(0)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(0)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
 		data := getJsString(r, f.Argument(1))
 
-		presencesIn := f.Argument(2)
-		var presences []map[string]any
-		if presencesIn == goja.Undefined() || presencesIn == goja.Null() {
-			presences = make([]map[string]any, 0)
+		presences := f.Argument(2)
+		var presencesArray []map[string]any
+		if presences == goja.Undefined() || presences == goja.Null() {
+			presencesArray = make([]map[string]any, 0)
 		} else {
 			var err error
-			presences, err = exportToSlice[[]map[string]any](presencesIn)
+			presencesArray, err = exportToSlice[[]map[string]any](presences)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of presence objects"))
 			}
 		}
 
-		presenceIDs := make([]*PresenceID, 0, len(presences))
-		for _, presence := range presences {
+		presenceIDs := make([]*PresenceID, 0, len(presencesArray))
+		for _, presence := range presencesArray {
 			presenceID := &PresenceID{}
 			sessionIdRaw, ok := presence["sessionId"]
 			if ok {
@@ -3359,14 +3360,14 @@ func (n *RuntimeJavascriptNakamaModule) streamSend(r *goja.Runtime) func(goja.Fu
 		}
 
 		streamWire := &rtapi.Stream{
-			Mode:  int32(stream.Mode),
-			Label: stream.Label,
+			Mode:  int32(streamValue.Mode),
+			Label: streamValue.Label,
 		}
-		if stream.Subject != uuid.Nil {
-			streamWire.Subject = stream.Subject.String()
+		if streamValue.Subject != uuid.Nil {
+			streamWire.Subject = streamValue.Subject.String()
 		}
-		if stream.Subcontext != uuid.Nil {
-			streamWire.Subcontext = stream.Subcontext.String()
+		if streamValue.Subcontext != uuid.Nil {
+			streamWire.Subcontext = streamValue.Subcontext.String()
 		}
 		msg := &rtapi.Envelope{Message: &rtapi.Envelope_StreamData{StreamData: &rtapi.StreamData{
 			Stream: streamWire,
@@ -3377,7 +3378,7 @@ func (n *RuntimeJavascriptNakamaModule) streamSend(r *goja.Runtime) func(goja.Fu
 
 		if len(presenceIDs) == 0 {
 			// Sending to whole stream.
-			n.router.SendToStream(n.logger, stream, msg, reliable)
+			n.router.SendToStream(n.logger, streamValue, msg, reliable)
 		} else {
 			// Sending to a subset of stream users.
 			n.router.SendToPresenceIDs(n.logger, presenceIDs, msg, reliable)
@@ -3389,23 +3390,23 @@ func (n *RuntimeJavascriptNakamaModule) streamSend(r *goja.Runtime) func(goja.Fu
 
 // @group streams
 // @summary Send a message to presences on a stream.
-// @param streamIn(type=nkruntime.Stream) A stream object.
+// @param stream(type=nkruntime.Stream) A stream object.
 // @param envelopeMap(type=&rtapi.Envelope{}) The message to send.
-// @param presencesIn(type=nkruntime.Presence[], optional=true, default=all) Array of presences to receive the sent data.
+// @param presences(type=nkruntime.Presence[], optional=true, default=all) Array of presences to receive the sent data.
 // @param reliable(type=bool, optional=true, default=true) Whether the sender has been validated prior.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) streamSendRaw(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		streamIn := f.Argument(0)
-		if streamIn == goja.Undefined() {
+		stream := f.Argument(0)
+		if stream == goja.Undefined() {
 			panic(r.NewTypeError("expects stream object"))
 		}
-		streamObj, ok := streamIn.Export().(map[string]interface{})
+		streamObj, ok := stream.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a stream object"))
 		}
 
-		stream := jsObjectToPresenceStream(r, streamObj)
+		streamValue := jsObjectToPresenceStream(r, streamObj)
 
 		envelopeMap, ok := f.Argument(1).Export().(map[string]interface{})
 		if !ok {
@@ -3421,19 +3422,19 @@ func (n *RuntimeJavascriptNakamaModule) streamSendRaw(r *goja.Runtime) func(goja
 			panic(r.NewGoError(fmt.Errorf("not a valid envelope: %s", err.Error())))
 		}
 
-		presencesIn := f.Argument(2)
-		var presences []map[string]any
-		if presencesIn == goja.Undefined() || presencesIn == goja.Null() {
-			presences = make([]map[string]any, 0)
+		presences := f.Argument(2)
+		var presencesArray []map[string]any
+		if presences == goja.Undefined() || presences == goja.Null() {
+			presencesArray = make([]map[string]any, 0)
 		} else {
-			presences, err = exportToSlice[[]map[string]any](presencesIn)
+			presencesArray, err = exportToSlice[[]map[string]any](presences)
 			if err != nil {
 				panic(r.NewTypeError("expects a presences array"))
 			}
 		}
 
-		presenceIDs := make([]*PresenceID, 0, len(presences))
-		for _, presence := range presences {
+		presenceIDs := make([]*PresenceID, 0, len(presencesArray))
+		for _, presence := range presencesArray {
 			presenceID := &PresenceID{}
 			sessionIdRaw, ok := presence["sessionId"]
 			if ok {
@@ -3467,7 +3468,7 @@ func (n *RuntimeJavascriptNakamaModule) streamSendRaw(r *goja.Runtime) func(goja
 
 		if len(presenceIDs) == 0 {
 			// Sending to whole stream.
-			n.router.SendToStream(n.logger, stream, msg, reliable)
+			n.router.SendToStream(n.logger, streamValue, msg, reliable)
 		} else {
 			// Sending to a subset of stream users.
 			n.router.SendToPresenceIDs(n.logger, presenceIDs, msg, reliable)
@@ -3479,30 +3480,30 @@ func (n *RuntimeJavascriptNakamaModule) streamSendRaw(r *goja.Runtime) func(goja
 
 // @group sessions
 // @summary Disconnect a session.
-// @param sessionIDString(type=string) The ID of the session to be disconnected.
-// @param reasonInt(type=nkruntime.PresenceReason) The reason for the session disconnect.
+// @param sessionID(type=string) The ID of the session to be disconnected.
+// @param reason(type=nkruntime.PresenceReason) The reason for the session disconnect.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) sessionDisconnect(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		sessionIDString := getJsString(r, f.Argument(0))
-		if sessionIDString == "" {
+		sessionID := getJsString(r, f.Argument(0))
+		if sessionID == "" {
 			panic(r.NewTypeError("expects a session id"))
 		}
-		sessionID, err := uuid.FromString(sessionIDString)
+		sid, err := uuid.FromString(sessionID)
 		if err != nil {
 			panic(r.NewTypeError("expects a valid session id"))
 		}
 
-		reason := make([]runtime.PresenceReason, 0, 1)
+		reasonArray := make([]runtime.PresenceReason, 0, 1)
 		if f.Argument(1) != goja.Undefined() && f.Argument(1) != goja.Null() {
-			reasonInt := getJsInt(r, f.Argument(1))
-			if reasonInt < 0 || reasonInt > 4 {
+			reason := getJsInt(r, f.Argument(1))
+			if reason < 0 || reason > 4 {
 				panic(r.NewTypeError("invalid disconnect reason, must be a value 0-4"))
 			}
-			reason = append(reason, runtime.PresenceReason(reasonInt))
+			reasonArray = append(reasonArray, runtime.PresenceReason(reason))
 		}
 
-		if err := n.sessionRegistry.Disconnect(n.ctx, sessionID, false, reason...); err != nil {
+		if err := n.sessionRegistry.Disconnect(n.ctx, sid, false, reasonArray...); err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to disconnect: %s", err.Error())))
 		}
 
@@ -3512,17 +3513,17 @@ func (n *RuntimeJavascriptNakamaModule) sessionDisconnect(r *goja.Runtime) func(
 
 // @group sessions
 // @summary Log out a user from their current session.
-// @param userIDString(type=string) The ID of the user to be logged out.
+// @param userID(type=string) The ID of the user to be logged out.
 // @param token(type=string, optional=true) The current session authentication token. If the current auth and refresh tokens are not provided, all user sessions will be logged out.
 // @param refreshToken(type=string, optional=true) The current session refresh token. If the current auth and refresh tokens are not provided, all user sessions will be logged out.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) sessionLogout(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.NewTypeError("expects a user id"))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects a valid user id"))
 		}
@@ -3547,7 +3548,7 @@ func (n *RuntimeJavascriptNakamaModule) sessionLogout(r *goja.Runtime) func(goja
 			}
 		}
 
-		if err := SessionLogout(n.config, n.sessionCache, userID, tokenString, refreshTokenString); err != nil {
+		if err := SessionLogout(n.config, n.sessionCache, uid, tokenString, refreshTokenString); err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to logout: %s", err.Error())))
 		}
 
@@ -3715,17 +3716,17 @@ func (n *RuntimeJavascriptNakamaModule) matchSignal(r *goja.Runtime) func(goja.F
 
 // @group notifications
 // @summary Send one in-app notification to a user.
-// @param userIDString(type=string) The user ID of the user to be sent the notification.
+// @param userID(type=string) The user ID of the user to be sent the notification.
 // @param subject(type=string) Notification subject.
-// @param contentIn(type=object) Notification content. Must be set but can be empty object.
+// @param content(type=object) Notification content. Must be set but can be empty object.
 // @param code(type=number) Notification code to use. Must be equal or greater than 0.
-// @param senderIDIn(type=string, optional=true) The sender of this notification. If left empty, it will be assumed that it is a system notification.
+// @param senderID(type=string, optional=true) The sender of this notification. If left empty, it will be assumed that it is a system notification.
 // @param persistent(type=bool, optional=true, default=false) Whether to record this in the database for later listing.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationSend(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		userID, err := uuid.FromString(userIDString)
+		userID := getJsString(r, f.Argument(0))
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects valid user id"))
 		}
@@ -3735,11 +3736,11 @@ func (n *RuntimeJavascriptNakamaModule) notificationSend(r *goja.Runtime) func(g
 			panic(r.NewTypeError("expects subject to be a non empty string"))
 		}
 
-		contentIn := f.Argument(2)
-		if contentIn == goja.Undefined() {
+		content := f.Argument(2)
+		if content == goja.Undefined() {
 			panic(r.NewTypeError("expects content"))
 		}
-		contentMap, ok := contentIn.Export().(map[string]interface{})
+		contentMap, ok := content.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects content to be an object"))
 		}
@@ -3747,21 +3748,21 @@ func (n *RuntimeJavascriptNakamaModule) notificationSend(r *goja.Runtime) func(g
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to convert content: %s", err.Error())))
 		}
-		content := string(contentBytes)
+		contentValue := string(contentBytes)
 
 		code := getJsInt(r, f.Argument(3))
 		if code <= 0 {
 			panic(r.NewGoError(errors.New("expects code number to be a positive integer")))
 		}
 
-		senderIDIn := f.Argument(4)
-		senderID := uuid.Nil.String()
-		if senderIDIn != goja.Undefined() && senderIDIn != goja.Null() {
-			suid, err := uuid.FromString(getJsString(r, senderIDIn))
+		senderID := f.Argument(4)
+		sid := uuid.Nil.String()
+		if senderID != goja.Undefined() && senderID != goja.Null() {
+			suid, err := uuid.FromString(getJsString(r, senderID))
 			if err != nil {
 				panic(r.NewTypeError("expects senderId to either be not set, empty string or a valid UUID"))
 			}
-			senderID = suid.String()
+			sid = suid.String()
 		}
 
 		persistent := false
@@ -3772,14 +3773,14 @@ func (n *RuntimeJavascriptNakamaModule) notificationSend(r *goja.Runtime) func(g
 		nots := []*api.Notification{{
 			Id:         uuid.Must(uuid.NewV4()).String(),
 			Subject:    subject,
-			Content:    content,
+			Content:    contentValue,
 			Code:       int32(code),
-			SenderId:   senderID,
+			SenderId:   sid,
 			Persistent: persistent,
 			CreateTime: &timestamppb.Timestamp{Seconds: time.Now().UTC().Unix()},
 		}}
 		notifications := map[uuid.UUID][]*api.Notification{
-			userID: nots,
+			uid: nots,
 		}
 
 		if err := NotificationSend(n.ctx, n.logger, n.db, n.tracker, n.router, notifications); err != nil {
@@ -3792,18 +3793,18 @@ func (n *RuntimeJavascriptNakamaModule) notificationSend(r *goja.Runtime) func(g
 
 // @group notifications
 // @summary List notifications by user id.
-// @param userIDString(type=string) Optional userID to scope results to that user only.
+// @param userID(type=string) Optional userID to scope results to that user only.
 // @param limit(type=int, optiona=true, default=100) Limit number of results. Must be a value between 1 and 1000.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return notifications(nkruntime.NotificationList) A list of notifications.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationsList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.ToValue(r.NewTypeError("expects user id")))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("invalid user id"))
 		}
@@ -3821,7 +3822,7 @@ func (n *RuntimeJavascriptNakamaModule) notificationsList(r *goja.Runtime) func(
 			cursor = getJsString(r, f.Argument(2))
 		}
 
-		list, err := NotificationList(n.ctx, n.logger, n.db, userID, limit, cursor, false)
+		list, err := NotificationList(n.ctx, n.logger, n.db, uid, limit, cursor, false)
 		if err != nil {
 			panic(r.ToValue(r.NewGoError(fmt.Errorf("failed to list notifications: %s", err.Error()))))
 		}
@@ -3858,21 +3859,21 @@ func (n *RuntimeJavascriptNakamaModule) notificationsList(r *goja.Runtime) func(
 
 // @group notifications
 // @summary Send one or more in-app notifications to a user.
-// @param notificationsIn(type=any[]) A list of notifications to be sent together.
+// @param notifications(type=any[]) A list of notifications to be sent together.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationsSend(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		notificationsIn := f.Argument(0)
-		if notificationsIn == goja.Undefined() || notificationsIn == goja.Null() {
+		notifications := f.Argument(0)
+		if notifications == goja.Undefined() || notifications == goja.Null() {
 			panic(r.NewTypeError("expects a valid array of notifications"))
 		}
 
-		notificationsSlice, err := exportToSlice[[]map[string]any](notificationsIn)
+		notificationsSlice, err := exportToSlice[[]map[string]any](notifications)
 		if err != nil {
 			panic(r.NewTypeError("expects notifications to be an array"))
 		}
 
-		notifications := make(map[uuid.UUID][]*api.Notification)
+		notificationsMap := make(map[uuid.UUID][]*api.Notification)
 		for _, notificationObj := range notificationsSlice {
 			notification := &api.Notification{}
 			userID := uuid.Nil
@@ -3953,15 +3954,15 @@ func (n *RuntimeJavascriptNakamaModule) notificationsSend(r *goja.Runtime) func(
 			notification.CreateTime = &timestamppb.Timestamp{Seconds: time.Now().UTC().Unix()}
 			notification.SenderId = senderID.String()
 
-			no := notifications[userID]
+			no := notificationsMap[userID]
 			if no == nil {
 				no = make([]*api.Notification, 0, 1)
 			}
 			no = append(no, notification)
-			notifications[userID] = no
+			notificationsMap[userID] = no
 		}
 
-		if err := NotificationSend(n.ctx, n.logger, n.db, n.tracker, n.router, notifications); err != nil {
+		if err := NotificationSend(n.ctx, n.logger, n.db, n.tracker, n.router, notificationsMap); err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to send notifications: %s", err.Error())))
 		}
 
@@ -3972,7 +3973,7 @@ func (n *RuntimeJavascriptNakamaModule) notificationsSend(r *goja.Runtime) func(
 // @group notifications
 // @summary Send an in-app notification to all users.
 // @param subject(type=string) Notification subject.
-// @param contentIn(type=object) Notification content. Must be set but can be an empty object.
+// @param content(type=object) Notification content. Must be set but can be an empty object.
 // @param code(type=number) Notification code to use. Must be greater than or equal to 0.
 // @param persistent(type=bool, optional=true, default=false) Whether to record this in the database for later listing.
 // @return error(error) An optional error value if an error occurred.
@@ -3983,11 +3984,11 @@ func (n *RuntimeJavascriptNakamaModule) notificationSendAll(r *goja.Runtime) fun
 			panic(r.NewTypeError("expects subject to be a non empty string"))
 		}
 
-		contentIn := f.Argument(1)
-		if contentIn == goja.Undefined() {
+		content := f.Argument(1)
+		if content == goja.Undefined() {
 			panic(r.NewTypeError("expects content"))
 		}
-		contentMap, ok := contentIn.Export().(map[string]interface{})
+		contentMap, ok := content.Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects content to be an object"))
 		}
@@ -3995,7 +3996,7 @@ func (n *RuntimeJavascriptNakamaModule) notificationSendAll(r *goja.Runtime) fun
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to convert content: %s", err.Error())))
 		}
-		content := string(contentBytes)
+		contentValue := string(contentBytes)
 
 		code := getJsInt(r, f.Argument(2))
 		if code <= 0 {
@@ -4013,7 +4014,7 @@ func (n *RuntimeJavascriptNakamaModule) notificationSendAll(r *goja.Runtime) fun
 		not := &api.Notification{
 			Id:         uuid.Must(uuid.NewV4()).String(),
 			Subject:    subject,
-			Content:    content,
+			Content:    contentValue,
 			Code:       int32(code),
 			SenderId:   senderID,
 			Persistent: persistent,
@@ -4030,21 +4031,21 @@ func (n *RuntimeJavascriptNakamaModule) notificationSendAll(r *goja.Runtime) fun
 
 // @group notifications
 // @summary Delete one or more in-app notifications.
-// @param notificationsIn(type=any[]) A list of notifications to be deleted.
+// @param notifications(type=any[]) A list of notifications to be deleted.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationsDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		notificationsIn := f.Argument(0)
-		if notificationsIn == goja.Undefined() || notificationsIn == goja.Null() {
+		notifications := f.Argument(0)
+		if notifications == goja.Undefined() || notifications == goja.Null() {
 			panic(r.NewTypeError("expects a valid array of notifications"))
 		}
 
-		notificationsSlice, err := exportToSlice[[]map[string]any](notificationsIn)
+		notificationsSlice, err := exportToSlice[[]map[string]any](notifications)
 		if err != nil {
 			panic(r.NewTypeError("expects notifications to be an array"))
 		}
 
-		notifications := make(map[uuid.UUID][]string)
+		notificationsMap := make(map[uuid.UUID][]string)
 		for _, notificationObj := range notificationsSlice {
 			userID := uuid.Nil
 			notificationIDStr := ""
@@ -4072,15 +4073,15 @@ func (n *RuntimeJavascriptNakamaModule) notificationsDelete(r *goja.Runtime) fun
 				}
 			}
 
-			no := notifications[userID]
+			no := notificationsMap[userID]
 			if no == nil {
 				no = make([]string, 0, 1)
 			}
 			no = append(no, notificationIDStr)
-			notifications[userID] = no
+			notificationsMap[userID] = no
 		}
 
-		for uid, notificationIDs := range notifications {
+		for uid, notificationIDs := range notificationsMap {
 			if err := NotificationDelete(n.ctx, n.logger, n.db, uid, notificationIDs); err != nil {
 				panic(r.NewGoError(fmt.Errorf("failed to delete notifications: %s", err.Error())))
 			}
@@ -4092,13 +4093,13 @@ func (n *RuntimeJavascriptNakamaModule) notificationsDelete(r *goja.Runtime) fun
 
 // @group notifications
 // @summary Update notifications by their id.
-// @param updatesIn(type=nkruntime.NotificationUpdate[]) A list of notifications to be updated.
+// @param updates(type=nkruntime.NotificationUpdate[]) A list of notifications to be updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationsUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		updatesIn := f.Argument(0)
+		updates := f.Argument(0)
 
-		dataSlice, err := exportToSlice[[]map[string]any](updatesIn)
+		dataSlice, err := exportToSlice[[]map[string]any](updates)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of notification updates objects"))
 		}
@@ -4160,29 +4161,29 @@ func (n *RuntimeJavascriptNakamaModule) notificationsUpdate(r *goja.Runtime) fun
 
 // @group notifications
 // @summary Get notifications by their id.
-// @param notifIDsIn(type=string[]) A list of notification ids.
+// @param notifIDs(type=string[]) A list of notification ids.
 // @param userIDIn(type=string) Optional userID to scope results to that user only.
 // @return notifications(type=runtime.Notification[]) A list of notifications.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		notifIDsIn := f.Argument(0)
+		notifIDs := f.Argument(0)
 
-		if notifIDsIn == goja.Undefined() || notifIDsIn == goja.Null() {
+		if notifIDs == goja.Undefined() || notifIDs == goja.Null() {
 			panic(r.NewTypeError("expects an array of ids"))
 		}
 
-		notifIds, err := exportToSlice[[]string](notifIDsIn)
+		notifIDsArray, err := exportToSlice[[]string](notifIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
-		for _, userID := range notifIds {
+		for _, userID := range notifIDsArray {
 			if _, err = uuid.FromString(userID); err != nil {
 				panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userID)))
 			}
 		}
 
-		if notifIds == nil {
+		if notifIDsArray == nil {
 			return r.ToValue(make([]string, 0))
 		}
 
@@ -4192,7 +4193,7 @@ func (n *RuntimeJavascriptNakamaModule) notificationsGetId(r *goja.Runtime) func
 			userID = getJsString(r, userIDIn)
 		}
 
-		results, err := NotificationsGetId(n.ctx, n.logger, n.db, userID, notifIds...)
+		results, err := NotificationsGetId(n.ctx, n.logger, n.db, userID, notifIDsArray...)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get notifications by id: %s", err.Error())))
 		}
@@ -4220,38 +4221,38 @@ func (n *RuntimeJavascriptNakamaModule) notificationsGetId(r *goja.Runtime) func
 
 // @group notifications
 // @summary Delete notifications by their id.
-// @param notifIDsIn(type=string[]) A list of notification ids.
-// @param userIDIn(type=string) Optional userID to scope deletions to that user only.
+// @param notifIDs(type=string[]) A list of notification ids.
+// @param userID(type=string) Optional userID to scope deletions to that user only.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) notificationsDeleteId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		notifIDsIn := f.Argument(0)
+		notifIDs := f.Argument(0)
 
-		if notifIDsIn == goja.Undefined() || notifIDsIn == goja.Null() {
+		if notifIDs == goja.Undefined() || notifIDs == goja.Null() {
 			panic(r.NewTypeError("expects an array of ids"))
 		}
 
-		notifIDs, err := exportToSlice[[]string](notifIDsIn)
+		notifIDsArray, err := exportToSlice[[]string](notifIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
-		for _, userID := range notifIDs {
+		for _, userID := range notifIDsArray {
 			if _, err = uuid.FromString(userID); err != nil {
 				panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userID)))
 			}
 		}
 
-		if notifIDs == nil {
+		if notifIDsArray == nil {
 			return r.ToValue(make([]string, 0))
 		}
 
-		userIDIn := f.Argument(1)
-		userID := ""
-		if userIDIn != goja.Undefined() && userIDIn != goja.Null() {
-			userID = getJsString(r, userIDIn)
+		userID := f.Argument(1)
+		uid := ""
+		if userID != goja.Undefined() && userID != goja.Null() {
+			uid = getJsString(r, userID)
 		}
 
-		if err := NotificationsDeleteId(n.ctx, n.logger, n.db, userID, notifIDs...); err != nil {
+		if err := NotificationsDeleteId(n.ctx, n.logger, n.db, uid, notifIDsArray...); err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get notifications by id: %s", err.Error())))
 		}
 
@@ -4261,40 +4262,40 @@ func (n *RuntimeJavascriptNakamaModule) notificationsDeleteId(r *goja.Runtime) f
 
 // @group wallets
 // @summary Update a user's wallet with the given changeset.
-// @param userIDIn(type=string) The ID of the user whose wallet to update.
-// @param changesetMap(type={[key: string]: number}) The set of wallet operations to apply.
-// @param metadataIn(type=object, optional=true) Additional metadata to tag the wallet update with.
+// @param userID(type=string) The ID of the user whose wallet to update.
+// @param changeset(type={[key: string]: number}) The set of wallet operations to apply.
+// @param metadata(type=object, optional=true) Additional metadata to tag the wallet update with.
 // @param updateLedger(type=bool, optional=true, default=false) Whether to record this update in the ledger.
 // @return result(nkruntime.WalletUpdateResult) The changeset after the update and before to the update, respectively.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) walletUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDIn := getJsString(r, f.Argument(0))
-		if userIDIn == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.NewTypeError("expects a valid user id"))
 		}
-		userID, err := uuid.FromString(userIDIn)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects a valid user id"))
 		}
 
-		changesetMap, ok := f.Argument(1).Export().(map[string]interface{})
+		changeset, ok := f.Argument(1).Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects a changeset object"))
 		}
-		changeSet := make(map[string]int64)
-		for k, v := range changesetMap {
+		changesetMap := make(map[string]int64)
+		for k, v := range changeset {
 			i64, ok := v.(int64)
 			if !ok {
 				panic(r.NewTypeError("expects changeset values to be whole numbers"))
 			}
-			changeSet[k] = i64
+			changesetMap[k] = i64
 		}
 
 		metadataBytes := []byte("{}")
-		metadataIn := f.Argument(2)
-		if metadataIn != goja.Undefined() && metadataIn != goja.Null() {
-			metadataMap, ok := metadataIn.Export().(map[string]interface{})
+		metadata := f.Argument(2)
+		if metadata != goja.Undefined() && metadata != goja.Null() {
+			metadataMap, ok := metadata.Export().(map[string]interface{})
 			if !ok {
 				panic(r.NewTypeError("expects metadata to be a key value object"))
 			}
@@ -4310,8 +4311,8 @@ func (n *RuntimeJavascriptNakamaModule) walletUpdate(r *goja.Runtime) func(goja.
 		}
 
 		results, err := UpdateWallets(n.ctx, n.logger, n.db, []*walletUpdate{{
-			UserID:    userID,
-			Changeset: changeSet,
+			UserID:    uid,
+			Changeset: changesetMap,
 			Metadata:  string(metadataBytes),
 		}}, updateLedger)
 		if err != nil {
@@ -4332,19 +4333,19 @@ func (n *RuntimeJavascriptNakamaModule) walletUpdate(r *goja.Runtime) func(goja.
 
 // @group wallets
 // @summary Update one or more user wallets with individual changesets. This function will also insert a new wallet ledger item into each user's wallet history that tracks their update.
-// @param updatesIn(type=nkruntime.WalletUpdate[]) The set of user wallet update operations to apply.
+// @param updates(type=nkruntime.WalletUpdate[]) The set of user wallet update operations to apply.
 // @param updateLedger(type=bool, optional=true, default=false) Whether to record this update in the ledger.
 // @return updateWallets(nkruntime.WalletUpdateResult[]) A list of wallet update results.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) walletsUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		updatesIn, err := exportToSlice[[]map[string]any](f.Argument(0))
+		updates, err := exportToSlice[[]map[string]any](f.Argument(0))
 		if err != nil {
 			panic(r.NewTypeError("expects an array of wallet update objects"))
 		}
 
-		updates := make([]*walletUpdate, 0, len(updatesIn))
-		for _, updateMap := range updatesIn {
+		updatesMap := make([]*walletUpdate, 0, len(updates))
+		for _, updateMap := range updates {
 			update := &walletUpdate{}
 
 			uidRaw, ok := updateMap["userId"]
@@ -4393,7 +4394,7 @@ func (n *RuntimeJavascriptNakamaModule) walletsUpdate(r *goja.Runtime) func(goja
 			}
 			update.Metadata = string(metadataBytes)
 
-			updates = append(updates, update)
+			updatesMap = append(updatesMap, update)
 		}
 
 		updateLedger := false
@@ -4401,7 +4402,7 @@ func (n *RuntimeJavascriptNakamaModule) walletsUpdate(r *goja.Runtime) func(goja
 			updateLedger = getJsBool(r, f.Argument(1))
 		}
 
-		results, err := UpdateWallets(n.ctx, n.logger, n.db, updates, updateLedger)
+		results, err := UpdateWallets(n.ctx, n.logger, n.db, updatesMap, updateLedger)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to update user wallet: %s", err.Error())))
 		}
@@ -4423,41 +4424,41 @@ func (n *RuntimeJavascriptNakamaModule) walletsUpdate(r *goja.Runtime) func(goja
 
 // @group wallets
 // @summary Update the metadata for a particular wallet update in a user's wallet ledger history. Useful when adding a note to a transaction for example.
-// @param itemIDIn(type=string) The ID of the wallet ledger item to update.
-// @param metadataMap(type=object) The new metadata to set on the wallet ledger item.
+// @param itemID(type=string) The ID of the wallet ledger item to update.
+// @param metadata(type=object) The new metadata to set on the wallet ledger item.
 // @return updateWalletLedger(nkruntime.WalletLedgerItem) The updated wallet ledger item.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) walletLedgerUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		// Parse ledger ID.
-		itemIDIn := getJsString(r, f.Argument(0))
-		if itemIDIn == "" {
+		itemID := getJsString(r, f.Argument(0))
+		if itemID == "" {
 			panic(r.NewTypeError("expects a valid id"))
 		}
-		itemID, err := uuid.FromString(itemIDIn)
+		iid, err := uuid.FromString(itemID)
 		if err != nil {
 			panic(r.NewTypeError("expects a valid id"))
 		}
 
-		metadataMap, ok := f.Argument(1).Export().(map[string]interface{})
+		metadata, ok := f.Argument(1).Export().(map[string]interface{})
 		if !ok {
 			panic(r.NewTypeError("expects metadata object"))
 		}
-		metadataBytes, err := json.Marshal(metadataMap)
+		metadataBytes, err := json.Marshal(metadata)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to convert metadata: %s", err.Error())))
 		}
-		item, err := UpdateWalletLedger(n.ctx, n.logger, n.db, itemID, string(metadataBytes))
+		item, err := UpdateWalletLedger(n.ctx, n.logger, n.db, iid, string(metadataBytes))
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to update user wallet ledger: %s", err.Error())))
 		}
 
 		return r.ToValue(map[string]interface{}{
-			"id":         itemIDIn,
+			"id":         itemID,
 			"userId":     item.UserID,
 			"createTime": item.CreateTime,
 			"updateTime": item.UpdateTime,
-			"changeset":  metadataMap,
+			"changeset":  metadata,
 			"metadata":   item.Metadata,
 		})
 	}
@@ -4466,7 +4467,7 @@ func (n *RuntimeJavascriptNakamaModule) walletLedgerUpdate(r *goja.Runtime) func
 // @group status
 // @summary Follow a player's status changes on a given session.
 // @param sessionID(type=string) A valid session identifier.
-// @param userIDsIn(type=string[]) A list of userIDs to follow.
+// @param userIDs(type=string[]) A list of userIDs to follow.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) statusFollow(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -4477,9 +4478,9 @@ func (n *RuntimeJavascriptNakamaModule) statusFollow(r *goja.Runtime) func(goja.
 			panic(r.NewTypeError("expects a valid session id"))
 		}
 
-		userIDsIn := f.Argument(1)
+		userIDs := f.Argument(1)
 
-		uidsSlice, err := exportToSlice[[]string](userIDsIn)
+		uidsSlice, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
@@ -4506,7 +4507,7 @@ func (n *RuntimeJavascriptNakamaModule) statusFollow(r *goja.Runtime) func(goja.
 // @group status
 // @summary Unfollow a player's status changes on a given session.
 // @param sessionID(type=string) A valid session identifier.
-// @param userIDsIn(type=string[]) A list of userIDs to unfollow.
+// @param userIDs(type=string[]) A list of userIDs to unfollow.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) statusUnfollow(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
@@ -4517,9 +4518,9 @@ func (n *RuntimeJavascriptNakamaModule) statusUnfollow(r *goja.Runtime) func(goj
 			panic(r.NewTypeError("expects a valid session id"))
 		}
 
-		userIDsIn := f.Argument(1)
+		userIDs := f.Argument(1)
 
-		uidsSlice, err := exportToSlice[[]string](userIDsIn)
+		uidsSlice, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
@@ -4545,18 +4546,18 @@ func (n *RuntimeJavascriptNakamaModule) statusUnfollow(r *goja.Runtime) func(goj
 
 // @group wallets
 // @summary List all wallet updates for a particular user from oldest to newest.
-// @param userIDIn(type=string) The ID of the user to list wallet updates for.
+// @param userID(type=string) The ID of the user to list wallet updates for.
 // @param limit(type=number, optional=true, default=100) Limit number of results.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return runtimeItems(nkruntime.WalletLedgerItem[]) A JavaScript Object containing wallet entries with Id, UserId, CreateTime, UpdateTime, Changeset, Metadata parameters, and possibly a cursor. If cursor is empty/null there are no further results.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) walletLedgerList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDIn := getJsString(r, f.Argument(0))
-		if userIDIn == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.NewTypeError("expects a valid user id"))
 		}
-		userID, err := uuid.FromString(userIDIn)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects a valid user id"))
 		}
@@ -4571,7 +4572,7 @@ func (n *RuntimeJavascriptNakamaModule) walletLedgerList(r *goja.Runtime) func(g
 			cursor = getJsString(r, f.Argument(2))
 		}
 
-		items, newCursor, _, err := ListWalletLedger(n.ctx, n.logger, n.db, userID, &limit, cursor)
+		items, newCursor, _, err := ListWalletLedger(n.ctx, n.logger, n.db, uid, &limit, cursor)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to retrieve user wallet ledger: %s", err.Error())))
 		}
@@ -4580,7 +4581,7 @@ func (n *RuntimeJavascriptNakamaModule) walletLedgerList(r *goja.Runtime) func(g
 		for _, item := range items {
 			results = append(results, map[string]interface{}{
 				"id":         item.ID,
-				"userId":     userIDIn,
+				"userId":     userID,
 				"createTime": item.CreateTime,
 				"updateTime": item.UpdateTime,
 				"changeset":  item.Changeset,
@@ -4603,11 +4604,11 @@ func (n *RuntimeJavascriptNakamaModule) walletLedgerList(r *goja.Runtime) func(g
 
 // @group storage
 // @summary List records in a collection and page through results. The records returned can be filtered to those owned by the user or "" for public records.
-// @param userIDString(type=string) User ID to list records for or "" (empty string) for public records.
+// @param userID(type=string) User ID to list records for or "" (empty string) for public records.
 // @param collection(type=string) Collection to list data from.
 // @param limit(type=number, optional=true, default=100) Limit number of records retrieved.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
-// @param callerIDString(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return objects(nkruntime.StorageObjectList) A list of storage objects.
 // @return cursor(string) Pagination cursor. Will be set to "" or null when fetching last available page.
 // @return error(error) An optional error value if an error occurred.
@@ -4615,8 +4616,8 @@ func (n *RuntimeJavascriptNakamaModule) storageList(r *goja.Runtime) func(goja.F
 	return func(f goja.FunctionCall) goja.Value {
 		var uid *uuid.UUID
 		if f.Argument(0) != goja.Undefined() && f.Argument(0) != goja.Null() {
-			userIDString := getJsString(r, f.Argument(0))
-			u, err := uuid.FromString(userIDString)
+			userID := getJsString(r, f.Argument(0))
+			u, err := uuid.FromString(userID)
 			if err != nil {
 				panic(r.NewTypeError("expects empty or valid user id"))
 			}
@@ -4641,17 +4642,17 @@ func (n *RuntimeJavascriptNakamaModule) storageList(r *goja.Runtime) func(goja.F
 			cursor = getJsString(r, f.Argument(3))
 		}
 
-		callerID := uuid.Nil
+		callerIDValue := uuid.Nil
 		if !goja.IsUndefined(f.Argument(4)) && !goja.IsNull(f.Argument(4)) {
-			callerIDString := getJsString(r, f.Argument(4))
-			cid, err := uuid.FromString(callerIDString)
+			callerID := getJsString(r, f.Argument(4))
+			cid, err := uuid.FromString(callerID)
 			if err != nil {
 				panic(r.NewTypeError("expects caller id to be valid identifier"))
 			}
-			callerID = cid
+			callerIDValue = cid
 		}
 
-		objectList, _, err := StorageListObjects(n.ctx, n.logger, n.db, callerID, uid, collection, limit, cursor)
+		objectList, _, err := StorageListObjects(n.ctx, n.logger, n.db, callerIDValue, uid, collection, limit, cursor)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to list storage objects: %s", err.Error())))
 		}
@@ -4698,17 +4699,17 @@ func (n *RuntimeJavascriptNakamaModule) storageList(r *goja.Runtime) func(goja.F
 
 // @group storage
 // @summary Fetch one or more records by their bucket/collection/keyname and optional user.
-// @param objectIDsIn(type=nkruntime.StorageReadRequest[]) An array of object identifiers to be fetched.
+// @param objectIDs(type=nkruntime.StorageReadRequest[]) An array of object identifiers to be fetched.
 // @return objects(nkruntime.StorageObject[]) A list of storage records matching the parameters criteria.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		objectIDsIn := f.Argument(0)
-		if objectIDsIn == goja.Undefined() || objectIDsIn == goja.Null() {
+		objectIDs := f.Argument(0)
+		if objectIDs == goja.Undefined() || objectIDs == goja.Null() {
 			panic(r.NewTypeError("expects an array ok keys"))
 		}
 
-		keysSlice, err := exportToSlice[[]map[string]any](objectIDsIn)
+		keysSlice, err := exportToSlice[[]map[string]any](objectIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of keys"))
 		}
@@ -4717,7 +4718,7 @@ func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.F
 			return r.ToValue([]any{})
 		}
 
-		objectIDs := make([]*api.ReadStorageObjectId, 0, len(keysSlice))
+		objectIDsMap := make([]*api.ReadStorageObjectId, 0, len(keysSlice))
 		for _, objMap := range keysSlice {
 			objectID := &api.ReadStorageObjectId{}
 
@@ -4757,10 +4758,10 @@ func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.F
 				objectID.UserId = uuid.Nil.String()
 			}
 
-			objectIDs = append(objectIDs, objectID)
+			objectIDsMap = append(objectIDsMap, objectID)
 		}
 
-		objects, err := StorageReadObjects(n.ctx, n.logger, n.db, uuid.Nil, objectIDs)
+		objects, err := StorageReadObjects(n.ctx, n.logger, n.db, uuid.Nil, objectIDsMap)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to read storage objects: %s", err.Error())))
 		}
@@ -5027,7 +5028,7 @@ func (n *RuntimeJavascriptNakamaModule) storageDelete(r *goja.Runtime) func(goja
 
 // @group users
 // @summary Update account, storage, and wallet information simultaneously.
-// @param accountUpdatesSlice(type=nkruntime.AccountUpdate[]) Array of account information to be updated.
+// @param accountUpdates(type=nkruntime.AccountUpdate[]) Array of account information to be updated.
 // @param storageWrites(type=nkruntime.StorageWriteRequest[]) Array of storage objects to be updated.
 // @param storageDeletes(type=nkruntime.StorageDeleteRequest[]) Array of storage objects to be deleted.
 // @param walletUpdates(type=nkruntime.WalletUpdate[]) Array of wallet updates to be made.
@@ -5038,15 +5039,15 @@ func (n *RuntimeJavascriptNakamaModule) storageDelete(r *goja.Runtime) func(goja
 func (n *RuntimeJavascriptNakamaModule) multiUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		// Process account update inputs.
-		var accountUpdates []*accountUpdate
+		var accountUpdatesArray []*accountUpdate
 		if f.Argument(0) != goja.Undefined() && f.Argument(0) != goja.Null() {
-			accountUpdatesSlice, err := exportToSlice[[]map[string]any](f.Argument(0))
+			accountUpdates, err := exportToSlice[[]map[string]any](f.Argument(0))
 			if err != nil {
 				panic(r.NewTypeError("expects an array of account updates"))
 			}
 
-			accountUpdates = make([]*accountUpdate, 0, len(accountUpdatesSlice))
-			for _, accUpdateObj := range accountUpdatesSlice {
+			accountUpdatesArray = make([]*accountUpdate, 0, len(accountUpdates))
+			for _, accUpdateObj := range accountUpdates {
 				update := &accountUpdate{}
 				if userIDIn, ok := accUpdateObj["userId"]; ok {
 					userIDStr, ok := userIDIn.(string)
@@ -5120,7 +5121,7 @@ func (n *RuntimeJavascriptNakamaModule) multiUpdate(r *goja.Runtime) func(goja.F
 					update.metadata = &wrapperspb.StringValue{Value: string(metadataBytes)}
 				}
 
-				accountUpdates = append(accountUpdates, update)
+				accountUpdatesArray = append(accountUpdatesArray, update)
 			}
 		}
 
@@ -5371,7 +5372,7 @@ func (n *RuntimeJavascriptNakamaModule) multiUpdate(r *goja.Runtime) func(goja.F
 			updateLedger = getJsBool(r, f.Argument(4))
 		}
 
-		acks, results, err := MultiUpdate(n.ctx, n.logger, n.db, n.metrics, accountUpdates, storageWriteOps, storageDeleteOps, n.storageIndex, walletUpdateOps, updateLedger)
+		acks, results, err := MultiUpdate(n.ctx, n.logger, n.db, n.metrics, accountUpdatesArray, storageWriteOps, storageDeleteOps, n.storageIndex, walletUpdateOps, updateLedger)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error running multi update: %s", err.Error())))
 		}
@@ -5531,7 +5532,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardDelete(r *goja.Runtime) func(
 // @group leaderboards
 // @summary Find leaderboards which have been created on the server. Leaderboards can be filtered with categories.
 // @param limit(type=number, optional=true, default=10) Return only the required number of leaderboards denoted by this limit value.
-// @param cursorString(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
+// @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return leaderboardList(nkruntime.LeaderboardList[]) A list of leaderboard results and possibly a cursor. If cursor is empty/null there are no further results.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) leaderboardList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -5544,20 +5545,20 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardList(r *goja.Runtime) func(go
 			}
 		}
 
-		var cursor *LeaderboardListCursor
+		var cursorValue *LeaderboardListCursor
 		if f.Argument(1) != goja.Undefined() && f.Argument(1) != goja.Null() {
-			cursorString := getJsString(r, f.Argument(1))
-			cb, err := base64.StdEncoding.DecodeString(cursorString)
+			cursor := getJsString(r, f.Argument(1))
+			cb, err := base64.StdEncoding.DecodeString(cursor)
 			if err != nil {
 				panic(r.NewTypeError("expects cursor to be valid when provided"))
 			}
-			cursor = &LeaderboardListCursor{}
-			if err := gob.NewDecoder(bytes.NewReader(cb)).Decode(cursor); err != nil {
+			cursorValue = &LeaderboardListCursor{}
+			if err := gob.NewDecoder(bytes.NewReader(cb)).Decode(cursorValue); err != nil {
 				panic(r.NewTypeError("expects cursor to be valid when provided"))
 			}
 		}
 
-		list, err := LeaderboardList(n.logger, n.leaderboardCache, limit, cursor)
+		list, err := LeaderboardList(n.logger, n.leaderboardCache, limit, cursorValue)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error listing leaderboards: %v", err.Error())))
 		}
@@ -5605,7 +5606,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRanksDisable(r *goja.Runtime)
 // @group leaderboards
 // @summary List records on the specified leaderboard, optionally filtering to only a subset of records by their owners. Records will be listed in the preconfigured leaderboard sort order.
 // @param id(type=string) The unique identifier for the leaderboard to list. Mandatory field.
-// @param ownerIDsIn(type=string[]) Array of owners to filter to.
+// @param ownerIDs(type=string[]) Array of owners to filter to.
 // @param limitNumber(type=number) The maximum number of records to return (Max 10,000).
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param overrideExpiry(type=int, optional=true) Records with expiry in the past are not returned unless within this defined limit. Must be equal or greater than 0.
@@ -5621,16 +5622,16 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsList(r *goja.Runtime) 
 			panic(r.NewTypeError("expects a leaderboard ID string"))
 		}
 
-		var ownerIDs []string
-		ownerIDsIn := f.Argument(1)
-		if ownerIDsIn != goja.Undefined() && ownerIDsIn != goja.Null() {
+		var ownerIDsArray []string
+		ownerIDs := f.Argument(1)
+		if ownerIDs != goja.Undefined() && ownerIDs != goja.Null() {
 			var err error
-			ownerIDs, err = exportToSlice[[]string](ownerIDsIn)
+			ownerIDsArray, err = exportToSlice[[]string](ownerIDs)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of user ids"))
 			}
 
-			for _, owner := range ownerIDs {
+			for _, owner := range ownerIDsArray {
 				if _, err := uuid.FromString(owner); err != nil {
 					panic(r.NewTypeError("expects a valid owner id"))
 				}
@@ -5656,7 +5657,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsList(r *goja.Runtime) 
 			overrideExpiry = getJsInt(r, f.Argument(4))
 		}
 
-		records, err := LeaderboardRecordsList(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, id, limit, cursor, ownerIDs, overrideExpiry)
+		records, err := LeaderboardRecordsList(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, id, limit, cursor, ownerIDsArray, overrideExpiry)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error listing leaderboard records: %v", err.Error())))
 		}
@@ -5738,7 +5739,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordsListCursorFromRank(r *
 // @param score(type=number, optional=true, default=0) The score to submit.
 // @param subscore(type=number, optional=true, default=0) A secondary subscore parameter for the submission.
 // @param metadata(type=object, optional=true) The metadata you want associated to this submission. Some good examples are weather conditions for a racing game.
-// @param operatorString(type=nkruntime.OverrideOperator, optional=true) An override operator for the new record. The accepted values include: 0 (no override), 1 (best), 2 (set), 3 (incr), 4 (decr).
+// @param overrideOperator(type=nkruntime.OverrideOperator, optional=true) An override operator for the new record. The accepted values include: 0 (no override), 1 (best), 2 (set), 3 (incr), 4 (decr).
 // @return record(nkruntime.LeaderboardRecord) The newly created leaderboard record.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) leaderboardRecordWrite(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -5782,24 +5783,24 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordWrite(r *goja.Runtime) 
 			metadataStr = string(metadataBytes)
 		}
 
-		overrideOperator := api.Operator_NO_OVERRIDE
+		overrideOperatorValue := api.Operator_NO_OVERRIDE
 		if f.Argument(6) != goja.Undefined() && f.Argument(6) != goja.Null() {
-			operatorString := strings.ToLower(getJsString(r, f.Argument(6)))
-			switch operatorString {
+			overrideOperator := strings.ToLower(getJsString(r, f.Argument(6)))
+			switch overrideOperator {
 			case "best":
-				overrideOperator = api.Operator_BEST
+				overrideOperatorValue = api.Operator_BEST
 			case "set":
-				overrideOperator = api.Operator_SET
+				overrideOperatorValue = api.Operator_SET
 			case "incr", "increment":
-				overrideOperator = api.Operator_INCREMENT
+				overrideOperatorValue = api.Operator_INCREMENT
 			case "decr", "decrement":
-				overrideOperator = api.Operator_DECREMENT
+				overrideOperatorValue = api.Operator_DECREMENT
 			default:
 				panic(r.NewTypeError(ErrInvalidOperator.Error()))
 			}
 		}
 
-		record, err := LeaderboardRecordWrite(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, uuid.Nil, id, ownerID, username, score, subscore, metadataStr, overrideOperator)
+		record, err := LeaderboardRecordWrite(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, uuid.Nil, id, ownerID, username, score, subscore, metadataStr, overrideOperatorValue)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error writing leaderboard record: %v", err.Error())))
 		}
@@ -5835,21 +5836,21 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardRecordDelete(r *goja.Runtime)
 
 // @group leaderboards
 // @summary Fetch one or more leaderboards by ID.
-// @param leaderboardIDsIn(type=string[]) The array of leaderboard ids.
+// @param leaderboardIDs(type=string[]) The array of leaderboard ids.
 // @return leaderboards(nkruntime.Leaderboard[]) The leaderboard records according to ID.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) leaderboardsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		leaderboardIDsIn := f.Argument(0)
-		if leaderboardIDsIn == goja.Undefined() || leaderboardIDsIn == goja.Null() {
+		leaderboardIDs := f.Argument(0)
+		if leaderboardIDs == goja.Undefined() || leaderboardIDs == goja.Null() {
 			panic(r.NewTypeError("expects an array of leaderboard ids"))
 		}
-		leaderboardIDs, err := exportToSlice[[]string](leaderboardIDsIn)
+		leaderboardIDsArray, err := exportToSlice[[]string](leaderboardIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
 
-		leaderboards := LeaderboardsGet(n.leaderboardCache, leaderboardIDs)
+		leaderboards := LeaderboardsGet(n.leaderboardCache, leaderboardIDsArray)
 
 		leaderboardsSlice := make([]interface{}, 0, len(leaderboards))
 		for _, l := range leaderboards {
@@ -6640,25 +6641,25 @@ func (n *RuntimeJavascriptNakamaModule) tournamentJoin(r *goja.Runtime) func(goj
 
 // @group tournaments
 // @summary Fetch one or more tournaments by ID.
-// @param tournamentIDsIn(type=string[]) The table array of tournament ids.
+// @param tournamentIDs(type=string[]) The table array of tournament ids.
 // @return result(nkruntime.Tournament[]) Array of tournament records.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) tournamentsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		tournamentIDsIn := f.Argument(0)
-		if tournamentIDsIn == goja.Undefined() || tournamentIDsIn == goja.Null() {
+		tournamentIDs := f.Argument(0)
+		if tournamentIDs == goja.Undefined() || tournamentIDs == goja.Null() {
 			panic(r.NewTypeError("expects an array of tournament ids"))
 		}
-		tournmentIDs, err := exportToSlice[[]string](tournamentIDsIn)
+		tournmentIDsArray, err := exportToSlice[[]string](tournamentIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
 
-		if len(tournmentIDs) == 0 {
+		if len(tournmentIDsArray) == 0 {
 			return r.ToValue(make([]interface{}, 0))
 		}
 
-		list, err := TournamentsGet(n.ctx, n.logger, n.db, n.leaderboardCache, tournmentIDs)
+		list, err := TournamentsGet(n.ctx, n.logger, n.db, n.leaderboardCache, tournmentIDsArray)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get tournaments: %s", err.Error())))
 		}
@@ -6681,7 +6682,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentsGetId(r *goja.Runtime) func(g
 // @summary List records on the specified tournament, optionally filtering to only a subset of records by their owners. Records will be listed in the preconfigured tournament sort order.
 // @param tournamentID(type=string) The ID of the tournament to list records for.
 // @param ownerIDs(type=string[], optional=true) Array of owner IDs to filter results by. Optional.
-// @param limitNumber(type=number, optional=true) Return only the required number of tournament records denoted by this limit value. Max is 10000.
+// @param limit(type=number, optional=true) Return only the required number of tournament records denoted by this limit value. Max is 10000.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param overrideExpiry(type=number, optional=true, default=0) Optionally retrieve records from previous resets by specifying the reset point in time in UTC seconds. Must be equal or greater than 0.
 // @return records(nkruntime.LeaderboardRecord) A page of tournament records.
@@ -6712,13 +6713,13 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordsList(r *goja.Runtime) f
 			}
 		}
 
-		limitNumber := 0
+		limit := 0
 		if f.Argument(2) != goja.Undefined() {
-			limitNumber = int(getJsInt(r, f.Argument(2)))
+			limit = int(getJsInt(r, f.Argument(2)))
 		}
-		var limit *wrapperspb.Int32Value
-		if limitNumber != 0 {
-			limit = &wrapperspb.Int32Value{Value: int32(limitNumber)}
+		var limitValue *wrapperspb.Int32Value
+		if limit != 0 {
+			limitValue = &wrapperspb.Int32Value{Value: int32(limit)}
 		}
 
 		cursor := ""
@@ -6731,7 +6732,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordsList(r *goja.Runtime) f
 			overrideExpiry = getJsInt(r, f.Argument(4))
 		}
 
-		records, err := TournamentRecordsList(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, tournamentID, owners, limit, cursor, overrideExpiry)
+		records, err := TournamentRecordsList(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, tournamentID, owners, limitValue, cursor, overrideExpiry)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error listing tournament records: %v", err.Error())))
 		}
@@ -6812,7 +6813,7 @@ func leaderboardRecordToJsMap(r *goja.Runtime, record *api.LeaderboardRecord) ma
 // @param startTime(type=number, optional=true) Filter tournament with that start after this time.
 // @param endTime(type=number, optional=true) Filter tournament with that end before this time.
 // @param limit(type=number, optional=true, default=10) Return only the required number of tournament denoted by this limit value.
-// @param cursorString(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
+// @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @return tournamentList(nkruntime.TournamentList[]) A list of tournament results and possibly a cursor. If cursor is empty/null there are no further results.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) tournamentList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -6865,20 +6866,20 @@ func (n *RuntimeJavascriptNakamaModule) tournamentList(r *goja.Runtime) func(goj
 			}
 		}
 
-		var cursor *TournamentListCursor
+		var cursorValue *TournamentListCursor
 		if f.Argument(5) != goja.Undefined() && f.Argument(5) != goja.Null() {
-			cursorString := getJsString(r, f.Argument(5))
-			cb, err := base64.StdEncoding.DecodeString(cursorString)
+			cursor := getJsString(r, f.Argument(5))
+			cb, err := base64.StdEncoding.DecodeString(cursor)
 			if err != nil {
 				panic(r.NewTypeError("expects cursor to be valid when provided"))
 			}
-			cursor = &TournamentListCursor{}
-			if err := gob.NewDecoder(bytes.NewReader(cb)).Decode(cursor); err != nil {
+			cursorValue = &TournamentListCursor{}
+			if err := gob.NewDecoder(bytes.NewReader(cb)).Decode(cursorValue); err != nil {
 				panic(r.NewTypeError("expects cursor to be valid when provided"))
 			}
 		}
 
-		list, err := TournamentList(n.ctx, n.logger, n.db, n.leaderboardCache, categoryStart, categoryEnd, startTime, endTime, limit, cursor)
+		list, err := TournamentList(n.ctx, n.logger, n.db, n.leaderboardCache, categoryStart, categoryEnd, startTime, endTime, limit, cursorValue)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error listing tournaments: %v", err.Error())))
 		}
@@ -7023,7 +7024,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordDelete(r *goja.Runtime) 
 // @group tournaments
 // @summary Fetch the list of tournament records around the owner.
 // @param id(type=string) The ID of the tournament to list records for.
-// @param ownerIDString(type=string) The owner ID around which to show records.
+// @param ownerID(type=string) The owner ID around which to show records.
 // @param limit(type=number, optional=true, default=10) Return only the required number of tournament records denoted by this limit value. Between 1-100.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
 // @param expiry(type=number, optional=true, default=0) Time since epoch in seconds. Must be greater than 0.
@@ -7036,8 +7037,8 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordsHaystack(r *goja.Runtim
 			panic(r.NewTypeError("expects a tournament ID string"))
 		}
 
-		ownerIDString := getJsString(r, f.Argument(1))
-		ownerID, err := uuid.FromString(ownerIDString)
+		ownerID := getJsString(r, f.Argument(1))
+		oid, err := uuid.FromString(ownerID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -7063,7 +7064,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordsHaystack(r *goja.Runtim
 			}
 		}
 
-		records, err := TournamentRecordsHaystack(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, id, cursor, ownerID, limit, expiry)
+		records, err := TournamentRecordsHaystack(n.ctx, n.logger, n.db, n.leaderboardCache, n.rankCache, id, cursor, oid, limit, expiry)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error listing tournament records haystack: %v", err.Error())))
 		}
@@ -7074,21 +7075,21 @@ func (n *RuntimeJavascriptNakamaModule) tournamentRecordsHaystack(r *goja.Runtim
 
 // @group groups
 // @summary Fetch one or more groups by their ID.
-// @param groupIDsIn(type=string[]) An array of strings of the IDs for the groups to get.
+// @param groupIDs(type=string[]) An array of strings of the IDs for the groups to get.
 // @return getGroups(nkruntime.Group[]) An array of groups with their fields.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupsGetId(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDsIn := f.Argument(0)
-		if groupIDsIn == goja.Undefined() || groupIDsIn == goja.Null() {
+		groupIDs := f.Argument(0)
+		if groupIDs == goja.Undefined() || groupIDs == goja.Null() {
 			panic(r.NewTypeError("expects an array of group ids"))
 		}
-		groupIDs, err := exportToSlice[[]string](groupIDsIn)
+		groupIDsArray, err := exportToSlice[[]string](groupIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects array of strings"))
 		}
 
-		groups, err := GetGroups(n.ctx, n.logger, n.db, groupIDs)
+		groups, err := GetGroups(n.ctx, n.logger, n.db, groupIDsArray)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to get groups: %s", err.Error())))
 		}
@@ -7124,9 +7125,9 @@ func (n *RuntimeJavascriptNakamaModule) groupsGetId(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Set up a group with various configuration settings. The group will be created if they don't exist or fail if the group name is taken.
-// @param userIDString(type=string) The user ID to be associated as the group superadmin.
+// @param userID(type=string) The user ID to be associated as the group superadmin.
 // @param name(type=string) Group name, must be unique.
-// @param creatorIDString(type=string, optional=true) The user ID to be associated as creator. If not set or nil/null, system user will be set.
+// @param creatorID(type=string, optional=true) The user ID to be associated as creator. If not set or nil/null, system user will be set.
 // @param langTag(type=string, optional=true, default="en") Group language.
 // @param description(type=string, optional=true) Group description, can be left empty as nil/null.
 // @param avatarURL(type=string, optional=true) URL to the group avatar, can be left empty as nil/null.
@@ -7137,11 +7138,11 @@ func (n *RuntimeJavascriptNakamaModule) groupsGetId(r *goja.Runtime) func(goja.F
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupCreate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.NewTypeError("expects a user ID string"))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -7151,11 +7152,11 @@ func (n *RuntimeJavascriptNakamaModule) groupCreate(r *goja.Runtime) func(goja.F
 			panic(r.NewTypeError("expects group name to not be empty"))
 		}
 
-		creatorIDString := uuid.Nil.String()
+		creatorID := uuid.Nil.String()
 		if f.Argument(2) != goja.Undefined() && f.Argument(2) != goja.Null() {
-			creatorIDString = getJsString(r, f.Argument(2))
+			creatorID = getJsString(r, f.Argument(2))
 		}
-		creatorID, err := uuid.FromString(creatorIDString)
+		cid, err := uuid.FromString(creatorID)
 		if err != nil {
 			panic(r.NewTypeError("expects owner ID to be a valid identifier"))
 		}
@@ -7199,7 +7200,7 @@ func (n *RuntimeJavascriptNakamaModule) groupCreate(r *goja.Runtime) func(goja.F
 			maxCount = int(getJsInt(r, f.Argument(8)))
 		}
 
-		group, err := CreateGroup(n.ctx, n.logger, n.db, userID, creatorID, name, langTag, description, avatarURL, metadataStr, open, maxCount)
+		group, err := CreateGroup(n.ctx, n.logger, n.db, uid, cid, name, langTag, description, avatarURL, metadataStr, open, maxCount)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to create group: %v", err.Error())))
 		}
@@ -7233,44 +7234,44 @@ func (n *RuntimeJavascriptNakamaModule) groupCreate(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Update a group with various configuration settings. The group which is updated can change some or all of its fields.
-// @param groupIDString(type=string) The ID of the group to update.
-// @param userIDString(type=string) User ID calling the update operation for permission checking. Set as nil to enact the changes as the system user.
-// @param nameString(type=string, optional=true) Group name, can be empty if not changed.
-// @param creatorIDString(type=string, optional=true) The user ID to be associated as creator. Can be empty if not changed.
+// @param groupID(type=string) The ID of the group to update.
+// @param userID(type=string) User ID calling the update operation for permission checking. Set as nil to enact the changes as the system user.
+// @param name(type=string, optional=true) Group name, can be empty if not changed.
+// @param creatorID(type=string, optional=true) The user ID to be associated as creator. Can be empty if not changed.
 // @param langTag(type=string, optional=true) Group language. Empty if not updated.
 // @param description(type=string, optional=true) Group description, can be left empty if not updated.
 // @param avatarURL(type=string, optional=true) URL to the group avatar, can be left empty if not updated.
 // @param open(type=bool, optional=true) Whether the group is for anyone to join or not.
-// @param metadataIn(type=object, optional=true) Custom information to store for this group. Use nil if field is not being updated.
+// @param metadata(type=object, optional=true) Custom information to store for this group. Use nil if field is not being updated.
 // @param maxCount(type=number, optional=true) Maximum number of members to have in the group. Use 0, nil/null if field is not being updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUpdate(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		groupID, err := uuid.FromString(groupIDString)
+		groupID := getJsString(r, f.Argument(0))
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userId := uuid.Nil
+		uid := uuid.Nil
 		if f.Argument(1) != goja.Undefined() && f.Argument(1) != goja.Null() {
-			userIDString := getJsString(r, f.Argument(1))
-			userId, err = uuid.FromString(userIDString)
+			userID := getJsString(r, f.Argument(1))
+			uid, err = uuid.FromString(userID)
 			if err != nil {
 				panic(r.NewTypeError("expects user ID to be a valid identifier"))
 			}
 		}
 
-		var name *wrapperspb.StringValue
+		var nameValue *wrapperspb.StringValue
 		if f.Argument(2) != goja.Undefined() && f.Argument(2) != goja.Null() {
-			nameString := getJsString(r, f.Argument(2))
-			name = &wrapperspb.StringValue{Value: nameString}
+			name := getJsString(r, f.Argument(2))
+			nameValue = &wrapperspb.StringValue{Value: name}
 		}
 
-		creatorID := uuid.Nil
+		cid := uuid.Nil
 		if f.Argument(3) != goja.Undefined() && f.Argument(3) != goja.Null() {
-			creatorIDString := getJsString(r, f.Argument(3))
-			creatorID, err = uuid.FromString(creatorIDString)
+			creatorID := getJsString(r, f.Argument(3))
+			cid, err = uuid.FromString(creatorID)
 			if err != nil {
 				panic(r.NewTypeError("expects creator ID to be a valid identifier"))
 			}
@@ -7299,10 +7300,10 @@ func (n *RuntimeJavascriptNakamaModule) groupUpdate(r *goja.Runtime) func(goja.F
 			open = &wrapperspb.BoolValue{Value: getJsBool(r, f.Argument(7))}
 		}
 
-		var metadata *wrapperspb.StringValue
-		metadataIn := f.Argument(8)
-		if metadataIn != goja.Undefined() && metadataIn != goja.Null() {
-			metadataMap, ok := metadataIn.Export().(map[string]interface{})
+		var metadataValue *wrapperspb.StringValue
+		metadata := f.Argument(8)
+		if metadata != goja.Undefined() && metadata != goja.Null() {
+			metadataMap, ok := metadata.Export().(map[string]interface{})
 			if !ok {
 				panic(r.NewTypeError("expects metadata to be a key value object"))
 			}
@@ -7310,7 +7311,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUpdate(r *goja.Runtime) func(goja.F
 			if err != nil {
 				panic(r.NewGoError(fmt.Errorf("failed to convert metadata: %s", err.Error())))
 			}
-			metadata = &wrapperspb.StringValue{Value: string(metadataBytes)}
+			metadataValue = &wrapperspb.StringValue{Value: string(metadataBytes)}
 		}
 
 		maxCount := 0
@@ -7318,7 +7319,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUpdate(r *goja.Runtime) func(goja.F
 			maxCount = int(getJsInt(r, f.Argument(9)))
 		}
 
-		if err = UpdateGroup(n.ctx, n.logger, n.db, groupID, userId, creatorID, name, lang, desc, avatar, metadata, open, maxCount); err != nil {
+		if err = UpdateGroup(n.ctx, n.logger, n.db, gid, uid, cid, nameValue, lang, desc, avatar, metadataValue, open, maxCount); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to update group: %v", err.Error())))
 		}
 
@@ -7328,17 +7329,17 @@ func (n *RuntimeJavascriptNakamaModule) groupUpdate(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Delete a group.
-// @param groupIDString(type=string) The ID of the group to delete.
+// @param groupID(type=string) The ID of the group to delete.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		groupID, err := uuid.FromString(groupIDString)
+		groupID := getJsString(r, f.Argument(0))
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		if err = DeleteGroup(n.ctx, n.logger, n.db, n.tracker, groupID, uuid.Nil); err != nil {
+		if err = DeleteGroup(n.ctx, n.logger, n.db, n.tracker, gid, uuid.Nil); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to delete group: %v", err.Error())))
 		}
 
@@ -7348,28 +7349,28 @@ func (n *RuntimeJavascriptNakamaModule) groupDelete(r *goja.Runtime) func(goja.F
 
 // @group groups
 // @summary Kick users from a group.
-// @param groupIDString(type=string) The ID of the group to kick users from.
-// @param userIDsIn(type=string[]) Table array of user IDs to kick.
-// @param callerIDString(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group to kick users from.
+// @param userIDs(type=string[]) Table array of user IDs to kick.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersKick(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		groupID, err := uuid.FromString(groupIDString)
+		groupID := getJsString(r, f.Argument(0))
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userIDsIn := f.Argument(1)
-		if goja.IsUndefined(userIDsIn) || goja.IsNull(userIDsIn) {
+		userIDs := f.Argument(1)
+		if goja.IsUndefined(userIDs) || goja.IsNull(userIDs) {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
-		usersSlice, err := exportToSlice[[]string](userIDsIn)
+		usersSlice, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
 
-		userIDs := make([]uuid.UUID, 0, len(usersSlice))
+		userIDsArray := make([]uuid.UUID, 0, len(usersSlice))
 		for _, id := range usersSlice {
 			userID, err := uuid.FromString(id)
 			if err != nil {
@@ -7378,20 +7379,20 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersKick(r *goja.Runtime) func(goj
 			if userID == uuid.Nil {
 				panic(r.NewTypeError("cannot kick the root user"))
 			}
-			userIDs = append(userIDs, userID)
+			userIDsArray = append(userIDsArray, userID)
 		}
 
-		callerID := uuid.Nil
+		callerIDValue := uuid.Nil
 		if !goja.IsUndefined(f.Argument(2)) && !goja.IsNull(f.Argument(2)) {
-			callerIDString := getJsString(r, f.Argument(2))
-			cid, err := uuid.FromString(callerIDString)
+			callerID := getJsString(r, f.Argument(2))
+			cid, err := uuid.FromString(callerID)
 			if err != nil {
 				panic(r.NewTypeError("expects caller id to be valid identifier"))
 			}
-			callerID = cid
+			callerIDValue = cid
 		}
 
-		if err := KickGroupUsers(n.ctx, n.logger, n.db, n.tracker, n.router, n.streamManager, callerID, groupID, userIDs, false); err != nil {
+		if err := KickGroupUsers(n.ctx, n.logger, n.db, n.tracker, n.router, n.streamManager, callerIDValue, gid, userIDsArray, false); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to kick users from a group: %v", err.Error())))
 		}
 
@@ -7401,7 +7402,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersKick(r *goja.Runtime) func(goj
 
 // @group groups
 // @summary List all members, admins and superadmins which belong to a group. This also list incoming join requests.
-// @param groupIDString(type=string) The ID of the group to list members for.
+// @param groupID(type=string) The ID of the group to list members for.
 // @param limit(type=int, optional=true, default=100) The maximum number of entries in the listing.
 // @param state(type=int, optional=true, default=null) The state of the user within the group. If unspecified this returns users in all states.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
@@ -7409,8 +7410,8 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersKick(r *goja.Runtime) func(goj
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		groupID, err := uuid.FromString(groupIDString)
+		groupID := getJsString(r, f.Argument(0))
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
@@ -7439,7 +7440,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersList(r *goja.Runtime) func(goj
 			cursor = getJsString(r, f.Argument(3))
 		}
 
-		res, err := ListGroupUsers(n.ctx, n.logger, n.db, n.statusRegistry, groupID, limit, stateWrapper, cursor)
+		res, err := ListGroupUsers(n.ctx, n.logger, n.db, n.statusRegistry, gid, limit, stateWrapper, cursor)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to list users in a group: %v", err.Error())))
 		}
@@ -7509,7 +7510,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersList(r *goja.Runtime) func(goj
 
 // @group groups
 // @summary List all groups which a user belongs to and whether they've been accepted or if it's an invitation.
-// @param userIDString(type=string) The ID of the user to list groups for.
+// @param userID(type=string) The ID of the user to list groups for.
 // @param limit(type=int, optional=true, default=100) The maximum number of entries in the listing.
 // @param state(type=int optional=true) The state of the user within the group. If unspecified this returns users in all states.
 // @param cursor(type=string, optional=true) An optional next page cursor that can be used to retrieve the next page of records (if any).
@@ -7518,8 +7519,8 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersList(r *goja.Runtime) func(goj
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) userGroupsList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		userID, err := uuid.FromString(userIDString)
+		userID := getJsString(r, f.Argument(0))
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -7548,7 +7549,7 @@ func (n *RuntimeJavascriptNakamaModule) userGroupsList(r *goja.Runtime) func(goj
 			cursor = getJsString(r, f.Argument(3))
 		}
 
-		res, err := ListUserGroups(n.ctx, n.logger, n.db, userID, limit, stateWrapper, cursor)
+		res, err := ListUserGroups(n.ctx, n.logger, n.db, uid, limit, stateWrapper, cursor)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to list groups for a user: %v", err.Error())))
 		}
@@ -7600,7 +7601,7 @@ func (n *RuntimeJavascriptNakamaModule) userGroupsList(r *goja.Runtime) func(goj
 
 // @group friends
 // @summary List all friends, invites, invited, and blocked which belong to a user.
-// @param userIDString(type=string) The ID of the user whose friends, invites, invited, and blocked you want to list.
+// @param userID(type=string) The ID of the user whose friends, invites, invited, and blocked you want to list.
 // @param limit(type=number, optional=true, default=100) The number of friends to retrieve in this page of results. No more than 100 limit allowed per result.
 // @param state(type=number, optional=true) The state of the friendship with the user. If unspecified this returns friends in all states for the user.
 // @param cursor(type=string, optional=true, default="") Pagination cursor from previous result. Don't set to start fetching from the beginning.
@@ -7609,11 +7610,11 @@ func (n *RuntimeJavascriptNakamaModule) userGroupsList(r *goja.Runtime) func(goj
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) friendsList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
 			panic(r.NewTypeError("expects a user ID string"))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -7642,7 +7643,7 @@ func (n *RuntimeJavascriptNakamaModule) friendsList(r *goja.Runtime) func(goja.F
 			cursor = getJsString(r, f.Argument(3))
 		}
 
-		friends, err := ListFriends(n.ctx, n.logger, n.db, n.statusRegistry, userID, limit, stateWrapper, cursor)
+		friends, err := ListFriends(n.ctx, n.logger, n.db, n.statusRegistry, uid, limit, stateWrapper, cursor)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to list friends for a user: %v", err.Error())))
 		}
@@ -7743,16 +7744,16 @@ func (n *RuntimeJavascriptNakamaModule) friendsOfFriendsList(r *goja.Runtime) fu
 
 // @group friends
 // @summary Add friends to a user.
-// @param userIDString(type=string) The ID of the user to whom you want to add friends.
+// @param userID(type=string) The ID of the user to whom you want to add friends.
 // @param username(type=string) The name of the user to whom you want to add friends.
-// @param userIDsIn(type=[]string) Table array of IDs of the users you want to add as friends.
-// @param usernamesIn(type=[]string) Table array of usernames of the users you want to add as friends.
+// @param userIDs(type=[]string) Table array of IDs of the users you want to add as friends.
+// @param usernames(type=[]string) Table array of usernames of the users you want to add as friends.
 // @param metadataMap(type=object, optional=true) Custom information to store for this friend. Use nil if field is not being updated.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) friendsAdd(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		userID, err := uuid.FromString(userIDString)
+		userID := getJsString(r, f.Argument(0))
+		userIDValue, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -7762,30 +7763,30 @@ func (n *RuntimeJavascriptNakamaModule) friendsAdd(r *goja.Runtime) func(goja.Fu
 			panic(r.NewTypeError("expects a username string"))
 		}
 
-		userIDsIn := f.Argument(2)
-		var userIDs []string
-		if userIDsIn != goja.Undefined() && userIDsIn != goja.Null() {
-			userIDs, err = exportToSlice[[]string](userIDsIn)
+		userIDs := f.Argument(2)
+		var userIDsArray []string
+		if userIDs != goja.Undefined() && userIDs != goja.Null() {
+			userIDsArray, err = exportToSlice[[]string](userIDs)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
-			for _, id := range userIDs {
+			for _, id := range userIDsArray {
 				if uid, err := uuid.FromString(id); err != nil || uid == uuid.Nil {
-					panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userID)))
-				} else if userIDString == id {
+					panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userIDValue)))
+				} else if userID == id {
 					panic(r.NewTypeError("cannot add self as friend"))
 				}
 			}
 		}
 
-		var usernames []string
-		usernamesIn := f.Argument(3)
-		if usernamesIn != goja.Undefined() && usernamesIn != goja.Null() {
-			usernames, err = exportToSlice[[]string](usernamesIn)
+		var usernamesArray []string
+		usernames := f.Argument(3)
+		if usernames != goja.Undefined() && usernames != goja.Null() {
+			usernamesArray, err = exportToSlice[[]string](usernames)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
-			for _, uname := range usernames {
+			for _, uname := range usernamesArray {
 				if uname == "" {
 					panic(r.NewTypeError("username to add must not be empty"))
 				} else if uname == username {
@@ -7794,22 +7795,22 @@ func (n *RuntimeJavascriptNakamaModule) friendsAdd(r *goja.Runtime) func(goja.Fu
 			}
 		}
 
-		if userIDs == nil && usernames == nil {
+		if userIDs == nil && usernamesArray == nil {
 			return goja.Undefined()
 		}
 
-		fetchIDs, err := fetchUserID(n.ctx, n.db, usernames)
+		fetchIDs, err := fetchUserID(n.ctx, n.db, usernamesArray)
 		if err != nil {
-			n.logger.Error("Could not fetch user IDs.", zap.Error(err), zap.Strings("usernames", usernames))
+			n.logger.Error("Could not fetch user IDs.", zap.Error(err), zap.Strings("usernames", usernamesArray))
 			panic(r.NewTypeError("error while trying to add friends"))
 		}
 
-		if len(fetchIDs)+len(userIDs) == 0 {
+		if len(fetchIDs)+len(userIDsArray) == 0 {
 			panic(r.NewTypeError("no valid ID or username was provided"))
 		}
 
-		allIDs := make([]string, 0, len(userIDs)+len(fetchIDs))
-		allIDs = append(allIDs, userIDs...)
+		allIDs := make([]string, 0, len(userIDsArray)+len(fetchIDs))
+		allIDs = append(allIDs, userIDsArray...)
 		allIDs = append(allIDs, fetchIDs...)
 
 		metadataMap := f.Argument(4)
@@ -7828,7 +7829,7 @@ func (n *RuntimeJavascriptNakamaModule) friendsAdd(r *goja.Runtime) func(goja.Fu
 			metadataStr = string(bytes)
 		}
 
-		err = AddFriends(n.ctx, n.logger, n.db, n.tracker, n.router, userID, username, allIDs, metadataStr)
+		err = AddFriends(n.ctx, n.logger, n.db, n.tracker, n.router, userIDValue, username, allIDs, metadataStr)
 		if err != nil {
 			panic(r.NewTypeError(err.Error()))
 		}
@@ -7839,15 +7840,15 @@ func (n *RuntimeJavascriptNakamaModule) friendsAdd(r *goja.Runtime) func(goja.Fu
 
 // @group friends
 // @summary Delete friends from a user.
-// @param userIDString(type=string) The ID of the user from whom you want to delete friends.
+// @param userID(type=string) The ID of the user from whom you want to delete friends.
 // @param username(type=string) The name of the user from whom you want to delete friends.
-// @param userIDsIn(type=[]string) Table array of IDs of the users you want to delete as friends.
-// @param usernamesIn(type=[]string) Table array of usernames of the users you want to delete as friends.
+// @param userIDs(type=[]string) Table array of IDs of the users you want to delete as friends.
+// @param usernames(type=[]string) Table array of usernames of the users you want to delete as friends.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) friendsDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		userID, err := uuid.FromString(userIDString)
+		userID := getJsString(r, f.Argument(0))
+		userIDValue, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -7857,30 +7858,30 @@ func (n *RuntimeJavascriptNakamaModule) friendsDelete(r *goja.Runtime) func(goja
 			panic(r.NewTypeError("expects a username string"))
 		}
 
-		var userIDs []string
-		userIDsIn := f.Argument(2)
-		if userIDsIn != goja.Undefined() && userIDsIn != goja.Null() {
-			userIDs, err = exportToSlice[[]string](userIDsIn)
+		var userIDsArray []string
+		userIDs := f.Argument(2)
+		if userIDs != goja.Undefined() && userIDs != goja.Null() {
+			userIDsArray, err = exportToSlice[[]string](userIDs)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
-			for _, userId := range userIDs {
+			for _, userId := range userIDsArray {
 				if uid, err := uuid.FromString(userId); err != nil || uid == uuid.Nil {
-					panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userID)))
-				} else if userIDString == userId {
+					panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userIDValue)))
+				} else if userID == userId {
 					panic(r.NewTypeError("cannot delete self"))
 				}
 			}
 		}
 
-		var usernames []string
-		usernamesIn := f.Argument(3)
-		if usernamesIn != goja.Undefined() && usernamesIn != goja.Null() {
-			usernames, err = exportToSlice[[]string](usernamesIn)
+		var usernamesArray []string
+		usernames := f.Argument(3)
+		if usernames != goja.Undefined() && usernames != goja.Null() {
+			usernamesArray, err = exportToSlice[[]string](usernames)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
-			for _, uname := range usernames {
+			for _, uname := range usernamesArray {
 				if uname == "" {
 					panic(r.NewTypeError("username to delete must not be empty"))
 				} else if uname == username {
@@ -7889,25 +7890,25 @@ func (n *RuntimeJavascriptNakamaModule) friendsDelete(r *goja.Runtime) func(goja
 			}
 		}
 
-		if userIDs == nil && usernames == nil {
+		if userIDsArray == nil && usernamesArray == nil {
 			return goja.Undefined()
 		}
 
-		fetchIDs, err := fetchUserID(n.ctx, n.db, usernames)
+		fetchIDs, err := fetchUserID(n.ctx, n.db, usernamesArray)
 		if err != nil {
-			n.logger.Error("Could not fetch user IDs.", zap.Error(err), zap.Strings("usernames", usernames))
+			n.logger.Error("Could not fetch user IDs.", zap.Error(err), zap.Strings("usernames", usernamesArray))
 			panic(r.NewTypeError("error while trying to delete friends"))
 		}
 
-		if len(fetchIDs)+len(userIDs) == 0 {
+		if len(fetchIDs)+len(userIDsArray) == 0 {
 			panic(r.NewTypeError("no valid ID or username was provided"))
 		}
 
-		allIDs := make([]string, 0, len(userIDs)+len(fetchIDs))
-		allIDs = append(allIDs, userIDs...)
+		allIDs := make([]string, 0, len(userIDsArray)+len(fetchIDs))
+		allIDs = append(allIDs, userIDsArray...)
 		allIDs = append(allIDs, fetchIDs...)
 
-		err = DeleteFriends(n.ctx, n.logger, n.db, userID, allIDs)
+		err = DeleteFriends(n.ctx, n.logger, n.db, userIDValue, allIDs)
 		if err != nil {
 			panic(r.NewTypeError(err.Error()))
 		}
@@ -7918,15 +7919,15 @@ func (n *RuntimeJavascriptNakamaModule) friendsDelete(r *goja.Runtime) func(goja
 
 // @group friends
 // @summary Block friends for a user.
-// @param userIDString(type=string) The ID of the user for whom you want to block friends.
+// @param userID(type=string) The ID of the user for whom you want to block friends.
 // @param username(type=string) The name of the user for whom you want to block friends.
-// @param userIDsIn(type=[]string) Table array of IDs of the users you want to block as friends.
-// @param usernamesIn(type=[]string) Table array of usernames of the users you want to block as friends.
+// @param userIDs(type=[]string) Table array of IDs of the users you want to block as friends.
+// @param usernames(type=[]string) Table array of usernames of the users you want to block as friends.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) friendsBlock(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		userIDString := getJsString(r, f.Argument(0))
-		userID, err := uuid.FromString(userIDString)
+		userID := getJsString(r, f.Argument(0))
+		userIDValue, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -7936,31 +7937,31 @@ func (n *RuntimeJavascriptNakamaModule) friendsBlock(r *goja.Runtime) func(goja.
 			panic(r.NewTypeError("expects a username string"))
 		}
 
-		var userIDs []string
-		userIDsIn := f.Argument(2)
-		if userIDsIn != goja.Undefined() && userIDsIn != goja.Null() {
-			userIDs, err = exportToSlice[[]string](userIDsIn)
+		var userIDsArray []string
+		userIDs := f.Argument(2)
+		if userIDs != goja.Undefined() && userIDs != goja.Null() {
+			userIDsArray, err = exportToSlice[[]string](userIDs)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
 
-			for _, id := range userIDs {
+			for _, id := range userIDsArray {
 				if uid, err := uuid.FromString(id); err != nil || uid == uuid.Nil {
-					panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userID)))
-				} else if userIDString == id {
+					panic(r.NewTypeError(fmt.Sprintf("invalid user id: %v", userIDValue)))
+				} else if userID == id {
 					panic(r.NewTypeError("cannot block self"))
 				}
 			}
 		}
 
-		var usernames []string
-		usernamesIn := f.Argument(3)
-		if usernamesIn != goja.Undefined() && usernamesIn != goja.Null() {
-			usernames, err = exportToSlice[[]string](usernamesIn)
+		var usernamesArray []string
+		usernames := f.Argument(3)
+		if usernames != goja.Undefined() && usernames != goja.Null() {
+			usernamesArray, err = exportToSlice[[]string](usernames)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
-			for _, uname := range usernames {
+			for _, uname := range usernamesArray {
 				if uname == "" {
 					panic(r.NewTypeError("username to block must not be empty"))
 				} else if uname == username {
@@ -7969,25 +7970,25 @@ func (n *RuntimeJavascriptNakamaModule) friendsBlock(r *goja.Runtime) func(goja.
 			}
 		}
 
-		if userIDs == nil && usernames == nil {
+		if userIDsArray == nil && usernamesArray == nil {
 			return goja.Undefined()
 		}
 
-		fetchIDs, err := fetchUserID(n.ctx, n.db, usernames)
+		fetchIDs, err := fetchUserID(n.ctx, n.db, usernamesArray)
 		if err != nil {
-			n.logger.Error("Could not fetch user IDs.", zap.Error(err), zap.Strings("usernames", usernames))
+			n.logger.Error("Could not fetch user IDs.", zap.Error(err), zap.Strings("usernames", usernamesArray))
 			panic(r.NewTypeError("error while trying to block friends"))
 		}
 
-		if len(fetchIDs)+len(userIDs) == 0 {
+		if len(fetchIDs)+len(userIDsArray) == 0 {
 			panic(r.NewTypeError("no valid ID or username was provided"))
 		}
 
-		allIDs := make([]string, 0, len(userIDs)+len(fetchIDs))
-		allIDs = append(allIDs, userIDs...)
+		allIDs := make([]string, 0, len(userIDsArray)+len(fetchIDs))
+		allIDs = append(allIDs, userIDsArray...)
 		allIDs = append(allIDs, fetchIDs...)
 
-		err = BlockFriends(n.ctx, n.logger, n.db, n.tracker, userID, allIDs)
+		err = BlockFriends(n.ctx, n.logger, n.db, n.tracker, userIDValue, allIDs)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to block friends: %v", err.Error())))
 		}
@@ -8029,26 +8030,26 @@ func (n *RuntimeJavascriptNakamaModule) friendMetadataUpdate(r *goja.Runtime) fu
 
 // @group groups
 // @summary Join a group for a particular user.
-// @param groupIDString(type=string) The ID of the group to join.
-// @param userIDString(type=string) The user ID to add to this group.
+// @param groupID(type=string) The ID of the group to join.
+// @param userID(type=string) The user ID to add to this group.
 // @param username(type=string) The username of the user to add to this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUserJoin(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		if groupIDString == "" {
+		groupID := getJsString(r, f.Argument(0))
+		if groupID == "" {
 			panic(r.NewTypeError("expects a group ID string"))
 		}
-		groupID, err := uuid.FromString(groupIDString)
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userIDString := getJsString(r, f.Argument(1))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(1))
+		if userID == "" {
 			panic(r.NewTypeError("expects a user ID string"))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -8058,7 +8059,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUserJoin(r *goja.Runtime) func(goja
 			panic(r.NewTypeError("expects a username string"))
 		}
 
-		if err := JoinGroup(n.ctx, n.logger, n.db, n.tracker, n.router, groupID, userID, username); err != nil {
+		if err := JoinGroup(n.ctx, n.logger, n.db, n.tracker, n.router, gid, uid, username); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error trying to join group: %v", err.Error())))
 		}
 
@@ -8068,26 +8069,26 @@ func (n *RuntimeJavascriptNakamaModule) groupUserJoin(r *goja.Runtime) func(goja
 
 // @group groups
 // @summary Leave a group for a particular user.
-// @param groupIDString(type=string) The ID of the group to leave.
-// @param userIDString(type=string) The user ID to remove from this group.
+// @param groupID(type=string) The ID of the group to leave.
+// @param userID(type=string) The user ID to remove from this group.
 // @param username(type=string) The username of the user to remove from this group.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUserLeave(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		if groupIDString == "" {
+		groupID := getJsString(r, f.Argument(0))
+		if groupID == "" {
 			panic(r.NewTypeError("expects a group ID string"))
 		}
-		groupID, err := uuid.FromString(groupIDString)
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userIDString := getJsString(r, f.Argument(1))
-		if userIDString == "" {
+		userID := getJsString(r, f.Argument(1))
+		if userID == "" {
 			panic(r.NewTypeError("expects a user ID string"))
 		}
-		userID, err := uuid.FromString(userIDString)
+		uid, err := uuid.FromString(userID)
 		if err != nil {
 			panic(r.NewTypeError("expects user ID to be a valid identifier"))
 		}
@@ -8097,7 +8098,7 @@ func (n *RuntimeJavascriptNakamaModule) groupUserLeave(r *goja.Runtime) func(goj
 			panic(r.NewTypeError("expects a username string"))
 		}
 
-		if err := LeaveGroup(n.ctx, n.logger, n.db, n.tracker, n.router, n.streamManager, groupID, userID, username); err != nil {
+		if err := LeaveGroup(n.ctx, n.logger, n.db, n.tracker, n.router, n.streamManager, gid, uid, username); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to leave group: %v", err.Error())))
 		}
 
@@ -8107,32 +8108,32 @@ func (n *RuntimeJavascriptNakamaModule) groupUserLeave(r *goja.Runtime) func(goj
 
 // @group groups
 // @summary Add users to a group.
-// @param groupIDString(type=string) The ID of the group to add users to.
-// @param userIDsIn(type=string[]) Table array of user IDs to add to this group.
-// @param callerIDString(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group to add users to.
+// @param userIDs(type=string[]) Table array of user IDs to add to this group.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersAdd(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		if groupIDString == "" {
+		groupID := getJsString(r, f.Argument(0))
+		if groupID == "" {
 			panic(r.NewTypeError("expects a group ID string"))
 		}
-		groupID, err := uuid.FromString(groupIDString)
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userIDsIn := f.Argument(1)
-		if goja.IsUndefined(userIDsIn) || goja.IsNull(userIDsIn) {
+		userIDs := f.Argument(1)
+		if goja.IsUndefined(userIDs) || goja.IsNull(userIDs) {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
-		userIDs, err := exportToSlice[[]string](userIDsIn)
+		userIDsArray, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of strings"))
 		}
 
-		uids := make([]uuid.UUID, 0, len(userIDs))
-		for _, id := range userIDs {
+		uids := make([]uuid.UUID, 0, len(userIDsArray))
+		for _, id := range userIDsArray {
 			uid, err := uuid.FromString(id)
 			if err != nil {
 				panic(r.NewTypeError("expects user id to be valid identifier"))
@@ -8142,21 +8143,21 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersAdd(r *goja.Runtime) func(goja
 			}
 			uids = append(uids, uid)
 		}
-		if len(userIDs) == 0 {
+		if len(userIDsArray) == 0 {
 			return goja.Undefined()
 		}
 
-		callerID := uuid.Nil
+		callerIDValue := uuid.Nil
 		if !goja.IsUndefined(f.Argument(2)) && !goja.IsNull(f.Argument(2)) {
-			callerIDString := getJsString(r, f.Argument(2))
-			cid, err := uuid.FromString(callerIDString)
+			callerID := getJsString(r, f.Argument(2))
+			cid, err := uuid.FromString(callerID)
 			if err != nil {
 				panic(r.NewTypeError("expects caller id to be valid identifier"))
 			}
-			callerID = cid
+			callerIDValue = cid
 		}
 
-		if err := AddGroupUsers(n.ctx, n.logger, n.db, n.tracker, n.router, callerID, groupID, uids); err != nil {
+		if err := AddGroupUsers(n.ctx, n.logger, n.db, n.tracker, n.router, callerIDValue, gid, uids); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to add users into group: %v", err.Error())))
 		}
 
@@ -8166,32 +8167,32 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersAdd(r *goja.Runtime) func(goja
 
 // @group groups
 // @summary Ban users from a group.
-// @param groupIDString(string) The ID of the group to ban users from.
-// @param userIDsIn(string[]) Table array of user IDs to ban from this group.
-// @param callerIDString(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(string) The ID of the group to ban users from.
+// @param userIDs(string[]) Table array of user IDs to ban from this group.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersBan(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		if groupIDString == "" {
+		groupID := getJsString(r, f.Argument(0))
+		if groupID == "" {
 			panic(r.NewTypeError("expects a group ID string"))
 		}
-		groupID, err := uuid.FromString(groupIDString)
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userIDsIn := f.Argument(1)
-		if goja.IsUndefined(userIDsIn) || goja.IsNull(userIDsIn) {
+		userIDs := f.Argument(1)
+		if goja.IsUndefined(userIDs) || goja.IsNull(userIDs) {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
-		userIDs, err := exportToSlice[[]string](userIDsIn)
+		userIDsArray, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
 
-		uids := make([]uuid.UUID, 0, len(userIDs))
-		for _, id := range userIDs {
+		uids := make([]uuid.UUID, 0, len(userIDsArray))
+		for _, id := range userIDsArray {
 			uid, err := uuid.FromString(id)
 			if err != nil {
 				panic(r.NewTypeError("expects user id to be valid identifier"))
@@ -8201,21 +8202,21 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersBan(r *goja.Runtime) func(goja
 			}
 			uids = append(uids, uid)
 		}
-		if len(userIDs) == 0 {
+		if len(userIDsArray) == 0 {
 			return goja.Undefined()
 		}
 
-		callerID := uuid.Nil
+		callerIDValue := uuid.Nil
 		if !goja.IsUndefined(f.Argument(2)) && !goja.IsNull(f.Argument(2)) {
-			callerIDString := getJsString(r, f.Argument(2))
-			cid, err := uuid.FromString(callerIDString)
+			callerID := getJsString(r, f.Argument(2))
+			cid, err := uuid.FromString(callerID)
 			if err != nil {
 				panic(r.NewTypeError("expects caller id to be valid identifier"))
 			}
-			callerID = cid
+			callerIDValue = cid
 		}
 
-		if err := BanGroupUsers(n.ctx, n.logger, n.db, n.tracker, n.router, n.streamManager, callerID, groupID, uids); err != nil {
+		if err := BanGroupUsers(n.ctx, n.logger, n.db, n.tracker, n.router, n.streamManager, callerIDValue, gid, uids); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to ban users from group: %v", err.Error())))
 		}
 
@@ -8225,32 +8226,32 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersBan(r *goja.Runtime) func(goja
 
 // @group groups
 // @summary Promote users in a group.
-// @param groupIDString(type=string) The ID of the group whose members are being promoted.
-// @param userIDsIn(type=string[]) Table array of user IDs to promote.
-// @param callerIDString(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group whose members are being promoted.
+// @param userIDs(type=string[]) Table array of user IDs to promote.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersPromote(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		if groupIDString == "" {
+		groupID := getJsString(r, f.Argument(0))
+		if groupID == "" {
 			panic(r.NewTypeError("expects a group ID string"))
 		}
-		groupID, err := uuid.FromString(groupIDString)
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userIDsIn := f.Argument(1)
-		if goja.IsUndefined(userIDsIn) || goja.IsNull(userIDsIn) {
+		userIDs := f.Argument(1)
+		if goja.IsUndefined(userIDs) || goja.IsNull(userIDs) {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
-		userIDs, err := exportToSlice[[]string](userIDsIn)
+		userIDsArray, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
 
-		uids := make([]uuid.UUID, 0, len(userIDs))
-		for _, id := range userIDs {
+		uids := make([]uuid.UUID, 0, len(userIDsArray))
+		for _, id := range userIDsArray {
 			uid, err := uuid.FromString(id)
 			if err != nil {
 				panic(r.NewTypeError("expects user id to be valid identifier"))
@@ -8260,21 +8261,21 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersPromote(r *goja.Runtime) func(
 			}
 			uids = append(uids, uid)
 		}
-		if len(userIDs) == 0 {
+		if len(userIDsArray) == 0 {
 			return goja.Undefined()
 		}
 
-		callerID := uuid.Nil
+		callerIDValue := uuid.Nil
 		if !goja.IsUndefined(f.Argument(2)) && !goja.IsNull(f.Argument(2)) {
-			callerIDString := getJsString(r, f.Argument(2))
-			cid, err := uuid.FromString(callerIDString)
+			callerID := getJsString(r, f.Argument(2))
+			cid, err := uuid.FromString(callerID)
 			if err != nil {
 				panic(r.NewTypeError("expects caller id to be valid identifier"))
 			}
-			callerID = cid
+			callerIDValue = cid
 		}
 
-		if err := PromoteGroupUsers(n.ctx, n.logger, n.db, n.router, callerID, groupID, uids); err != nil {
+		if err := PromoteGroupUsers(n.ctx, n.logger, n.db, n.router, callerIDValue, gid, uids); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to promote users in a group: %v", err.Error())))
 		}
 
@@ -8284,32 +8285,32 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersPromote(r *goja.Runtime) func(
 
 // @group groups
 // @summary Demote users in a group.
-// @param groupIDString(type=string) The ID of the group whose members are being demoted.
-// @param userIDsIn(type=string[]) Table array of user IDs to demote.
-// @param callerIDString(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
+// @param groupID(type=string) The ID of the group whose members are being demoted.
+// @param userIDs(type=string[]) Table array of user IDs to demote.
+// @param callerID(type=string, optional=true) User ID of the caller, will apply permissions checks of the user. If empty defaults to system user and permission checks are bypassed.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) groupUsersDemote(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		groupIDString := getJsString(r, f.Argument(0))
-		if groupIDString == "" {
+		groupID := getJsString(r, f.Argument(0))
+		if groupID == "" {
 			panic(r.NewTypeError("expects a group ID string"))
 		}
-		groupID, err := uuid.FromString(groupIDString)
+		gid, err := uuid.FromString(groupID)
 		if err != nil {
 			panic(r.NewTypeError("expects group ID to be a valid identifier"))
 		}
 
-		userIDsIn := f.Argument(1)
-		if goja.IsUndefined(userIDsIn) || goja.IsNull(userIDsIn) {
+		userIDs := f.Argument(1)
+		if goja.IsUndefined(userIDs) || goja.IsNull(userIDs) {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
-		userIDs, err := exportToSlice[[]string](userIDsIn)
+		userIDsArray, err := exportToSlice[[]string](userIDs)
 		if err != nil {
 			panic(r.NewTypeError("expects an array of user ids"))
 		}
 
-		uids := make([]uuid.UUID, 0, len(userIDs))
-		for _, id := range userIDs {
+		uids := make([]uuid.UUID, 0, len(userIDsArray))
+		for _, id := range userIDsArray {
 			uid, err := uuid.FromString(id)
 			if err != nil {
 				panic(r.NewTypeError("expects user id to be valid identifier"))
@@ -8319,21 +8320,21 @@ func (n *RuntimeJavascriptNakamaModule) groupUsersDemote(r *goja.Runtime) func(g
 			}
 			uids = append(uids, uid)
 		}
-		if len(userIDs) == 0 {
+		if len(userIDsArray) == 0 {
 			return goja.Undefined()
 		}
 
-		callerID := uuid.Nil
+		callerIDValue := uuid.Nil
 		if !goja.IsUndefined(f.Argument(2)) && !goja.IsNull(f.Argument(2)) {
-			callerIDString := getJsString(r, f.Argument(2))
-			cid, err := uuid.FromString(callerIDString)
+			callerID := getJsString(r, f.Argument(2))
+			cid, err := uuid.FromString(callerID)
 			if err != nil {
 				panic(r.NewTypeError("expects caller id to be valid identifier"))
 			}
-			callerID = cid
+			callerIDValue = cid
 		}
 
-		if err := DemoteGroupUsers(n.ctx, n.logger, n.db, n.router, callerID, groupID, uids); err != nil {
+		if err := DemoteGroupUsers(n.ctx, n.logger, n.db, n.router, callerIDValue, gid, uids); err != nil {
 			panic(r.NewGoError(fmt.Errorf("error while trying to demote users in a group: %v", err.Error())))
 		}
 
@@ -8556,8 +8557,8 @@ func (n *RuntimeJavascriptNakamaModule) localcacheClear(r *goja.Runtime) func(go
 // @group chat
 // @summary Send a message on a realtime chat channel.
 // @param channelId(type=string) The ID of the channel to send the message on.
-// @param contentMap(type=object) Message content.
-// @param senderIDString(type=string) The UUID for the sender of this message. If left empty, it will be assumed that it is a system message.
+// @param content(type=object) Message content.
+// @param senderID(type=string) The UUID for the sender of this message. If left empty, it will be assumed that it is a system message.
 // @param senderUsername(type=string) The username of the user to send this message as. If left empty, it will be assumed that it is a system message.
 // @param persist(type=bool, optional=true, default=true) Whether to record this message in the channel history.
 // @return channelMessageSend(nkruntime.ChannelMessageAck) Message sent ack containing the following variables: 'channelId', 'messageId', 'code', 'username', 'createTime', 'updateTime', and 'persistent'.
@@ -8568,11 +8569,11 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageSend(r *goja.Runtime) func
 
 		contentStr := "{}"
 		if f.Argument(1) != goja.Undefined() && f.Argument(1) != goja.Null() {
-			contentMap, ok := f.Argument(1).Export().(map[string]interface{})
+			content, ok := f.Argument(1).Export().(map[string]interface{})
 			if !ok {
 				panic(r.NewTypeError("expects content to be an object"))
 			}
-			contentBytes, err := json.Marshal(contentMap)
+			contentBytes, err := json.Marshal(content)
 			if err != nil {
 				panic(r.NewTypeError(fmt.Sprintf("error encoding content: %v", err.Error())))
 			}
@@ -8582,14 +8583,14 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageSend(r *goja.Runtime) func
 			contentStr = string(contentBytes)
 		}
 
-		senderId := uuid.Nil
+		sid := uuid.Nil
 		if !goja.IsUndefined(f.Argument(2)) && !goja.IsNull(f.Argument(2)) {
-			senderIDString := getJsString(r, f.Argument(2))
-			senderUUID, err := uuid.FromString(senderIDString)
+			senderID := getJsString(r, f.Argument(2))
+			senderUUID, err := uuid.FromString(senderID)
 			if err != nil {
 				panic(r.NewTypeError("expects sender id to be valid identifier"))
 			}
-			senderId = senderUUID
+			sid = senderUUID
 		}
 
 		var senderUsername string
@@ -8607,7 +8608,7 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageSend(r *goja.Runtime) func
 			panic(r.NewTypeError(err.Error()))
 		}
 
-		ack, err := ChannelMessageSend(n.ctx, n.logger, n.db, n.router, channelIdToStreamResult.Stream, channelId, contentStr, senderId.String(), senderUsername, persist)
+		ack, err := ChannelMessageSend(n.ctx, n.logger, n.db, n.router, channelIdToStreamResult.Stream, channelId, contentStr, sid.String(), senderUsername, persist)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to send channel message: %s", err.Error())))
 		}
@@ -8629,8 +8630,8 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageSend(r *goja.Runtime) func
 // @summary Update a message on a realtime chat channel.
 // @param channelId(type=string) The ID of the channel to send the message on.
 // @param messageId(type=string) The ID of the message to update.
-// @param contentMap(type=object) Message content.
-// @param senderIDString(type=string) The UUID for the sender of this message. If left empty, it will be assumed that it is a system message.
+// @param content(type=object) Message content.
+// @param senderID(type=string) The UUID for the sender of this message. If left empty, it will be assumed that it is a system message.
 // @param senderUsername(type=string) The username of the user to send this message as. If left empty, it will be assumed that it is a system message.
 // @param persist(type=bool, optional=true, default=true) Whether to record this message in the channel history.
 // @return channelMessageUpdate(nkruntime.ChannelMessageAck) Message updated ack containing the following variables: 'channelId', 'messageId', 'code', 'username', 'createTime', 'updateTime', and 'persistent'.
@@ -8646,11 +8647,11 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageUpdate(r *goja.Runtime) fu
 
 		contentStr := "{}"
 		if f.Argument(2) != goja.Undefined() && f.Argument(2) != goja.Null() {
-			contentMap, ok := f.Argument(2).Export().(map[string]interface{})
+			content, ok := f.Argument(2).Export().(map[string]interface{})
 			if !ok {
 				panic(r.NewTypeError("expects content to be an object"))
 			}
-			contentBytes, err := json.Marshal(contentMap)
+			contentBytes, err := json.Marshal(content)
 			if err != nil {
 				panic(r.NewTypeError(fmt.Sprintf("error encoding content: %v", err.Error())))
 			}
@@ -8660,14 +8661,14 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageUpdate(r *goja.Runtime) fu
 			contentStr = string(contentBytes)
 		}
 
-		senderID := uuid.Nil
+		sid := uuid.Nil
 		if !goja.IsUndefined(f.Argument(3)) && !goja.IsNull(f.Argument(3)) {
-			senderIDString := getJsString(r, f.Argument(3))
-			senderUUID, err := uuid.FromString(senderIDString)
+			senderID := getJsString(r, f.Argument(3))
+			senderUUID, err := uuid.FromString(senderID)
 			if err != nil {
 				panic(r.NewTypeError("expects sender id to be valid identifier"))
 			}
-			senderID = senderUUID
+			sid = senderUUID
 		}
 
 		var senderUsername string
@@ -8685,7 +8686,7 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageUpdate(r *goja.Runtime) fu
 			panic(r.NewTypeError(err.Error()))
 		}
 
-		ack, err := ChannelMessageUpdate(n.ctx, n.logger, n.db, n.router, channelIdToStreamResult.Stream, channelId, messageId, contentStr, senderID.String(), senderUsername, persist)
+		ack, err := ChannelMessageUpdate(n.ctx, n.logger, n.db, n.router, channelIdToStreamResult.Stream, channelId, messageId, contentStr, sid.String(), senderUsername, persist)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to update channel message: %s", err.Error())))
 		}
@@ -8707,7 +8708,7 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageUpdate(r *goja.Runtime) fu
 // @summary Remove a message on a realtime chat channel.
 // @param channelID(type=string) The ID of the channel to send the message on.
 // @param messageID(type=string) The ID of the message to remove.
-// @param senderIDString(type=string) The UUID for the sender of this message. If left empty, it will be assumed that it is a system message.
+// @param senderID(type=string) The UUID for the sender of this message. If left empty, it will be assumed that it is a system message.
 // @param senderUsername(type=string) The username of the user to send this message as. If left empty, it will be assumed that it is a system message.
 // @param persist(type=bool, optional=true, default=true) Whether to record this message in the channel history.
 // @return channelMessageRemove(nkruntime.ChannelMessageAck) Message removed ack containing the following variables: 'channelId', 'messageId', 'code', 'username', 'createTime', 'updateTime', and 'persistent'.
@@ -8721,14 +8722,14 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageRemove(r *goja.Runtime) fu
 			panic(r.NewTypeError(errChannelMessageIdInvalid.Error()))
 		}
 
-		senderID := uuid.Nil
+		sid := uuid.Nil
 		if !goja.IsUndefined(f.Argument(2)) && !goja.IsNull(f.Argument(2)) {
-			senderIDString := getJsString(r, f.Argument(2))
-			senderUUID, err := uuid.FromString(senderIDString)
+			senderID := getJsString(r, f.Argument(2))
+			senderUUID, err := uuid.FromString(senderID)
 			if err != nil {
 				panic(r.NewTypeError("expects sender id to be valid identifier"))
 			}
-			senderID = senderUUID
+			sid = senderUUID
 		}
 
 		var senderUsername string
@@ -8746,7 +8747,7 @@ func (n *RuntimeJavascriptNakamaModule) channelMessageRemove(r *goja.Runtime) fu
 			panic(r.NewTypeError(err.Error()))
 		}
 
-		ack, err := ChannelMessageRemove(n.ctx, n.logger, n.db, n.router, channelIdToStreamResult.Stream, channelID, messageID, senderID.String(), senderUsername, persist)
+		ack, err := ChannelMessageRemove(n.ctx, n.logger, n.db, n.router, channelIdToStreamResult.Stream, channelID, messageID, sid.String(), senderUsername, persist)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to remove channel message: %s", err.Error())))
 		}
@@ -8835,22 +8836,22 @@ func (n *RuntimeJavascriptNakamaModule) channelMessagesList(r *goja.Runtime) fun
 
 // @group chat
 // @summary Create a channel identifier to be used in other runtime calls. Does not create a channel.
-// @param senderIDIn(type=string) UserID of the message sender (when applicable). Defaults to the system user if void.
+// @param senderID(type=string) UserID of the message sender (when applicable). Defaults to the system user if void.
 // @param target(type=string) Can be the room name, group identifier, or another username.
 // @param chanType(type=nkruntime.ChannelType) The type of channel, either Room (1), Direct (2), or Group (3).
-// @return channelId(string) The generated ID representing a channel.
+// @return channelID(string) The generated ID representing a channel.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) channelIdBuild(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		senderID := uuid.Nil
-		senderIDIn := f.Argument(0)
-		if senderIDIn != goja.Undefined() && senderIDIn != goja.Null() {
-			senderIDStr := getJsString(r, senderIDIn)
+		sid := uuid.Nil
+		senderID := f.Argument(0)
+		if senderID != goja.Undefined() && senderID != goja.Null() {
+			senderIDStr := getJsString(r, senderID)
 			senderUUID, err := uuid.FromString(senderIDStr)
 			if err != nil {
 				panic(r.NewTypeError("expects sender id to be valid identifier"))
 			}
-			senderID = senderUUID
+			sid = senderUUID
 		}
 
 		target := getJsString(r, f.Argument(1))
@@ -8860,7 +8861,7 @@ func (n *RuntimeJavascriptNakamaModule) channelIdBuild(r *goja.Runtime) func(goj
 			panic(r.NewTypeError("invalid channel type: expects value 1-3"))
 		}
 
-		channelId, _, err := BuildChannelId(n.ctx, n.logger, n.db, senderID, target, rtapi.ChannelJoin_Type(chanType))
+		channelId, _, err := BuildChannelId(n.ctx, n.logger, n.db, sid, target, rtapi.ChannelJoin_Type(chanType))
 		if err != nil {
 			if errors.Is(err, runtime.ErrInvalidChannelTarget) || errors.Is(err, runtime.ErrInvalidChannelType) {
 				panic(r.NewTypeError(err.Error()))
@@ -9030,21 +9031,21 @@ func (n *RuntimeJavascriptNakamaModule) satoriPropertiesUpdate(r *goja.Runtime) 
 // @group satori
 // @summary Publish an event.
 // @param identifier(type=string) The identifier of the identity.
-// @param eventsIn(type=nkruntime.Event[]) An array of events to publish.
+// @param events(type=nkruntime.Event[]) An array of events to publish.
 // @param ip(type=string, optional=true, default="") An optional client IP address to pass on to Satori for geo-IP lookup.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) satoriPublishEvents(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		identifier := getJsString(r, f.Argument(0))
 
-		eventsIn := f.Argument(1)
-		events, err := exportToSlice[[]map[string]any](eventsIn)
+		events := f.Argument(1)
+		eventsArray, err := exportToSlice[[]map[string]any](events)
 		if err != nil {
 			panic(r.NewTypeError("expects array of event objects"))
 		}
 
-		evts := make([]*runtime.Event, 0, len(events))
-		for _, eMap := range events {
+		evts := make([]*runtime.Event, 0, len(eventsArray))
+		for _, eMap := range eventsArray {
 			evt := &runtime.Event{}
 
 			name, ok := eMap["name"]
@@ -9111,24 +9112,24 @@ func (n *RuntimeJavascriptNakamaModule) satoriPublishEvents(r *goja.Runtime) fun
 // @group satori
 // @summary List experiments.
 // @param identifier(type=string) The identifier of the identity.
-// @param nameFiltersIn(type=string[], optional=true, default=[]) Optional list of experiment names to filter.
+// @param nameFilters(type=string[], optional=true, default=[]) Optional list of experiment names to filter.
 // @return experiments(*nkruntime.Experiment[]) The experiment list.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) satoriExperimentsList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		identifier := getJsString(r, f.Argument(0))
 
-		nameFilters := make([]string, 0)
-		nameFiltersIn := f.Argument(1)
-		if !goja.IsUndefined(nameFiltersIn) && !goja.IsNull(nameFiltersIn) {
+		nameFiltersArray := make([]string, 0)
+		nameFilters := f.Argument(1)
+		if !goja.IsUndefined(nameFilters) && !goja.IsNull(nameFilters) {
 			var err error
-			nameFilters, err = exportToSlice[[]string](nameFiltersIn)
+			nameFiltersArray, err = exportToSlice[[]string](nameFilters)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
 		}
 
-		experimentList, err := n.satori.ExperimentsList(n.ctx, identifier, nameFilters...)
+		experimentList, err := n.satori.ExperimentsList(n.ctx, identifier, nameFiltersArray...)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to list satori experiments: %s", err.Error())))
 		}
@@ -9150,24 +9151,24 @@ func (n *RuntimeJavascriptNakamaModule) satoriExperimentsList(r *goja.Runtime) f
 // @group satori
 // @summary List flags.
 // @param identifier(type=string) The identifier of the identity. Set to empty string to fetch all default flag values.
-// @param nameFiltersIn(type=string[], optional=true, default=[]) Optional list of flag names to filter.
+// @param nameFilters(type=string[], optional=true, default=[]) Optional list of flag names to filter.
 // @return flags(*nkruntime.Flag[]) The flag list.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) satoriFlagsList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		identifier := getJsString(r, f.Argument(0))
 
-		nameFilters := make([]string, 0)
-		nameFiltersIn := f.Argument(1)
-		if !goja.IsUndefined(nameFiltersIn) && !goja.IsNull(nameFiltersIn) {
+		nameFiltersArray := make([]string, 0)
+		nameFilters := f.Argument(1)
+		if !goja.IsUndefined(nameFilters) && !goja.IsNull(nameFilters) {
 			var err error
-			nameFilters, err = exportToSlice[[]string](nameFiltersIn)
+			nameFiltersArray, err = exportToSlice[[]string](nameFilters)
 			if err != nil {
 				panic(r.NewTypeError("expect array of strings"))
 			}
 		}
 
-		flagsList, err := n.satori.FlagsList(n.ctx, identifier, nameFilters...)
+		flagsList, err := n.satori.FlagsList(n.ctx, identifier, nameFiltersArray...)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to list satori flags: %s", err.Error())))
 		}
@@ -9190,24 +9191,24 @@ func (n *RuntimeJavascriptNakamaModule) satoriFlagsList(r *goja.Runtime) func(go
 // @group satori
 // @summary List live events.
 // @param identifier(type=string) The identifier of the identity.
-// @param nameFiltersIn(type=string[], optional=true, default=[]) Optional list of live event names to filter.
+// @param nameFilters(type=string[], optional=true, default=[]) Optional list of live event names to filter.
 // @return liveEvents(*nkruntime.LiveEvent[]) The live event list.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) satoriLiveEventsList(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		identifier := getJsString(r, f.Argument(0))
 
-		nameFilters := make([]string, 0)
-		nameFiltersIn := f.Argument(1)
-		if !goja.IsUndefined(nameFiltersIn) && !goja.IsNull(nameFiltersIn) {
+		nameFiltersArray := make([]string, 0)
+		nameFilters := f.Argument(1)
+		if !goja.IsUndefined(nameFilters) && !goja.IsNull(nameFilters) {
 			var err error
-			nameFilters, err = exportToSlice[[]string](nameFiltersIn)
+			nameFiltersArray, err = exportToSlice[[]string](nameFilters)
 			if err != nil {
 				panic(r.NewTypeError("expects an array of strings"))
 			}
 		}
 
-		liveEventsList, err := n.satori.LiveEventsList(n.ctx, identifier, nameFilters...)
+		liveEventsList, err := n.satori.LiveEventsList(n.ctx, identifier, nameFiltersArray...)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to list satori live-events %s:", err.Error())))
 		}
@@ -9301,7 +9302,7 @@ func (n *RuntimeJavascriptNakamaModule) satoriMessagesList(r *goja.Runtime) func
 // @group satori
 // @summary Update message.
 // @param identifier(type=string) The identifier of the identity.
-// @param messageId(type=string) The id of the message.
+// @param messageID(type=string) The id of the message.
 // @param readTime(type=int) The time the message was read at the client.
 // @param consumeTime(type=int, optiona=true, default=0) The time the message was consumed by the identity.
 // @return error(error) An optional error value if an error occurred.
@@ -9309,7 +9310,7 @@ func (n *RuntimeJavascriptNakamaModule) satoriMessageUpdate(r *goja.Runtime) fun
 	return func(f goja.FunctionCall) goja.Value {
 		identifier := getJsString(r, f.Argument(0))
 
-		messageId := getJsString(r, f.Argument(1))
+		messageID := getJsString(r, f.Argument(1))
 
 		readTime := getJsInt(r, f.Argument(2))
 
@@ -9318,7 +9319,7 @@ func (n *RuntimeJavascriptNakamaModule) satoriMessageUpdate(r *goja.Runtime) fun
 			consumeTime = getJsInt(r, f.Argument(3))
 		}
 
-		if err := n.satori.MessageUpdate(n.ctx, identifier, messageId, readTime, consumeTime); err != nil {
+		if err := n.satori.MessageUpdate(n.ctx, identifier, messageID, readTime, consumeTime); err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to update satori message %s:", err.Error())))
 		}
 
@@ -9329,15 +9330,15 @@ func (n *RuntimeJavascriptNakamaModule) satoriMessageUpdate(r *goja.Runtime) fun
 // @group satori
 // @summary Delete message.
 // @param identifier(type=string) The identifier of the identity.
-// @param messageId(type=string) The identifier of the message.
+// @param messageID(type=string) The identifier of the message.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) satoriMessageDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
 		identifier := getJsString(r, f.Argument(0))
 
-		messageId := getJsString(r, f.Argument(1))
+		messageID := getJsString(r, f.Argument(1))
 
-		if err := n.satori.MessageDelete(n.ctx, identifier, messageId); err != nil {
+		if err := n.satori.MessageDelete(n.ctx, identifier, messageID); err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to delete satori message %s:", err.Error())))
 		}
 


### PR DESCRIPTION
- Updated casing/variable names to have annotations match code for the parser.
- Added missing annotations found along the way
- Left some as they were, even though they are causing parser warnings. The parser should be updated to deal with edge cases in the future (for lua and typescript)