### PR TITLE
NK-646 Encode cursors in a url safe way.

### DIFF
--- a/server/api_tournament.go
+++ b/server/api_tournament.go
@@ -241,7 +241,7 @@ func (s *ApiServer) ListTournaments(ctx context.Context, in *api.ListTournaments
 	var incomingCursor *TournamentListCursor
 
 	if in.GetCursor() != "" {
-		cb, err := base64.StdEncoding.DecodeString(in.GetCursor())
+		cb, err := base64.URLEncoding.DecodeString(in.GetCursor())
 		if err != nil {
 			return nil, ErrLeaderboardInvalidCursor
 		}

--- a/server/core_channel.go
+++ b/server/core_channel.go
@@ -64,7 +64,11 @@ func ChannelMessagesList(ctx context.Context, logger *zap.Logger, db *sql.DB, ca
 	if cursor != "" {
 		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
-			return nil, runtime.ErrChannelCursorInvalid
+			// Attempt to decode with StdEncoding for backwards compatibility.
+			cb, err = base64.StdEncoding.DecodeString(cursor)
+			if err != nil {
+				return nil, runtime.ErrChannelCursorInvalid
+			}
 		}
 		incomingCursor = &channelMessageListCursor{}
 		if err := gob.NewDecoder(bytes.NewReader(cb)).Decode(incomingCursor); err != nil {

--- a/server/core_friend.go
+++ b/server/core_friend.go
@@ -188,7 +188,7 @@ FROM users, user_edge WHERE id = destination_id AND source_id = $1 AND destinati
 func ListFriends(ctx context.Context, logger *zap.Logger, db *sql.DB, statusRegistry StatusRegistry, userID uuid.UUID, limit int, state *wrapperspb.Int32Value, cursor string) (*api.FriendList, error) {
 	var incomingCursor *edgeListCursor
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			return nil, runtime.ErrFriendInvalidCursor
 		}
@@ -275,7 +275,7 @@ FROM users, user_edge WHERE id = destination_id AND source_id = $1`
 				logger.Error("Error creating friend list cursor", zap.Error(err))
 				return nil, err
 			}
-			outgoingCursor = base64.StdEncoding.EncodeToString(cursorBuf.Bytes())
+			outgoingCursor = base64.URLEncoding.EncodeToString(cursorBuf.Bytes())
 			break
 		}
 
@@ -328,7 +328,7 @@ type friendsOfFriendsListCursor struct {
 func ListFriendsOfFriends(ctx context.Context, logger *zap.Logger, db *sql.DB, statusRegistry StatusRegistry, userID uuid.UUID, limit int, cursor string) (*api.FriendsOfFriendsList, error) {
 	var incomingCursor *friendsOfFriendsListCursor
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			return nil, runtime.ErrFriendInvalidCursor
 		}
@@ -424,7 +424,7 @@ AND state = 0
 					logger.Error("Error creating friends of friends list cursor", zap.Error(err))
 					return nil, err
 				}
-				outgoingCursor = base64.StdEncoding.EncodeToString(cursorBuf.Bytes())
+				outgoingCursor = base64.URLEncoding.EncodeToString(cursorBuf.Bytes())
 				break friendLoop
 			}
 

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -1387,7 +1387,7 @@ VALUES ($1, $2, $3, $4, $5, $6::UUID, $7::UUID, $8, $9, $10, $10)`
 func ListGroupUsers(ctx context.Context, logger *zap.Logger, db *sql.DB, statusRegistry StatusRegistry, groupID uuid.UUID, limit int, state *wrapperspb.Int32Value, cursor string) (*api.GroupUserList, error) {
 	var incomingCursor *edgeListCursor
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			return nil, runtime.ErrGroupUserInvalidCursor
 		}
@@ -1484,7 +1484,7 @@ WHERE u.id = ge.destination_id AND ge.source_id = $1`
 				logger.Error("Error creating group user list cursor", zap.Error(err))
 				return nil, err
 			}
-			outgoingCursor = base64.StdEncoding.EncodeToString(cursorBuf.Bytes())
+			outgoingCursor = base64.URLEncoding.EncodeToString(cursorBuf.Bytes())
 			break
 		}
 
@@ -1529,7 +1529,7 @@ WHERE u.id = ge.destination_id AND ge.source_id = $1`
 func ListUserGroups(ctx context.Context, logger *zap.Logger, db *sql.DB, userID uuid.UUID, limit int, state *wrapperspb.Int32Value, cursor string) (*api.UserGroupList, error) {
 	var incomingCursor *edgeListCursor
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			return nil, runtime.ErrUserGroupInvalidCursor
 		}
@@ -1618,7 +1618,7 @@ WHERE g.id = ge.destination_id AND ge.source_id = $1`
 				logger.Error("Error creating group user list cursor", zap.Error(err))
 				return nil, err
 			}
-			outgoingCursor = base64.StdEncoding.EncodeToString(cursorBuf.Bytes())
+			outgoingCursor = base64.URLEncoding.EncodeToString(cursorBuf.Bytes())
 			break
 		}
 

--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -116,7 +116,7 @@ func LeaderboardList(logger *zap.Logger, leaderboardCache LeaderboardCache, limi
 			logger.Error("Error creating leaderboard records list cursor", zap.Error(err))
 			return nil, err
 		}
-		leaderboardList.Cursor = base64.StdEncoding.EncodeToString(cursorBuf.Bytes())
+		leaderboardList.Cursor = base64.URLEncoding.EncodeToString(cursorBuf.Bytes())
 	}
 
 	return leaderboardList, nil

--- a/server/core_tournament.go
+++ b/server/core_tournament.go
@@ -385,7 +385,7 @@ func TournamentList(ctx context.Context, logger *zap.Logger, db *sql.DB, leaderb
 			logger.Error("Error creating tournament records list cursor", zap.Error(err))
 			return nil, err
 		}
-		tournamentList.Cursor = base64.StdEncoding.EncodeToString(cursorBuf.Bytes())
+		tournamentList.Cursor = base64.URLEncoding.EncodeToString(cursorBuf.Bytes())
 	}
 
 	return tournamentList, nil

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -2541,7 +2541,7 @@ func (n *RuntimeGoNakamaModule) LeaderboardList(limit int, cursor string) (*api.
 
 	var cursorPtr *LeaderboardListCursor
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			return nil, errors.New("expects cursor to be valid when provided")
 		}
@@ -2975,7 +2975,7 @@ func (n *RuntimeGoNakamaModule) TournamentList(ctx context.Context, categoryStar
 
 	var cursorPtr *TournamentListCursor
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			return nil, errors.New("expects cursor to be valid when provided")
 		}

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -5548,7 +5548,7 @@ func (n *RuntimeJavascriptNakamaModule) leaderboardList(r *goja.Runtime) func(go
 		var cursorValue *LeaderboardListCursor
 		if f.Argument(1) != goja.Undefined() && f.Argument(1) != goja.Null() {
 			cursor := getJsString(r, f.Argument(1))
-			cb, err := base64.StdEncoding.DecodeString(cursor)
+			cb, err := base64.URLEncoding.DecodeString(cursor)
 			if err != nil {
 				panic(r.NewTypeError("expects cursor to be valid when provided"))
 			}
@@ -6869,7 +6869,7 @@ func (n *RuntimeJavascriptNakamaModule) tournamentList(r *goja.Runtime) func(goj
 		var cursorValue *TournamentListCursor
 		if f.Argument(5) != goja.Undefined() && f.Argument(5) != goja.Null() {
 			cursor := getJsString(r, f.Argument(5))
-			cb, err := base64.StdEncoding.DecodeString(cursor)
+			cb, err := base64.URLEncoding.DecodeString(cursor)
 			if err != nil {
 				panic(r.NewTypeError("expects cursor to be valid when provided"))
 			}

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -7236,7 +7236,7 @@ func (n *RuntimeLuaNakamaModule) leaderboardList(l *lua.LState) int {
 	var listCursor *LeaderboardListCursor
 	cursor := l.OptString(2, "")
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			l.ArgError(2, "expects cursor to be valid when provided")
 			return 0
@@ -8631,7 +8631,7 @@ func (n *RuntimeLuaNakamaModule) tournamentList(l *lua.LState) int {
 	var listCursor *TournamentListCursor
 	cursor := l.OptString(6, "")
 	if cursor != "" {
-		cb, err := base64.StdEncoding.DecodeString(cursor)
+		cb, err := base64.URLEncoding.DecodeString(cursor)
 		if err != nil {
 			l.ArgError(6, "expects cursor to be valid when provided")
 			return 0


### PR DESCRIPTION
Ensure that all cursors that we accept via url params use url-safe encoding to prevent decoding issues.