### PR TITLE
Update Satori event client with explicit client IP for geo-IP control

### DIFF
--- a/internal/satori/satori.go
+++ b/internal/satori/satori.go
@@ -600,8 +600,6 @@ func (s *SatoriClient) ServerEventsPublish(ctx context.Context, events []*runtim
 		if ipAddr := net.ParseIP(ipAddress[0]); ipAddr != nil {
 			req.Header.Set("X-Client-IP", ipAddr.String())
 		}
-	} else if ipAddr, ok := ctx.Value(runtime.RUNTIME_CTX_CLIENT_IP).(string); ok {
-		req.Header.Set("X-Forwarded-For", ipAddr)
 	}
 
 	res, err := s.httpc.Do(req)

--- a/internal/satori/satori.go
+++ b/internal/satori/satori.go
@@ -540,7 +540,7 @@ func (s *SatoriClient) EventsPublish(ctx context.Context, id string, events []*r
 			req.Header.Set("X-Client-IP", "none")
 		}
 	} else if ipAddr, ok := ctx.Value(runtime.RUNTIME_CTX_CLIENT_IP).(string); ok {
-		req.Header.Set("X-Forwarded-For", ipAddr)
+		req.Header.Set("X-Client-IP", ipAddr)
 	}
 
 	res, err := s.httpc.Do(req)

--- a/internal/satori/satori.go
+++ b/internal/satori/satori.go
@@ -500,7 +500,7 @@ func (e *event) setTimestamp() {
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param id(type=string) The identifier of the identity.
 // @param events(type=[]*runtime.Event) An array of events to publish.
-// @param ipAddress(type=string, optional=true, default="") An optional client IP address to pass on to Satori for geo-IP lookup.
+// @param ipAddress(type=string, optional=true, default="") An optional client IP address to pass on to Satori for geo-IP lookup. Pass "none" to disable geo-IP lookup.
 // @return error(error) An optional error value if an error occurred.
 func (s *SatoriClient) EventsPublish(ctx context.Context, id string, events []*runtime.Event, ipAddress ...string) error {
 	if s.invalidConfig {
@@ -535,7 +535,9 @@ func (s *SatoriClient) EventsPublish(ctx context.Context, id string, events []*r
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", sessionToken))
 	if len(ipAddress) > 0 && ipAddress[0] != "" {
 		if ipAddr := net.ParseIP(ipAddress[0]); ipAddr != nil {
-			req.Header.Set("X-Forwarded-For", ipAddr.String())
+			req.Header.Set("X-Client-IP", ipAddr.String())
+		} else if ipAddress[0] == "none" {
+			req.Header.Set("X-Client-IP", "none")
 		}
 	} else if ipAddr, ok := ctx.Value(runtime.RUNTIME_CTX_CLIENT_IP).(string); ok {
 		req.Header.Set("X-Forwarded-For", ipAddr)
@@ -596,7 +598,7 @@ func (s *SatoriClient) ServerEventsPublish(ctx context.Context, events []*runtim
 
 	if len(ipAddress) > 0 && ipAddress[0] != "" {
 		if ipAddr := net.ParseIP(ipAddress[0]); ipAddr != nil {
-			req.Header.Set("X-Forwarded-For", ipAddr.String())
+			req.Header.Set("X-Client-IP", ipAddr.String())
 		}
 	} else if ipAddr, ok := ctx.Value(runtime.RUNTIME_CTX_CLIENT_IP).(string); ok {
 		req.Header.Set("X-Forwarded-For", ipAddr)

--- a/internal/satori/satori.go
+++ b/internal/satori/satori.go
@@ -289,10 +289,10 @@ func (s *SatoriClient) Authenticate(ctx context.Context, id string, defaultPrope
 	req.SetBasicAuth(s.apiKey, "")
 	if len(ipAddress) > 0 && ipAddress[0] != "" {
 		if ipAddr := net.ParseIP(ipAddress[0]); ipAddr != nil {
-			req.Header.Set("X-Forwarded-For", ipAddr.String())
+			req.Header.Set("X-Client-IP", ipAddr.String())
 		}
 	} else if ipAddr, ok := ctx.Value(runtime.RUNTIME_CTX_CLIENT_IP).(string); ok {
-		req.Header.Set("X-Forwarded-For", ipAddr)
+		req.Header.Set("X-Client-IP", ipAddr)
 	}
 
 	res, err := s.httpc.Do(req)


### PR DESCRIPTION
Transitioned from `X-Forwarded-For` to `X-Client-IP` header when forwarding the client's IP address. This ensures that Satori can observe it is an explicit override, which will be required for geolocation in `ServerEvent` calls. It also makes the integration less dependent on how intermediate Satori infrastructure might interact with the `X-Forwarded-For` header.