### PR TITLE
Fix docs for get friends list.

### DIFF
--- a/apigrpc/apigrpc.swagger.json
+++ b/apigrpc/apigrpc.swagger.json
@@ -1404,7 +1404,7 @@
         "parameters": [
           {
             "name": "limit",
-            "description": "Max number of records to return. Between 1 and 100.",
+            "description": "Max number of records to return. Between 1 and 1000.",
             "in": "query",
             "required": false,
             "type": "integer",


### PR DESCRIPTION
Server header and implementation point to a 1000 limit, but docs mention 100.