### PR TITLE
Fix subscription event handling panic

### DIFF
--- a/server/core_subscription.go
+++ b/server/core_subscription.go
@@ -859,7 +859,9 @@ func appleNotificationHandler(logger *zap.Logger, db *sql.DB, purchaseNotificati
 					w.WriteHeader(http.StatusInternalServerError) // Return error to keep retrying.
 					return
 				}
-				uid = uuid.Must(uuid.FromString(s.UserId))
+				if s.UserId != "" {
+					uid = uuid.Must(uuid.FromString(s.UserId))
+				}
 			}
 
 			sub := &storageSubscription{


### PR DESCRIPTION
Correctly handle uid lookup for incoming Apple subscription event pertaining to a subscription of a deleted account.