### PR TITLE
fix Tournament reset calculation bug in non-UTC environment

### DIFF
--- a/server/core_tournament.go
+++ b/server/core_tournament.go
@@ -721,11 +721,11 @@ func calculateTournamentDeadlines(startTime, endTime, duration int64, resetSched
 			startActiveUnix = resetSchedule.Next(time.Unix(startTime, 0).UTC()).UTC().Unix()
 		} else {
 			// check if we are landing squarely on the reset schedule
-			landsOnSched := resetSchedule.Next(t.Add(-1*time.Second)).Unix() == t.Unix()
+			landsOnSched := resetSchedule.Next(t.UTC().Add(-1*time.Second)).Unix() == t.Unix()
 			if landsOnSched {
 				startActiveUnix = tUnix
 			} else {
-				startActiveUnix = resetSchedule.Last(t).UTC().Unix()
+				startActiveUnix = resetSchedule.Last(t.UTC()).UTC().Unix()
 			}
 		}
 


### PR DESCRIPTION
let's say in a StartTime = 0, EndTime = 0, Duration = 604800, cron = “0 0 * * 1“ settings, it will not correctly making the startActiveUnix and endActiveUnix as 1 week apart. After some investigation I found the calculation logic in the core_tournament.go’s calculateTournamentDeadlines() function forgot to add .UTC() in two places.

Adding the two missing .UTC() to time.Time in the calculateTournamentDeadlines() fix this issue.