### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/gopher-lua/state.go
+++ b/internal/gopher-lua/state.go
@@ -386,10 +386,8 @@ func (rg *registry) checkSize(requiredSize int) { // +inline-start
 } // +inline-end
 
 func (rg *registry) resize(requiredSize int) { // +inline-start
-	newSize := requiredSize + rg.growBy // give some padding
-	if newSize > rg.maxSize {
-		newSize = rg.maxSize
-	}
+	// give some padding
+	newSize := min(requiredSize+rg.growBy, rg.maxSize)
 	if newSize < requiredSize {
 		rg.handler.registryOverflow()
 		return
@@ -1037,10 +1035,7 @@ func (ls *LState) initCallFrame(cf *callFrame) { // +inline-start
 					   namedparam1 <- lbase
 					   namedparam2
 			*/
-			nvarargs := nargs - np
-			if nvarargs < 0 {
-				nvarargs = 0
-			}
+			nvarargs := max(nargs-np, 0)
 
 			ls.reg.SetTop(cf.LocalBase + nargs + np)
 			for i := 0; i < np; i++ {
@@ -1149,10 +1144,7 @@ func (ls *LState) pushCallFrame(cf callFrame, fn LValue, meta bool) { // +inline
 						   namedparam1 <- lbase
 						   namedparam2
 				*/
-				nvarargs := nargs - np
-				if nvarargs < 0 {
-					nvarargs = 0
-				}
+				nvarargs := max(nargs-np, 0)
 
 				ls.reg.SetTop(cf.LocalBase + nargs + np)
 				for i := 0; i < np; i++ {

--- a/internal/gopher-lua/vm.go
+++ b/internal/gopher-lua/vm.go
@@ -783,10 +783,7 @@ func init() {
 									   namedparam1 <- lbase
 									   namedparam2
 							*/
-							nvarargs := nargs - np
-							if nvarargs < 0 {
-								nvarargs = 0
-							}
+							nvarargs := max(nargs-np, 0)
 
 							ls.reg.SetTop(cf.LocalBase + nargs + np)
 							for i := 0; i < np; i++ {
@@ -965,10 +962,7 @@ func init() {
 									   namedparam1 <- lbase
 									   namedparam2
 							*/
-							nvarargs := nargs - np
-							if nvarargs < 0 {
-								nvarargs = 0
-							}
+							nvarargs := max(nargs-np, 0)
 
 							ls.reg.SetTop(cf.LocalBase + nargs + np)
 							for i := 0; i < np; i++ {
@@ -1452,10 +1446,7 @@ func init() {
 			RA := lbase + A
 			B := int(inst & 0x1ff) //GETB
 			nparams := int(cf.Fn.Proto.NumParameters)
-			nvarargs := cf.NArgs - nparams
-			if nvarargs < 0 {
-				nvarargs = 0
-			}
+			nvarargs := max(cf.NArgs-nparams, 0)
 			nwant := B - 1
 			if B == 0 {
 				nwant = nvarargs

--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -846,10 +846,7 @@ func getLeaderboardRecordsHaystack(ctx context.Context, logger *zap.Logger, db *
 		if start < 0 || len(firstRecords) < secondLimit {
 			start = 0
 		}
-		end := start + limit
-		if end > numRecords {
-			end = numRecords
-		}
+		end := min(start+limit, numRecords)
 
 		if start > 0 {
 			// There was a previous result that was discarded, the prev_cursor should be set.


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.