### PR TITLE
Prevent Lua/JS storage index filter deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com) and this project uses [semantic versioning](http://semver.org).
 
 ## [Unreleased]
+### Fixed
+- Fix a possible deadlock when Lua/JS runtimes storage index filters are used.
 
 ## [3.38.0] - 2026-03-20
 ### Added

--- a/server/runtime_javascript.go
+++ b/server/runtime_javascript.go
@@ -45,6 +45,8 @@ import (
 
 const JsEntrypointFilename = "index.js"
 
+type ctxJsRuntimeKey struct{}
+
 type RuntimeJS struct {
 	logger       *zap.Logger
 	node         string
@@ -206,6 +208,7 @@ func (rp *RuntimeProviderJS) Rpc(ctx context.Context, id string, headers, queryP
 	}
 
 	ctx = NewRuntimeGoContext(ctx, r.node, r.version, r.envMap, RuntimeExecutionModeRPC, headers, queryParams, traceID, expiry, userID, username, vars, sessionID, clientIP, clientPort, lang)
+	ctx = context.WithValue(ctx, ctxJsRuntimeKey{}, r)
 	r.SetContext(ctx)
 	retValue, err, code := r.InvokeFunction(RuntimeExecutionModeRPC, id, fn, jsLogger, headers, queryParams, traceID, userID, username, vars, expiry, sessionID, clientIP, clientPort, lang, payload)
 	r.SetContext(context.Background())
@@ -2366,10 +2369,19 @@ func (rp *RuntimeProviderJS) SubscriptionNotificationGoogle(ctx context.Context,
 }
 
 func (rp *RuntimeProviderJS) StorageIndexFilter(ctx context.Context, indexName string, storageWrite *StorageOpWrite) (bool, error) {
-	r, err := rp.Get(ctx)
-	if err != nil {
-		return false, err
+	var r *RuntimeJS
+	var err error
+	if ctxVm := ctx.Value(ctxJsRuntimeKey{}); ctxVm != nil {
+		// Reuse previously checked out runtime if executed in the context of an RPC
+		r = ctxVm.(*RuntimeJS)
+	} else {
+		r, err = rp.Get(ctx)
+		if err != nil {
+			return false, err
+		}
+		defer rp.Put(r)
 	}
+
 	jsFn := r.GetCallback(RuntimeExecutionModeStorageIndexFilter, indexName)
 	if jsFn == "" {
 		rp.Put(r)
@@ -2379,14 +2391,12 @@ func (rp *RuntimeProviderJS) StorageIndexFilter(ctx context.Context, indexName s
 
 	fn, ok := goja.AssertFunction(r.vm.Get(jsFn))
 	if !ok {
-		rp.Put(r)
 		rp.logger.Error("JavaScript runtime function invalid.", zap.String("key", jsFn), zap.Error(err))
 		return false, errors.New("Could not run Storage Index Filter hook.")
 	}
 
 	jsLogger, err := NewJsLogger(ctx, r.vm, r.logger, zap.String("mode", RuntimeExecutionModeStorageIndexFilter.String()))
 	if err != nil {
-		rp.Put(r)
 		rp.logger.Error("Could not instantiate js logger.", zap.Error(err))
 		return false, errors.New("Could not run Storage Index Filter hook.")
 	}
@@ -2415,7 +2425,6 @@ func (rp *RuntimeProviderJS) StorageIndexFilter(ctx context.Context, indexName s
 	r.SetContext(ctx)
 	retValue, err, _ := r.InvokeFunction(RuntimeExecutionModeStorageIndexFilter, "storageIndexFilter", fn, jsLogger, nil, nil, "", "", "", nil, 0, "", "", "", "", r.vm.ToValue(objectMap))
 	r.SetContext(context.Background())
-	rp.Put(r)
 	if err != nil {
 		return false, fmt.Errorf("Error running runtime Storage Index Filter hook for %q index: %v", indexName, err.Error())
 	}

--- a/server/runtime_lua.go
+++ b/server/runtime_lua.go
@@ -44,6 +44,8 @@ import (
 
 const LTSentinel = lua.LValueType(-1)
 
+type ctxLuaRuntimeKey struct{}
+
 type LSentinelType struct {
 	lua.LNilType
 }
@@ -1377,6 +1379,7 @@ func (rp *RuntimeProviderLua) Rpc(ctx context.Context, id string, headers, query
 	// Set context value used for logging
 	vmCtx := context.WithValue(ctx, ctxLoggerFields{}, map[string]string{"rpc_id": id})
 	vmCtx = NewRuntimeGoContext(vmCtx, r.node, r.version, r.env, RuntimeExecutionModeRPC, headers, queryParams, traceID, expiry, userID, username, vars, sessionID, clientIP, clientPort, lang)
+	vmCtx = context.WithValue(vmCtx, ctxLuaRuntimeKey{}, r)
 	r.vm.SetContext(vmCtx)
 	result, fnErr, code, isCustomErr := r.InvokeFunction(RuntimeExecutionModeRPC, lf, headers, queryParams, traceID, userID, username, vars, expiry, sessionID, clientIP, clientPort, lang, payload)
 	r.vm.SetContext(context.Background())
@@ -2129,22 +2132,25 @@ func (rp *RuntimeProviderLua) SubscriptionNotificationGoogle(ctx context.Context
 }
 
 func (rp *RuntimeProviderLua) StorageIndexFilter(ctx context.Context, indexName string, write *StorageOpWrite) (bool, error) {
-	r, err := rp.Get(ctx)
-	if err != nil {
-		return false, err
+	var r *RuntimeLua
+	var err error
+	if ctxVm := ctx.Value(ctxLuaRuntimeKey{}); ctxVm != nil {
+		// Reuse previously checked out runtime if executed in the context of an RPC
+		r = ctxVm.(*RuntimeLua)
+	} else {
+		r, err = rp.Get(ctx)
+		if err != nil {
+			return false, err
+		}
+		defer rp.Put(r)
 	}
+
 	lf := r.GetCallback(RuntimeExecutionModeStorageIndexFilter, indexName)
 	if lf == nil {
-		rp.Put(r)
 		return false, fmt.Errorf("Runtime Storage Index function not found for index: %q.", indexName)
 	}
 
 	luaCtx := NewRuntimeLuaContext(r.vm, r.node, r.version, r.luaEnv, RuntimeExecutionModeStorageIndexFilter, nil, nil, "", 0, "", "", nil, "", "", "", "")
-
-	//table, err := storageOpWritesToTable(r.vm, storageWrites)
-	if err != nil {
-		return false, fmt.Errorf("Error running runtime Storage Index Filter hook for %q index: %v", indexName, err.Error())
-	}
 
 	writeTable := r.vm.CreateTable(0, 7)
 	writeTable.RawSetString("key", lua.LString(write.Object.Key))
@@ -2172,7 +2178,6 @@ func (rp *RuntimeProviderLua) StorageIndexFilter(ctx context.Context, indexName 
 	r.vm.SetContext(vmCtx)
 	retValue, err, _, _ := r.invokeFunction(r.vm, lf, luaCtx, writeTable)
 	r.vm.SetContext(context.Background())
-	rp.Put(r)
 	if err != nil {
 		return false, fmt.Errorf("Error running runtime Storage Index Filter hook for %q index: %v", indexName, err.Error())
 	}

--- a/server/storage_index.go
+++ b/server/storage_index.go
@@ -696,6 +696,10 @@ func (si *LocalStorageIndex) CreateIndex(ctx context.Context, name, collection, 
 		return err
 	}
 
+	if key == "*" {
+		key = ""
+	}
+
 	storageIdx := &storageIndex{
 		Name:           name,
 		Collection:     collection,


### PR DESCRIPTION
JS/Lua runtimes storage index filter function require a VM for its execution, if an RPC trigger a filter function call it can create a deadlock.
This PR allows the reuse of the currently checked out VM for an incoming RPC request so that no new JS VM is required, preventing the deadlock.