### PR TITLE
Fix wrong error in ListSubscriptions cursor validation

### DIFF
--- a/server/core_subscription.go
+++ b/server/core_subscription.go
@@ -72,10 +72,10 @@ func ListSubscriptions(ctx context.Context, logger *zap.Logger, db *sql.DB, user
 			return nil, ErrSubscriptionsListInvalidCursor
 		}
 		if !after.Equal(incomingCursor.After) {
-			return nil, ErrPurchasesListInvalidCursor
+			return nil, ErrSubscriptionsListInvalidCursor
 		}
 		if !before.Equal(incomingCursor.Before) {
-			return nil, ErrPurchasesListInvalidCursor
+			return nil, ErrSubscriptionsListInvalidCursor
 		}
 	}
 


### PR DESCRIPTION
`ListSubscriptions` returned `ErrPurchasesListInvalidCursor` instead of `ErrSubscriptionsListInvalidCursor` when the after or before time filters didn't match the cursor values.

It's most likely a copy paste issue since Purchase has the same check. 