### PR TITLE
feat: add Amazon Appstore IAP purchase validation

### DIFF
--- a/iap/iap_amazon.go
+++ b/iap/iap_amazon.go
@@ -1,0 +1,123 @@
+// Copyright 2024 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	amazonRvsProductionBase = "https://appstore-sdk.amazon.com"
+	amazonRvsSandboxBase    = "https://appstore-sdk.amazon.com/sandbox"
+)
+
+// AmazonRvsResponse is the response from the Amazon Receipt Validation Service.
+// https://developer.amazon.com/docs/in-app-purchasing/iap-rvs-for-android-apps.html
+type AmazonRvsResponse struct {
+	ReceiptId       string `json:"receiptId"`
+	UserId          string `json:"userId"`
+	ProductType     string `json:"productType"`
+	ProductId       string `json:"productId"`
+	ItemType        string `json:"itemType"`
+	PurchaseDate    int64  `json:"purchaseDate"`
+	CancelDate      *int64 `json:"cancelDate"`
+	CancelReason    int    `json:"cancelReason"`
+	TestTransaction bool   `json:"testTransaction"`
+}
+
+// ValidateReceiptAmazon validates an Amazon IAP receipt against the Amazon
+// Receipt Validation Service (RVS).
+//
+// developerSecret is the secret from the Amazon Developer Console under
+// Apps & Services > In-App Purchasing.
+// receiptId and amazonUserId come from the Amazon Appstore SDK PurchaseResponse.
+// sandbox enables the Amazon RVS sandbox endpoint for test purchases.
+//
+// Returns the parsed RVS response, the raw response body, and any error.
+func ValidateReceiptAmazon(ctx context.Context, httpc *http.Client, developerSecret, receiptId, amazonUserId string, sandbox bool) (*AmazonRvsResponse, []byte, error) {
+	base := amazonRvsProductionBase
+	if sandbox {
+		base = amazonRvsSandboxBase
+	}
+
+	url := fmt.Sprintf(
+		"%s/version/1.0/verifyReceiptId/developer/%s/user/%s/receiptId/%s",
+		base, developerSecret, amazonUserId, receiptId,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, &ValidationError{Err: fmt.Errorf("failed to build Amazon RVS request: %w", err)}
+	}
+
+	resp, err := httpc.Do(req)
+	if err != nil {
+		return nil, nil, &ValidationError{Err: fmt.Errorf("Amazon RVS request failed: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, &ValidationError{Err: err, StatusCode: resp.StatusCode}
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Valid receipt — parse response below.
+	case http.StatusBadRequest:
+		// 400: the receiptId is not valid.
+		return nil, raw, &ValidationError{
+			Err:        fmt.Errorf("Amazon RVS: invalid receipt"),
+			StatusCode: resp.StatusCode,
+			Payload:    string(raw),
+		}
+	case 496:
+		// 496: the developer secret is wrong (Amazon-specific status code).
+		return nil, raw, &ValidationError{
+			Err:        fmt.Errorf("Amazon RVS: invalid developer secret"),
+			StatusCode: resp.StatusCode,
+			Payload:    string(raw),
+		}
+	default:
+		return nil, raw, &ValidationError{
+			Err:        fmt.Errorf("Amazon RVS returned HTTP %d", resp.StatusCode),
+			StatusCode: resp.StatusCode,
+			Payload:    string(raw),
+		}
+	}
+
+	var rvsResp AmazonRvsResponse
+	if err := json.Unmarshal(raw, &rvsResp); err != nil {
+		return nil, raw, &ValidationError{
+			Err:        fmt.Errorf("failed to parse Amazon RVS response: %w", err),
+			StatusCode: resp.StatusCode,
+			Payload:    string(raw),
+		}
+	}
+
+	if rvsResp.ReceiptId == "" {
+		return nil, raw, &ValidationError{
+			Err:        fmt.Errorf("Amazon RVS response missing receiptId"),
+			StatusCode: resp.StatusCode,
+			Payload:    string(raw),
+		}
+	}
+
+	return &rvsResp, raw, nil
+}

--- a/server/api_purchase.go
+++ b/server/api_purchase.go
@@ -257,3 +257,65 @@ func (s *ApiServer) ValidatePurchaseFacebookInstant(ctx context.Context, in *api
 
 	return validation, err
 }
+
+func (s *ApiServer) ValidatePurchaseAmazon(ctx context.Context, in *api.ValidatePurchaseAmazonRequest) (*api.ValidatePurchaseResponse, error) {
+	userID := ctx.Value(ctxUserIDKey{}).(uuid.UUID)
+	logger, traceID := LoggerWithTraceId(ctx, s.logger)
+
+	// Before hook.
+	if fn := s.runtime.BeforeValidatePurchaseAmazon(); fn != nil {
+		beforeFn := func(clientIP, clientPort string) error {
+			result, err, code := fn(ctx, logger, traceID, userID.String(), ctx.Value(ctxUsernameKey{}).(string), ctx.Value(ctxVarsKey{}).(map[string]string), ctx.Value(ctxExpiryKey{}).(int64), clientIP, clientPort, in)
+			if err != nil {
+				return status.Error(code, err.Error())
+			}
+			if result == nil {
+				// If result is nil, requested resource is disabled.
+				logger.Warn("Intercepted a disabled resource.", zap.Any("resource", ctx.Value(ctxFullMethodKey{}).(string)), zap.String("uid", userID.String()))
+				return status.Error(codes.NotFound, "Requested resource was not found.")
+			}
+			in = result
+			return nil
+		}
+
+		// Execute the before function lambda wrapped in a trace for stats measurement.
+		err := traceApiBefore(ctx, logger, s.config, s.metrics, ctx.Value(ctxFullMethodKey{}).(string), beforeFn)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if s.config.GetIAP().Amazon.DeveloperSecret == "" {
+		return nil, status.Error(codes.FailedPrecondition, "Amazon IAP is not configured.")
+	}
+
+	if len(in.ReceiptId) < 1 {
+		return nil, status.Error(codes.InvalidArgument, "Receipt ID cannot be empty.")
+	}
+
+	if len(in.AmazonUserId) < 1 {
+		return nil, status.Error(codes.InvalidArgument, "Amazon user ID cannot be empty.")
+	}
+
+	persist := true
+	if in.Persist != nil {
+		persist = in.Persist.GetValue()
+	}
+
+	validation, err := ValidatePurchaseAmazon(ctx, logger, s.db, userID, s.config.GetIAP().Amazon, in.ReceiptId, in.AmazonUserId, persist)
+	if err != nil {
+		return nil, err
+	}
+
+	// After hook.
+	if fn := s.runtime.AfterValidatePurchaseAmazon(); fn != nil {
+		afterFn := func(clientIP, clientPort string) error {
+			return fn(ctx, logger, traceID, userID.String(), ctx.Value(ctxUsernameKey{}).(string), ctx.Value(ctxVarsKey{}).(map[string]string), ctx.Value(ctxExpiryKey{}).(int64), clientIP, clientPort, validation, in)
+		}
+
+		// Execute the after function lambda wrapped in a trace for stats measurement.
+		traceApiAfter(ctx, logger, s.config, s.metrics, ctx.Value(ctxFullMethodKey{}).(string), afterFn)
+	}
+
+	return validation, err
+}

--- a/server/config.go
+++ b/server/config.go
@@ -1354,6 +1354,7 @@ var _ runtime.IAPConfig = (*IAPConfig)(nil)
 
 type IAPConfig struct {
 	Apple           *IAPAppleConfig           `yaml:"apple" json:"apple" usage:"Apple App Store purchase validation configuration."`
+	Amazon          *IAPAmazonConfig          `yaml:"amazon" json:"amazon" usage:"Amazon Appstore purchase validation configuration."`
 	Google          *IAPGoogleConfig          `yaml:"google" json:"google" usage:"Google Play Store purchase validation configuration."`
 	Huawei          *IAPHuaweiConfig          `yaml:"huawei" json:"huawei" usage:"Huawei purchase validation configuration."`
 	FacebookInstant *IAPFacebookInstantConfig `yaml:"facebook_instant" json:"facebook_instant" usage:"Facebook Instant purchase validation configuration."`
@@ -1361,6 +1362,10 @@ type IAPConfig struct {
 
 func (cfg *IAPConfig) GetApple() runtime.IAPAppleConfig {
 	return cfg.Apple
+}
+
+func (cfg *IAPConfig) GetAmazon() runtime.IAPAmazonConfig {
+	return cfg.Amazon
 }
 
 func (cfg *IAPConfig) GetGoogle() runtime.IAPGoogleConfig {
@@ -1405,6 +1410,7 @@ func (cfg *IAPConfig) Clone() *IAPConfig {
 func NewIAPConfig() *IAPConfig {
 	return &IAPConfig{
 		Apple:           &IAPAppleConfig{},
+		Amazon:          &IAPAmazonConfig{},
 		Google:          &IAPGoogleConfig{},
 		Huawei:          &IAPHuaweiConfig{},
 		FacebookInstant: &IAPFacebookInstantConfig{},
@@ -1425,6 +1431,16 @@ func (iap IAPAppleConfig) GetSharedPassword() string {
 func (iap IAPAppleConfig) GetNotificationsEndpointId() string {
 	return iap.NotificationsEndpointId
 }
+
+var _ runtime.IAPAmazonConfig = (*IAPAmazonConfig)(nil)
+
+type IAPAmazonConfig struct {
+	DeveloperSecret string `yaml:"developer_secret" json:"developer_secret" usage:"The Amazon developer secret for In-App Purchase validation. Found in the Amazon Developer Console under Apps & Services > In-App Purchasing."`
+	Sandbox         bool   `yaml:"sandbox" json:"sandbox" usage:"Enables the Amazon RVS sandbox endpoint. Enable this for development and test purchases."`
+}
+
+func (i IAPAmazonConfig) GetDeveloperSecret() string { return i.DeveloperSecret }
+func (i IAPAmazonConfig) GetSandbox() bool           { return i.Sandbox }
 
 var _ runtime.IAPGoogleConfig = (*IAPGoogleConfig)(nil)
 

--- a/server/core_purchase.go
+++ b/server/core_purchase.go
@@ -483,6 +483,92 @@ func ValidatePurchaseFacebookInstant(ctx context.Context, logger *zap.Logger, db
 	}, nil
 }
 
+func ValidatePurchaseAmazon(ctx context.Context, logger *zap.Logger, db *sql.DB, userID uuid.UUID, config *IAPAmazonConfig, receiptId, amazonUserId string, persist bool) (*api.ValidatePurchaseResponse, error) {
+	if config.DeveloperSecret == "" {
+		return nil, status.Error(codes.FailedPrecondition, "Amazon IAP is not configured.")
+	}
+
+	rvsResp, raw, err := iap.ValidateReceiptAmazon(ctx, httpc, config.DeveloperSecret, receiptId, amazonUserId, config.Sandbox)
+	if err != nil {
+		if err != context.Canceled {
+			var vErr *iap.ValidationError
+			if errors.As(err, &vErr) {
+				logger.Debug("Error validating Amazon receipt", zap.Error(vErr.Err), zap.Int("status_code", vErr.StatusCode), zap.String("payload", vErr.Payload))
+				return nil, vErr
+			} else {
+				logger.Error("Error validating Amazon receipt", zap.Error(err))
+			}
+		}
+		return nil, err
+	}
+
+	env := api.StoreEnvironment_PRODUCTION
+	if rvsResp.TestTransaction {
+		env = api.StoreEnvironment_SANDBOX
+	}
+
+	sPurchase := &storagePurchase{
+		userID:        userID,
+		store:         api.StoreProvider_AMAZON_APP_STORE,
+		productId:     rvsResp.ProductId,
+		transactionId: rvsResp.ReceiptId,
+		rawResponse:   string(raw),
+		purchaseTime:  parseMillisecondUnixTimestamp(rvsResp.PurchaseDate),
+		environment:   env,
+	}
+
+	if rvsResp.CancelDate != nil {
+		sPurchase.refundTime = parseMillisecondUnixTimestamp(*rvsResp.CancelDate)
+	}
+
+	if !persist {
+		return &api.ValidatePurchaseResponse{
+			ValidatedPurchases: []*api.ValidatedPurchase{
+				{
+					ProductId:        sPurchase.productId,
+					TransactionId:    sPurchase.transactionId,
+					Store:            sPurchase.store,
+					PurchaseTime:     timestamppb.New(sPurchase.purchaseTime),
+					ProviderResponse: string(raw),
+					Environment:      sPurchase.environment,
+				},
+			},
+		}, nil
+	}
+
+	purchases, err := upsertPurchases(ctx, db, []*storagePurchase{sPurchase})
+	if err != nil {
+		if err != context.Canceled {
+			logger.Error("Error storing Amazon receipt", zap.Error(err))
+		}
+		return nil, err
+	}
+
+	validatedPurchases := make([]*api.ValidatedPurchase, 0, len(purchases))
+	for _, p := range purchases {
+		suid := p.userID.String()
+		if p.userID.IsNil() {
+			suid = ""
+		}
+		validatedPurchases = append(validatedPurchases, &api.ValidatedPurchase{
+			UserId:           suid,
+			ProductId:        p.productId,
+			TransactionId:    p.transactionId,
+			Store:            p.store,
+			PurchaseTime:     timestamppb.New(p.purchaseTime),
+			CreateTime:       timestamppb.New(p.createTime),
+			UpdateTime:       timestamppb.New(p.updateTime),
+			ProviderResponse: string(raw),
+			SeenBefore:       p.seenBefore,
+			Environment:      p.environment,
+		})
+	}
+
+	return &api.ValidatePurchaseResponse{
+		ValidatedPurchases: validatedPurchases,
+	}, nil
+}
+
 func GetPurchaseByTransactionId(ctx context.Context, logger *zap.Logger, db *sql.DB, transactionID string) (*api.ValidatedPurchase, error) {
 	var (
 		dbTransactionId string

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -3330,6 +3330,41 @@ func (n *RuntimeGoNakamaModule) PurchaseValidateFacebookInstant(ctx context.Cont
 }
 
 // @group purchases
+// @summary Validates and stores a purchase receipt from the Amazon Appstore.
+// @param ctx(type=context.Context) The context object represents information about the server and requester.
+// @param userID(type=string) The user ID of the owner of the receipt.
+// @param receiptId(type=string) The receipt ID returned by the Amazon Appstore SDK PurchaseResponse.
+// @param amazonUserId(type=string) The user ID returned by the Amazon Appstore SDK UserDataResponse.
+// @param persist(type=bool) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
+// @return validation(*api.ValidatePurchaseResponse) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeGoNakamaModule) PurchaseValidateAmazon(ctx context.Context, userID, receiptId, amazonUserId string, persist bool) (*api.ValidatePurchaseResponse, error) {
+	if n.config.GetIAP().Amazon.DeveloperSecret == "" {
+		return nil, errors.New("amazon IAP is not configured")
+	}
+
+	uid, err := uuid.FromString(userID)
+	if err != nil {
+		return nil, errors.New("user ID must be a valid id string")
+	}
+
+	if len(receiptId) < 1 {
+		return nil, errors.New("receiptId cannot be empty string")
+	}
+
+	if len(amazonUserId) < 1 {
+		return nil, errors.New("amazonUserId cannot be empty string")
+	}
+
+	validation, err := ValidatePurchaseAmazon(ctx, n.logger, n.db, uid, n.config.GetIAP().Amazon, receiptId, amazonUserId, persist)
+	if err != nil {
+		return nil, err
+	}
+
+	return validation, nil
+}
+
+// @group purchases
 // @summary List stored validated purchase receipts.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param userID(type=string) Filter by user ID. Can be an empty string to list purchases for all users.

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -261,6 +261,7 @@ func (n *RuntimeJavascriptNakamaModule) mappings(r *goja.Runtime) map[string]fun
 		"purchaseValidateGoogle":               n.purchaseValidateGoogle(r),
 		"purchaseValidateHuawei":               n.purchaseValidateHuawei(r),
 		"purchaseValidateFacebookInstant":      n.purchaseValidateFacebookInstant(r),
+		"purchaseValidateAmazon":               n.purchaseValidateAmazon(r),
 		"purchaseGetByTransactionId":           n.purchaseGetByTransactionId(r),
 		"purchasesList":                        n.purchasesList(r),
 		"subscriptionValidateApple":            n.subscriptionValidateApple(r),
@@ -6268,6 +6269,55 @@ func (n *RuntimeJavascriptNakamaModule) purchaseValidateFacebookInstant(r *goja.
 		validation, err := ValidatePurchaseFacebookInstant(n.ctx, n.logger, n.db, uid, n.config.GetIAP().FacebookInstant, signedRequest, persist)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("error validating Facebook Instant receipt: %s", err.Error())))
+		}
+
+		validationResult := purchaseResponseToJsObject(validation)
+
+		return r.ToValue(validationResult)
+	}
+}
+
+// @group purchases
+// @summary Validates and stores a purchase receipt from the Amazon Appstore.
+// @param userID(type=string) The user ID of the owner of the receipt.
+// @param receiptId(type=string) The receipt ID returned by the Amazon Appstore SDK PurchaseResponse.
+// @param amazonUserId(type=string) The user ID returned by the Amazon Appstore SDK UserDataResponse.
+// @param persist(type=bool, optional=true, default=true) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
+// @return validation(nkruntime.ValidatePurchaseResponse) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeJavascriptNakamaModule) purchaseValidateAmazon(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(f goja.FunctionCall) goja.Value {
+		if n.config.GetIAP().Amazon.DeveloperSecret == "" {
+			panic(r.NewGoError(errors.New("amazon IAP is not configured")))
+		}
+
+		userID := getJsString(r, f.Argument(0))
+		if userID == "" {
+			panic(r.NewTypeError("expects a user ID string"))
+		}
+		uid, err := uuid.FromString(userID)
+		if err != nil {
+			panic(r.NewTypeError("expects user ID to be a valid identifier"))
+		}
+
+		receiptId := getJsString(r, f.Argument(1))
+		if receiptId == "" {
+			panic(r.NewTypeError("expects receiptId"))
+		}
+
+		amazonUserId := getJsString(r, f.Argument(2))
+		if amazonUserId == "" {
+			panic(r.NewTypeError("expects amazonUserId"))
+		}
+
+		persist := true
+		if f.Argument(3) != goja.Undefined() && f.Argument(3) != goja.Null() {
+			persist = getJsBool(r, f.Argument(3))
+		}
+
+		validation, err := ValidatePurchaseAmazon(n.ctx, n.logger, n.db, uid, n.config.GetIAP().Amazon, receiptId, amazonUserId, persist)
+		if err != nil {
+			panic(r.NewGoError(fmt.Errorf("error validating Amazon receipt: %s", err.Error())))
 		}
 
 		validationResult := purchaseResponseToJsObject(validation)

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -277,6 +277,7 @@ func (n *RuntimeLuaNakamaModule) Loader(l *lua.LState) int {
 		"purchase_validate_google":                  n.purchaseValidateGoogle,
 		"purchase_validate_huawei":                  n.purchaseValidateHuawei,
 		"purchase_validate_facebook_instant":        n.purchaseValidateFacebookInstant,
+		"purchase_validate_amazon":                  n.purchaseValidateAmazon,
 		"purchase_get_by_transaction_id":            n.purchaseGetByTransactionId,
 		"purchases_list":                            n.purchasesList,
 		"subscription_validate_apple":               n.subscriptionValidateApple,
@@ -7911,6 +7912,55 @@ func (n *RuntimeLuaNakamaModule) purchaseValidateFacebookInstant(l *lua.LState) 
 	validation, err := ValidatePurchaseFacebookInstant(l.Context(), n.logger, n.db, uid, n.config.GetIAP().FacebookInstant, signedRequest, persist)
 	if err != nil {
 		l.RaiseError("error validating Facebook Instant receipt: %v", err.Error())
+		return 0
+	}
+
+	l.Push(purchaseValidationToLuaTable(l, validation))
+	return 1
+}
+
+// @group purchases
+// @summary Validates and stores a purchase receipt from the Amazon Appstore.
+// @param userID(type=string) The user ID of the owner of the receipt.
+// @param receiptId(type=string) The receipt ID returned by the Amazon Appstore SDK PurchaseResponse.
+// @param amazonUserId(type=string) The user ID returned by the Amazon Appstore SDK UserDataResponse.
+// @param persist(type=bool, optional=true, default=true) Persist the purchase so that seenBefore can be computed to protect against replay attacks.
+// @return validation(table) The resulting successfully validated purchases. Any previously validated purchases are returned with a seenBefore flag.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeLuaNakamaModule) purchaseValidateAmazon(l *lua.LState) int {
+	if n.config.GetIAP().Amazon.DeveloperSecret == "" {
+		l.RaiseError("Amazon IAP is not configured.")
+		return 0
+	}
+
+	userID := l.CheckString(1)
+	if userID == "" {
+		l.ArgError(1, "expects user id")
+		return 0
+	}
+	uid, err := uuid.FromString(userID)
+	if err != nil {
+		l.ArgError(1, "invalid user id")
+		return 0
+	}
+
+	receiptId := l.CheckString(2)
+	if receiptId == "" {
+		l.ArgError(2, "expects receiptId")
+		return 0
+	}
+
+	amazonUserId := l.CheckString(3)
+	if amazonUserId == "" {
+		l.ArgError(3, "expects amazonUserId")
+		return 0
+	}
+
+	persist := l.OptBool(4, true)
+
+	validation, err := ValidatePurchaseAmazon(l.Context(), n.logger, n.db, uid, n.config.GetIAP().Amazon, receiptId, amazonUserId, persist)
+	if err != nil {
+		l.RaiseError("error validating Amazon receipt: %v", err.Error())
 		return 0
 	}
 

--- a/vendor/github.com/heroiclabs/nakama-common/api/api.pb.go
+++ b/vendor/github.com/heroiclabs/nakama-common/api/api.pb.go
@@ -52,6 +52,8 @@ const (
 	StoreProvider_HUAWEI_APP_GALLERY StoreProvider = 2
 	// Facebook Instant Store
 	StoreProvider_FACEBOOK_INSTANT_STORE StoreProvider = 3
+	// Amazon App Store
+	StoreProvider_AMAZON_APP_STORE StoreProvider = 4
 )
 
 // Enum value maps for StoreProvider.
@@ -61,12 +63,14 @@ var (
 		1: "GOOGLE_PLAY_STORE",
 		2: "HUAWEI_APP_GALLERY",
 		3: "FACEBOOK_INSTANT_STORE",
+		4: "AMAZON_APP_STORE",
 	}
 	StoreProvider_value = map[string]int32{
 		"APPLE_APP_STORE":        0,
 		"GOOGLE_PLAY_STORE":      1,
 		"HUAWEI_APP_GALLERY":     2,
 		"FACEBOOK_INSTANT_STORE": 3,
+		"AMAZON_APP_STORE":       4,
 	}
 )
 
@@ -7520,6 +7524,44 @@ func (x *ValidatePurchaseFacebookInstantRequest) GetSignedRequest() string {
 }
 
 func (x *ValidatePurchaseFacebookInstantRequest) GetPersist() *wrapperspb.BoolValue {
+	if x != nil {
+		return x.Persist
+	}
+	return nil
+}
+
+// Amazon IAP Purchase validation request.
+type ValidatePurchaseAmazonRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The receipt ID returned by the Amazon Appstore SDK PurchaseResponse.
+	ReceiptId string `protobuf:"bytes,1,opt,name=receipt_id,json=receiptId,proto3" json:"receipt_id,omitempty"`
+	// The user ID returned by the Amazon Appstore SDK UserDataResponse.
+	AmazonUserId string `protobuf:"bytes,2,opt,name=amazon_user_id,json=amazonUserId,proto3" json:"amazon_user_id,omitempty"`
+	// Persist the purchase so that seenBefore can be computed to protect against replay attacks.
+	Persist       *wrapperspb.BoolValue `protobuf:"bytes,3,opt,name=persist,proto3" json:"persist,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ValidatePurchaseAmazonRequest) Reset()         {}
+func (x *ValidatePurchaseAmazonRequest) String() string { return protoimpl.X.MessageStringOf(x) }
+func (*ValidatePurchaseAmazonRequest) ProtoMessage()    {}
+
+func (x *ValidatePurchaseAmazonRequest) GetReceiptId() string {
+	if x != nil {
+		return x.ReceiptId
+	}
+	return ""
+}
+
+func (x *ValidatePurchaseAmazonRequest) GetAmazonUserId() string {
+	if x != nil {
+		return x.AmazonUserId
+	}
+	return ""
+}
+
+func (x *ValidatePurchaseAmazonRequest) GetPersist() *wrapperspb.BoolValue {
 	if x != nil {
 		return x.Persist
 	}

--- a/vendor/github.com/heroiclabs/nakama-common/api/api.proto
+++ b/vendor/github.com/heroiclabs/nakama-common/api/api.proto
@@ -1239,6 +1239,16 @@ message ValidatePurchaseFacebookInstantRequest {
   google.protobuf.BoolValue persist = 2;
 }
 
+// Amazon IAP Purchase validation request.
+message ValidatePurchaseAmazonRequest {
+  // The receipt ID returned by the Amazon Appstore SDK PurchaseResponse.
+  string receipt_id = 1;
+  // The user ID returned by the Amazon Appstore SDK UserDataResponse.
+  string amazon_user_id = 2;
+  // Persist the purchase so that seenBefore can be computed to protect against replay attacks.
+  google.protobuf.BoolValue persist = 3;
+}
+
 // Validated Purchase stored by Nakama.
 message ValidatedPurchase {
   // Purchase User ID.
@@ -1286,6 +1296,8 @@ enum StoreProvider {
   HUAWEI_APP_GALLERY = 2;
   // Facebook Instant Store
   FACEBOOK_INSTANT_STORE = 3;
+  // Amazon App Store
+  AMAZON_APP_STORE = 4;
 }
 
 // Environment where a purchase/subscription took place,

--- a/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
+++ b/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
@@ -793,6 +793,12 @@ type Initializer interface {
 	// RegisterAfterValidatePurchaseFacebookInstant can be used to perform additional logic after validating an Facebook Instant IAP receipt.
 	RegisterAfterValidatePurchaseFacebookInstant(fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseFacebookInstantRequest) error) error
 
+	// RegisterBeforeValidatePurchaseAmazon can be used to perform additional logic before validating an Amazon Appstore IAP receipt.
+	RegisterBeforeValidatePurchaseAmazon(fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, in *api.ValidatePurchaseAmazonRequest) (*api.ValidatePurchaseAmazonRequest, error)) error
+
+	// RegisterAfterValidatePurchaseAmazon can be used to perform additional logic after validating an Amazon Appstore IAP receipt.
+	RegisterAfterValidatePurchaseAmazon(fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseAmazonRequest) error) error
+
 	// RegisterBeforeListSubscriptions can be used to perform additional logic before listing subscriptions.
 	RegisterBeforeListSubscriptions(fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule, in *api.ListSubscriptionsRequest) (*api.ListSubscriptionsRequest, error)) error
 
@@ -1175,6 +1181,7 @@ type NakamaModule interface {
 	}) (*api.ValidatePurchaseResponse, error)
 	PurchaseValidateHuawei(ctx context.Context, userID, signature, inAppPurchaseData string, persist bool) (*api.ValidatePurchaseResponse, error)
 	PurchaseValidateFacebookInstant(ctx context.Context, userID, signedRequest string, persist bool) (*api.ValidatePurchaseResponse, error)
+	PurchaseValidateAmazon(ctx context.Context, userID, receiptId, amazonUserId string, persist bool) (*api.ValidatePurchaseResponse, error)
 	PurchasesList(ctx context.Context, userID string, limit int, cursor string) (*api.PurchaseList, error)
 	PurchaseGetByTransactionId(ctx context.Context, transactionID string) (*api.ValidatedPurchase, error)
 


### PR DESCRIPTION
## Summary

Adds native Amazon Appstore IAP receipt validation to Nakama, resolving #732.

Amazon uses its own Receipt Verification Service (RVS) — a simple HTTP GET with `developerSecret`, `receiptId`, and `amazonUserId` — rather than the OAuth-based flows used by Google. This PR follows the same architecture as the existing Apple, Google, Huawei, and Facebook Instant validators.

## Changes

| File | What |
|---|---|
| `iap/iap_amazon.go` | **New.** HTTP client for Amazon RVS. Handles HTTP 200 (valid), 400 (invalid receipt), 496 (bad developer secret). Parses `testTransaction` field for sandbox detection. |
| `server/core_purchase.go` | `ValidatePurchaseAmazon()` stores `receiptId` as `transactionId`, `CancelDate` as `refundTime`, `testTransaction` as sandbox environment. |
| `server/api_purchase.go` | gRPC/HTTP handler with before/after runtime hooks. |
| `server/config.go` | `IAPAmazonConfig{DeveloperSecret, Sandbox}` integrated into `IAPConfig`. |
| `server/runtime_go_nakama.go` | `PurchaseValidateAmazon` Go runtime method. |
| `server/runtime_lua_nakama.go` | `nk.purchase_validate_amazon(userId, receiptId, amazonUserId[, persist])` Lua binding. |
| `server/runtime_javascript_nakama.go` | `nkruntime.purchaseValidateAmazon` JS binding. |
| `vendor/.../api.proto` | `AMAZON_APP_STORE = 4` in `StoreProvider`; new `ValidatePurchaseAmazonRequest` message. |
| `vendor/.../api.pb.go` | `StoreProvider_AMAZON_APP_STORE` constant + `ValidatePurchaseAmazonRequest` struct. |
| `vendor/.../runtime.go` | `PurchaseValidateAmazon` in `NakamaModule`; `RegisterBefore/AfterValidatePurchaseAmazon` in `Initializer`. |

> **Note on proto:** `api.proto` and `api.pb.go` are modified in-vendor here to keep the PR self-contained. A parallel PR to [heroiclabs/nakama-common](https://github.com/heroiclabs/nakama-common) is needed to land the proto change officially, after which `api.pb.go` should be regenerated with `buf generate`.

## Configuration

```yaml
iap:
  amazon:
    developer_secret: "your-secret-from-amazon-developer-console"
    sandbox: false   # set true for development/test builds
```

## Usage (Lua)

```lua
local result = nk.purchase_validate_amazon(user_id, receipt_id, amazon_user_id)
if result.validated_purchases[1].seen_before then
  -- replay attack — reject
end
```

## Amazon RVS API reference

https://developer.amazon.com/docs/in-app-purchasing/iap-rvs-for-android-apps.html

## Test plan

- [ ] Unit test: `iap/iap_amazon_test.go` with mock HTTP server returning 200/400/496
- [ ] Integration test: configure `developer_secret` + `sandbox: true`, call `nk.purchase_validate_amazon` from Lua with a real Amazon sandbox receipt
- [ ] Verify `StoreProvider_AMAZON_APP_STORE` appears in `purchase` table
- [ ] Verify `seen_before = true` on duplicate receipt
- [ ] Verify `refund_time` is set when `cancelDate` is present in the RVS response
