### PR TITLE
2394 Adding storage tx lifecyle management to runtime API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com) and this project uses [semantic versioning](http://semver.org).
 
 ## [Unreleased]
+### Added
+- Add `txBegin`, `txCommit`, `txRollback` runtime functions across Go, Lua, and JavaScript runtimes to allow callers to manage database transaction lifecycle explicitly.
+- Add optional transaction parameter to `storageRead`, `storageWrite`, and `storageDelete` runtime functions so multiple storage operations can be executed within a single atomic transaction.
 
 ## [3.39.0] - 2026-05-20
 ### Added

--- a/server/api_storage.go
+++ b/server/api_storage.go
@@ -136,7 +136,7 @@ func (s *ApiServer) ReadStorageObjects(ctx context.Context, in *api.ReadStorageO
 		}
 	}
 
-	objects, err := StorageReadObjects(ctx, logger, s.db, userID, in.GetObjectIds())
+	objects, err := StorageReadObjects(ctx, logger, s.db, userID, in.GetObjectIds(), nil)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "Error reading storage objects.")
 	}
@@ -217,7 +217,7 @@ func (s *ApiServer) WriteStorageObjects(ctx context.Context, in *api.WriteStorag
 		})
 	}
 
-	acks, code, err := StorageWriteObjects(ctx, logger, s.db, s.metrics, s.storageIndex, false, ops)
+	acks, code, err := StorageWriteObjects(ctx, logger, s.db, s.metrics, s.storageIndex, false, ops, nil)
 	if err != nil {
 		if code == codes.Internal {
 			return nil, status.Error(codes.Internal, "Error writing storage objects.")
@@ -283,7 +283,7 @@ func (s *ApiServer) DeleteStorageObjects(ctx context.Context, in *api.DeleteStor
 		})
 	}
 
-	if code, err := StorageDeleteObjects(ctx, logger, s.db, s.storageIndex, false, ops); err != nil {
+	if code, err := StorageDeleteObjects(ctx, logger, s.db, s.storageIndex, false, ops, nil); err != nil {
 		if code == codes.Internal {
 			return nil, status.Error(codes.Internal, "Error deleting storage objects.")
 		}

--- a/server/console_storage.go
+++ b/server/console_storage.go
@@ -77,7 +77,7 @@ func (s *ConsoleServer) DeleteStorageObject(ctx context.Context, in *console.Del
 				Version:    in.Version,
 			},
 		},
-	})
+	}, nil)
 
 	if err != nil {
 		if code == codes.Internal {
@@ -105,7 +105,7 @@ func (s *ConsoleServer) GetStorage(ctx context.Context, in *api.ReadStorageObjec
 		return nil, status.Error(codes.InvalidArgument, "Requires a valid user ID.")
 	}
 
-	objects, err := StorageReadObjects(ctx, logger, s.db, uuid.Nil, []*api.ReadStorageObjectId{in})
+	objects, err := StorageReadObjects(ctx, logger, s.db, uuid.Nil, []*api.ReadStorageObjectId{in}, nil)
 	if err != nil {
 		// Errors already logged in function above.
 		return nil, status.Error(codes.Internal, "An error occurred while reading storage object.")
@@ -375,7 +375,7 @@ func (s *ConsoleServer) WriteStorageObject(ctx context.Context, in *console.Writ
 				PermissionWrite: in.PermissionWrite,
 			},
 		},
-	})
+	}, nil)
 
 	if err != nil {
 		if code == codes.Internal {

--- a/server/console_storage_import.go
+++ b/server/console_storage_import.go
@@ -200,7 +200,7 @@ func importStorageJSON(ctx context.Context, logger *zap.Logger, db *sql.DB, metr
 		return nil
 	}
 
-	acks, _, err := StorageWriteObjects(ctx, logger, db, metrics, storageIndex, true, ops)
+	acks, _, err := StorageWriteObjects(ctx, logger, db, metrics, storageIndex, true, ops, nil)
 	if err != nil {
 		logger.Warn("Failed to write imported records.", zap.Error(err))
 		return errors.New("could not import records due to an internal error - please consult server logs")
@@ -300,7 +300,7 @@ func importStorageCSV(ctx context.Context, logger *zap.Logger, db *sql.DB, metri
 		return nil
 	}
 
-	acks, _, err := StorageWriteObjects(ctx, logger, db, metrics, storageIndex, true, ops)
+	acks, _, err := StorageWriteObjects(ctx, logger, db, metrics, storageIndex, true, ops, nil)
 	if err != nil {
 		logger.Warn("Failed to write imported records.", zap.Error(err))
 		return errors.New("could not import records due to an internal error - please consult server logs")

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -588,7 +588,10 @@ SELECT collection, key, user_id, value, version, read, write, create_time, updat
 
 	var objects *api.StorageObjects
 	err := ExecuteRetryablePgx(ctx, db, func(conn *pgx.Conn) error {
-		rows, _ := conn.Query(ctx, query, params...)
+		rows, err := conn.Query(ctx, query, params...)
+		if err != nil {
+			return fmt.Errorf("query failed: %w", err)
+		}
 		var scanErr error
 		objects, scanErr = scanRows(rows)
 		return scanErr
@@ -965,8 +968,8 @@ type openTx struct {
 
 // txBegin acquires a dedicated connection, begins a transaction on it,
 // and registers it in openTxs. A goroutine watches ctx and rolls back
-// automatically if the caller never commits or ro.
-func txBegin(ctx context.Context, db *sql.DB, openTxs *sync.Map) (*runtime.StorageTx, error) {
+// automatically if the caller forgets to commit.
+func txBegin(ctx context.Context, logger *zap.Logger, db *sql.DB, openTxs *sync.Map) (*runtime.StorageTx, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return nil, err
@@ -976,20 +979,31 @@ func txBegin(ctx context.Context, db *sql.DB, openTxs *sync.Map) (*runtime.Stora
 	doneCh := make(chan struct{})
 	var pgxTx pgx.Tx
 
+	// Open a dedicated connection for the TX
 	go func() {
 		defer conn.Close()
-		_ = conn.Raw(func(driverConn any) error {
+
+		beginTxFailed := false
+		err = conn.Raw(func(driverConn any) error {
 			pgxConn := driverConn.(*stdlib.Conn).Conn()
-			tx, err := pgxConn.BeginTx(context.Background(), pgx.TxOptions{})
+			tx, err := pgxConn.BeginTx(ctx, pgx.TxOptions{})
 			if err != nil {
 				txReadyCh <- err
+				beginTxFailed = true
 				return err
 			}
 			pgxTx = tx
 			txReadyCh <- nil
+
+			// This receive blocks until TX is committed or rolled back
 			<-doneCh
 			return nil
 		})
+
+		// conn.Raw errored before callback - send error to unblock txReadyCh
+		if err != nil && !beginTxFailed {
+			txReadyCh <- err
+		}
 	}()
 
 	if err := <-txReadyCh; err != nil {
@@ -999,11 +1013,14 @@ func txBegin(ctx context.Context, db *sql.DB, openTxs *sync.Map) (*runtime.Stora
 	txID := uuid.Must(uuid.NewV4()).String()
 	openTxs.Store(txID, &openTx{tx: pgxTx, doneCh: doneCh})
 
+	// Watch for cancelled context to rollback an tx's
 	go func() {
 		<-ctx.Done()
 		if val, loaded := openTxs.LoadAndDelete(txID); loaded {
 			entry := val.(*openTx)
-			_ = entry.tx.Rollback(context.Background())
+			if rollbackErr := entry.tx.Rollback(context.Background()); rollbackErr != nil {
+				logger.Warn("Failed to rollback transaction on context cancellation.", zap.String("tx_id", txID), zap.Error(rollbackErr))
+			}
 			close(entry.doneCh)
 		}
 	}()

--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -29,12 +29,15 @@ import (
 	"sort"
 	"time"
 
+	"sync"
+
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/stdlib"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -425,7 +428,7 @@ type storageQueryArg struct {
 	param  any
 }
 
-func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, caller uuid.UUID, objectIDs []*api.ReadStorageObjectId) (*api.StorageObjects, error) {
+func StorageReadObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, caller uuid.UUID, objectIDs []*api.ReadStorageObjectId, tx pgx.Tx) (*api.StorageObjects, error) {
 	if len(objectIDs) == 0 {
 		return &api.StorageObjects{}, nil
 	}
@@ -548,9 +551,7 @@ SELECT collection, key, user_id, value, version, read, write, create_time, updat
 		params = append(params, caller)
 	}
 
-	var objects *api.StorageObjects
-	err := ExecuteRetryablePgx(ctx, db, func(conn *pgx.Conn) error {
-		rows, _ := conn.Query(ctx, query, params...)
+	scanRows := func(rows pgx.Rows) (*api.StorageObjects, error) {
 		defer rows.Close()
 		funcObjects := &api.StorageObjects{Objects: make([]*api.StorageObject, 0, len(objectIDs))}
 		for rows.Next() {
@@ -559,7 +560,7 @@ SELECT collection, key, user_id, value, version, read, write, create_time, updat
 			var updateTime pgtype.Timestamptz
 
 			if err := rows.Scan(&o.Collection, &o.Key, &o.UserId, &o.Value, &o.Version, &o.PermissionRead, &o.PermissionWrite, &createTime, &updateTime); err != nil {
-				return err
+				return nil, err
 			}
 
 			o.CreateTime.Seconds = createTime.Time.Unix()
@@ -571,18 +572,48 @@ SELECT collection, key, user_id, value, version, read, write, create_time, updat
 			if !errors.Is(err, context.Canceled) {
 				logger.Error("Could not read storage objects.", zap.Error(err))
 			}
-			return err
+			return nil, err
 		}
-		objects = funcObjects
-		return nil
+		return funcObjects, nil
+	}
+
+	// If custom tx was handed in execute that instead.
+	if tx != nil {
+		rows, err := tx.Query(ctx, query, params...)
+		if err != nil {
+			return nil, err
+		}
+		return scanRows(rows)
+	}
+
+	var objects *api.StorageObjects
+	err := ExecuteRetryablePgx(ctx, db, func(conn *pgx.Conn) error {
+		rows, _ := conn.Query(ctx, query, params...)
+		var scanErr error
+		objects, scanErr = scanRows(rows)
+		return scanErr
 	})
 
 	return objects, err
 }
 
-func StorageWriteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Metrics, storageIndex StorageIndex, authoritativeWrite bool, ops StorageOpWrites) (*api.StorageObjectAcks, codes.Code, error) {
+func StorageWriteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Metrics, storageIndex StorageIndex, authoritativeWrite bool, ops StorageOpWrites, tx pgx.Tx) (*api.StorageObjectAcks, codes.Code, error) {
 	var acks []*api.StorageObjectAck
 	var sortedWrites StorageOpWrites
+
+	// If custom tx was handed in execute that instead.
+	if tx != nil {
+		var writeErr error
+		sortedWrites, acks, writeErr = storageWriteObjects(ctx, logger, metrics, tx, authoritativeWrite, ops)
+		if writeErr != nil {
+			if errors.Is(writeErr, runtime.ErrStorageRejectedVersion) || errors.Is(writeErr, runtime.ErrStorageRejectedPermission) {
+				return nil, codes.InvalidArgument, writeErr
+			}
+			return nil, codes.Internal, writeErr
+		}
+		storageIndexWrite(ctx, storageIndex, sortedWrites, acks)
+		return &api.StorageObjectAcks{Acks: acks}, codes.OK, nil
+	}
 
 	if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
 		// If the transaction is retried ensure we wipe any acks that may have been prepared by previous attempts.
@@ -684,7 +715,7 @@ func storageWriteObjects(ctx context.Context, logger *zap.Logger, metrics Metric
 
 func StorageWriteWithRetries(ctx context.Context, logger *zap.Logger, db *sql.DB, metrics Metrics, storageIndex StorageIndex, objectIDs []*api.ReadStorageObjectId, updateFn func(objects []*api.StorageObject) ([]*runtime.StorageWrite, error), maxRetries int) (*api.StorageObjectAcks, error) {
 	for retryCount := 0; retryCount <= maxRetries; retryCount++ {
-		objs, err := StorageReadObjects(ctx, logger, db, uuid.Nil, objectIDs)
+		objs, err := StorageReadObjects(ctx, logger, db, uuid.Nil, objectIDs, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -730,7 +761,7 @@ func StorageWriteWithRetries(ctx context.Context, logger *zap.Logger, db *sql.DB
 			ops = append(ops, op)
 		}
 
-		acks, _, err := StorageWriteObjects(ctx, logger, db, metrics, storageIndex, true, ops)
+		acks, _, err := StorageWriteObjects(ctx, logger, db, metrics, storageIndex, true, ops, nil)
 		if err != nil {
 			if errors.Is(err, runtime.ErrStorageRejectedVersion) {
 				backoff := min(int64(2<<retryCount)*int64(time.Millisecond), int64(20*time.Millisecond))
@@ -837,7 +868,16 @@ func storagePrepBatch(batch *pgx.Batch, authoritativeWrite bool, op *StorageOpWr
 	batch.Queue(query, params...)
 }
 
-func StorageDeleteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, storageIndex StorageIndex, authoritativeDelete bool, ops StorageOpDeletes) (codes.Code, error) {
+func StorageDeleteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, storageIndex StorageIndex, authoritativeDelete bool, ops StorageOpDeletes, tx pgx.Tx) (codes.Code, error) {
+	// If custom tx was handed in execute that instead.
+	if tx != nil {
+		if err := storageDeleteObjects(ctx, logger, tx, authoritativeDelete, ops); err != nil {
+			return codes.Internal, err
+		}
+		storageIndex.Delete(ctx, ops)
+		return codes.OK, nil
+	}
+
 	if err := ExecuteInTxPgx(ctx, db, func(tx pgx.Tx) error {
 		deleteErr := storageDeleteObjects(ctx, logger, tx, authoritativeDelete, ops)
 		if deleteErr != nil {
@@ -914,4 +954,91 @@ func storageIndexWrite(ctx context.Context, storageIndex StorageIndex, ops Stora
 	}
 
 	storageIndex.Write(ctx, sw)
+}
+
+// openTx holds an in-progress database transaction and the channel used to
+// release the underlying connection once the transaction is closed.
+type openTx struct {
+	tx     pgx.Tx
+	doneCh chan struct{}
+}
+
+// txBegin acquires a dedicated connection, begins a transaction on it,
+// and registers it in openTxs. A goroutine watches ctx and rolls back
+// automatically if the caller never commits or ro.
+func txBegin(ctx context.Context, db *sql.DB, openTxs *sync.Map) (*runtime.StorageTx, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	txReadyCh := make(chan error, 1)
+	doneCh := make(chan struct{})
+	var pgxTx pgx.Tx
+
+	go func() {
+		defer conn.Close()
+		_ = conn.Raw(func(driverConn any) error {
+			pgxConn := driverConn.(*stdlib.Conn).Conn()
+			tx, err := pgxConn.BeginTx(context.Background(), pgx.TxOptions{})
+			if err != nil {
+				txReadyCh <- err
+				return err
+			}
+			pgxTx = tx
+			txReadyCh <- nil
+			<-doneCh
+			return nil
+		})
+	}()
+
+	if err := <-txReadyCh; err != nil {
+		return nil, err
+	}
+
+	txID := uuid.Must(uuid.NewV4()).String()
+	openTxs.Store(txID, &openTx{tx: pgxTx, doneCh: doneCh})
+
+	go func() {
+		<-ctx.Done()
+		if val, loaded := openTxs.LoadAndDelete(txID); loaded {
+			entry := val.(*openTx)
+			_ = entry.tx.Rollback(context.Background())
+			close(entry.doneCh)
+		}
+	}()
+
+	return &runtime.StorageTx{ID: txID}, nil
+}
+
+// txCommit commits the transaction and releases its connection.
+func txCommit(ctx context.Context, tx *runtime.StorageTx, openTxs *sync.Map) error {
+	val, loaded := openTxs.LoadAndDelete(tx.ID)
+	if !loaded {
+		return errors.New("transaction not found or already closed")
+	}
+	entry := val.(*openTx)
+	err := entry.tx.Commit(ctx)
+	close(entry.doneCh)
+	return err
+}
+
+// txRollback rolls back the transaction and releases its connection.
+func txRollback(ctx context.Context, tx *runtime.StorageTx, openTxs *sync.Map) error {
+	val, loaded := openTxs.LoadAndDelete(tx.ID)
+	if !loaded {
+		return errors.New("transaction not found or already closed")
+	}
+	entry := val.(*openTx)
+	err := entry.tx.Rollback(ctx)
+	close(entry.doneCh)
+	return err
+}
+
+func getTx(tx *runtime.StorageTx, openTxs *sync.Map) (pgx.Tx, bool) {
+	val, loaded := openTxs.Load(tx.ID)
+	if !loaded {
+		return nil, false
+	}
+	return val.(*openTx).tx, true
 }

--- a/server/core_storage_test.go
+++ b/server/core_storage_test.go
@@ -2767,7 +2767,7 @@ func TestStorageTxCommit(t *testing.T) {
 	key := GenerateString()
 	var openTxs sync.Map
 
-	tx, err := txBegin(context.Background(), db, &openTxs)
+	tx, err := txBegin(context.Background(), logger, db, &openTxs)
 	assert.Nil(t, err, "txBegin failed")
 	assert.NotEmpty(t, tx.ID, "tx ID was empty")
 
@@ -2803,7 +2803,7 @@ func TestStorageTxRollback(t *testing.T) {
 	key := GenerateString()
 	var openTxs sync.Map
 
-	tx, err := txBegin(context.Background(), db, &openTxs)
+	tx, err := txBegin(context.Background(), logger, db, &openTxs)
 	assert.Nil(t, err, "txBegin failed")
 
 	pgxTx, ok := getTx(tx, &openTxs)
@@ -2841,7 +2841,7 @@ func TestStorageTxContextCancelRollback(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	tx, err := txBegin(ctx, db, &openTxs)
+	tx, err := txBegin(ctx, logger, db, &openTxs)
 	assert.Nil(t, err, "txBegin failed")
 
 	entry, _ := openTxs.Load(tx.ID)

--- a/server/core_storage_test.go
+++ b/server/core_storage_test.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/gofrs/uuid/v5"
@@ -45,7 +46,7 @@ func TestStorageWriteRuntimeGlobalSingle(t *testing.T) {
 			PermissionWrite: &wrapperspb.Int32Value{Value: 1},
 		},
 	}}
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -60,7 +61,7 @@ func TestStorageWriteRuntimeGlobalSingle(t *testing.T) {
 			Collection: "testcollection",
 			Key:        key,
 		}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, readData.Objects, "readData was nil")
@@ -116,7 +117,7 @@ func TestStorageWriteRuntimeUserMultiple(t *testing.T) {
 			},
 		},
 	}
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -149,7 +150,7 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchNotExists(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -174,7 +175,7 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -199,7 +200,7 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not 0")
@@ -228,7 +229,7 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchExistsFail(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -253,7 +254,7 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchExistsFail(t *testing.T) {
 		},
 	}
 
-	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -279,7 +280,7 @@ func TestStorageWriteRuntimeGlobalSingleIfNoneMatchNotExists(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -307,7 +308,7 @@ func TestStorageWriteRuntimeGlobalSingleIfNoneMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -331,7 +332,7 @@ func TestStorageWriteRuntimeGlobalSingleIfNoneMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -367,7 +368,7 @@ func TestStorageWriteRuntimeGlobalMultipleIfMatchNotExists(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -395,7 +396,7 @@ func TestStorageWritePipelineUserSingle(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -446,7 +447,7 @@ func TestStorageWritePipelineUserMultiple(t *testing.T) {
 		},
 	}
 
-	allAcks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	allAcks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -509,7 +510,7 @@ func TestStorageWriteRuntimeGlobalMultipleSameKey(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -535,7 +536,7 @@ func TestStorageWriteRuntimeGlobalMultipleSameKey(t *testing.T) {
 		Key:        key,
 	}}
 
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, readData, "readData was nil")
 	assert.Len(t, readData.Objects, 1, "readData length was not 1")
@@ -578,7 +579,7 @@ func TestStorageWritePipelineUserMultipleSameKey(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not 0")
@@ -599,7 +600,7 @@ func TestStorageWritePipelineUserMultipleSameKey(t *testing.T) {
 		UserId:     uid.String(),
 	}}
 
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, readData, "readData was nil")
 	assert.Len(t, readData.Objects, 1, "readData length was not 1")
@@ -632,7 +633,7 @@ func TestStorageWritePipelineIfMatchNotExists(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -660,7 +661,7 @@ func TestStorageWritePipelineIfMatchExistsFail(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -684,7 +685,7 @@ func TestStorageWritePipelineIfMatchExistsFail(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -713,7 +714,7 @@ func TestStorageWritePipelineIfMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -737,7 +738,7 @@ func TestStorageWritePipelineIfMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -769,7 +770,7 @@ func TestStorageWritePipelineIfNoneMatchNotExists(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -801,7 +802,7 @@ func TestStorageWritePipelineIfNoneMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -825,7 +826,7 @@ func TestStorageWritePipelineIfNoneMatchExists(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -854,7 +855,7 @@ func TestStorageWritePipelinePermissionFail(t *testing.T) {
 		},
 	}
 
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, acks, "acks was nil")
@@ -877,7 +878,7 @@ func TestStorageWritePipelinePermissionFail(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, acks, "acks was not nil")
 	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
@@ -904,7 +905,7 @@ func TestStorageFetchRuntimeGlobalPrivate(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -920,7 +921,7 @@ func TestStorageFetchRuntimeGlobalPrivate(t *testing.T) {
 		Collection: "testcollection",
 		Key:        key,
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, readData, "readData was nil")
@@ -952,7 +953,7 @@ func TestStorageFetchRuntimeMixed(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -971,7 +972,7 @@ func TestStorageFetchRuntimeMixed(t *testing.T) {
 			Collection: "testcollection",
 			Key:        "notfound",
 		}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1007,7 +1008,7 @@ func TestStorageFetchRuntimeUserPrivate(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1024,7 +1025,7 @@ func TestStorageFetchRuntimeUserPrivate(t *testing.T) {
 		Key:        key,
 		UserId:     uid.String(),
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1058,7 +1059,7 @@ func TestStorageFetchPipelineGlobalPrivate(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1074,7 +1075,7 @@ func TestStorageFetchPipelineGlobalPrivate(t *testing.T) {
 		Collection: "testcollection",
 		Key:        key,
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1103,7 +1104,7 @@ func TestStorageFetchPipelineUserPrivate(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1120,7 +1121,7 @@ func TestStorageFetchPipelineUserPrivate(t *testing.T) {
 		Key:        key,
 		UserId:     uid.String(),
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1149,7 +1150,7 @@ func TestStorageFetchPipelineUserRead(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1166,7 +1167,7 @@ func TestStorageFetchPipelineUserRead(t *testing.T) {
 		Key:        key,
 		UserId:     uid.String(),
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1202,7 +1203,7 @@ func TestStorageFetchPipelineUserPublic(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1218,7 +1219,7 @@ func TestStorageFetchPipelineUserPublic(t *testing.T) {
 		Key:        key,
 		UserId:     uid.String(),
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1254,7 +1255,7 @@ func TestStorageFetchPipelineUserOtherRead(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1271,7 +1272,7 @@ func TestStorageFetchPipelineUserOtherRead(t *testing.T) {
 		Key:        key,
 		UserId:     uid.String(),
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, readData, "readData was nil")
@@ -1299,7 +1300,7 @@ func TestStorageFetchPipelineUserOtherPublic(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1317,7 +1318,7 @@ func TestStorageFetchPipelineUserOtherPublic(t *testing.T) {
 		Key:        key,
 		UserId:     uid.String(),
 	}}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, readData, "readData was nil")
@@ -1363,7 +1364,7 @@ func TestStorageFetchPipelineUserOtherPublicMixed(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1407,7 +1408,7 @@ func TestStorageFetchPipelineUserOtherPublicMixed(t *testing.T) {
 			UserId:     uid.String(),
 		},
 	}
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Must(uuid.NewV4()), ids, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.NotNil(t, readData, "readData was nil")
@@ -1440,7 +1441,7 @@ func TestStorageRemoveRuntimeGlobalPublic(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1462,7 +1463,7 @@ func TestStorageRemoveRuntimeGlobalPublic(t *testing.T) {
 		},
 	}
 
-	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.Nil(t, err, "err was not nil")
 }
 
@@ -1485,7 +1486,7 @@ func TestStorageRemoveRuntimeGlobalPrivate(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1507,7 +1508,7 @@ func TestStorageRemoveRuntimeGlobalPrivate(t *testing.T) {
 		},
 	}
 
-	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.Nil(t, err, "err was not nil")
 }
 
@@ -1532,7 +1533,7 @@ func TestStorageRemoveRuntimeUserPublic(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1554,7 +1555,7 @@ func TestStorageRemoveRuntimeUserPublic(t *testing.T) {
 		},
 	}
 
-	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.Nil(t, err, "err was not nil")
 }
 
@@ -1579,7 +1580,7 @@ func TestStorageRemoveRuntimeUserPrivate(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1601,7 +1602,7 @@ func TestStorageRemoveRuntimeUserPrivate(t *testing.T) {
 		},
 	}
 
-	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.Nil(t, err, "err was not nil")
 
 	ids := []*api.ReadStorageObjectId{{
@@ -1610,7 +1611,7 @@ func TestStorageRemoveRuntimeUserPrivate(t *testing.T) {
 		UserId:     uid.String(),
 	}}
 
-	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 0, "data length was not 0")
 }
@@ -1636,7 +1637,7 @@ func TestStorageRemovePipelineUserWrite(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1658,7 +1659,7 @@ func TestStorageRemovePipelineUserWrite(t *testing.T) {
 		},
 	}
 
-	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	_, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.Nil(t, err, "err was not nil")
 }
 
@@ -1683,7 +1684,7 @@ func TestStorageRemovePipelineUserDenied(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1705,7 +1706,7 @@ func TestStorageRemovePipelineUserDenied(t *testing.T) {
 		},
 	}
 
-	code, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, false, deleteOps)
+	code, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, false, deleteOps, nil)
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, code, codes.InvalidArgument, "code did not match InvalidArgument.")
 }
@@ -1725,7 +1726,7 @@ func TestStorageRemoveRuntimeGlobalIfMatchNotExists(t *testing.T) {
 		},
 	}
 
-	code, err := StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	code, err := StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, code, codes.InvalidArgument, "code did not match InvalidArgument.")
 }
@@ -1749,7 +1750,7 @@ func TestStorageRemoveRuntimeGlobalIfMatchRejected(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1772,7 +1773,7 @@ func TestStorageRemoveRuntimeGlobalIfMatchRejected(t *testing.T) {
 		},
 	}
 
-	code, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	code, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.NotNil(t, err, "err was not nil")
 	assert.Equal(t, code, codes.InvalidArgument, "code did not match InvalidArgument.")
 }
@@ -1796,7 +1797,7 @@ func TestStorageRemoveRuntimeGlobalIfMatch(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1819,7 +1820,7 @@ func TestStorageRemoveRuntimeGlobalIfMatch(t *testing.T) {
 		},
 	}
 
-	code, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps)
+	code, err = StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, deleteOps, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, code, codes.OK, "code did not match OK.")
 }
@@ -1864,7 +1865,7 @@ func TestStorageListRuntimeUser(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1921,7 +1922,7 @@ func TestStorageListPipelineUserSelf(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -1980,7 +1981,7 @@ func TestStorageListPipelineUserOther(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -2077,7 +2078,7 @@ func TestStorageListNoRepeats(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -2115,7 +2116,7 @@ func TestStorageOverrwriteEmptyAndNonEmptyVersions(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -2135,7 +2136,7 @@ func TestStorageOverrwriteEmptyAndNonEmptyVersions(t *testing.T) {
 		},
 	}
 
-	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -2156,7 +2157,7 @@ func TestStorageOverrwriteEmptyAndNonEmptyVersions(t *testing.T) {
 		},
 	}
 
-	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not OK")
@@ -2304,7 +2305,7 @@ func writeObject(t *testing.T, db *sql.DB, collection, key string, owner uuid.UU
 			PermissionWrite: &wrapperspb.Int32Value{Value: int32(writePerm)},
 		},
 	}}
-	return StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, authoritative, ops)
+	return StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, authoritative, ops, nil)
 }
 
 func TestOCCWriteSameValueWithOutdatedVersionFail(t *testing.T) {
@@ -2329,7 +2330,7 @@ func TestOCCWriteSameValueWithOutdatedVersionFail(t *testing.T) {
 	}
 
 	// Create object
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 	assert.Nil(t, err)
 	assert.Len(t, acks.Acks, 1)
 
@@ -2338,12 +2339,12 @@ func TestOCCWriteSameValueWithOutdatedVersionFail(t *testing.T) {
 	ops[0].Object.Version = version
 	ops[0].Object.Value = `{"closed":true}`
 
-	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 	assert.Nil(t, err)
 	assert.Len(t, acks.Acks, 1)
 
 	// Rewrite object to same value with now invalid version -- must fail
-	_, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	_, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error())
 }
@@ -2370,7 +2371,7 @@ func TestOCCWriteSameValueCorrectVersionSuccess(t *testing.T) {
 	}
 
 	// Create object
-	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 	assert.Nil(t, err)
 	assert.Len(t, acks.Acks, 1)
 
@@ -2378,14 +2379,14 @@ func TestOCCWriteSameValueCorrectVersionSuccess(t *testing.T) {
 	ops[0].Object.Version = acks.Acks[0].Version
 	ops[0].Object.Value = `{"closed":true}`
 
-	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 	assert.Nil(t, err)
 	assert.Len(t, acks.Acks, 1)
 
 	// Rewrite object to same value with correct version -- must succeed
 	ops[0].Object.Version = acks.Acks[0].Version
 
-	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
+	acks, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, nil)
 	assert.Nil(t, err)
 	assert.Len(t, acks.Acks, 1)
 }
@@ -2422,7 +2423,7 @@ func TestStorageReadObjectsSameArgs(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not 0")
@@ -2438,7 +2439,7 @@ func TestStorageReadObjectsSameArgs(t *testing.T) {
 		UserId:     uid.String(),
 	}}
 
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 1, "readData length was not 1")
 	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
@@ -2456,7 +2457,7 @@ func TestStorageReadObjectsSameArgs(t *testing.T) {
 		UserId:     uid.String(),
 	}}
 
-	readData, err = StorageReadObjects(context.Background(), logger, db, uid, ids)
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 1, "readData length was not 1")
 	assert.Equal(t, "testcollection2", readData.Objects[0].Collection, "collection did not match")
@@ -2520,7 +2521,7 @@ func TestStorageReadObjectsOneDistinctArg(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not 0")
@@ -2536,7 +2537,7 @@ func TestStorageReadObjectsOneDistinctArg(t *testing.T) {
 		UserId:     uid1.String(),
 	}}
 
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 2, "readData length was not 2")
 	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
@@ -2555,7 +2556,7 @@ func TestStorageReadObjectsOneDistinctArg(t *testing.T) {
 		UserId:     uid1.String(),
 	}}
 
-	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 2, "readData length was not 2")
 	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
@@ -2574,7 +2575,7 @@ func TestStorageReadObjectsOneDistinctArg(t *testing.T) {
 		UserId:     uid2.String(),
 	}}
 
-	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 2, "readData length was not 2")
 	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
@@ -2639,7 +2640,7 @@ func TestStorageReadObjectsTwoDistinctArgs(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not 0")
@@ -2655,7 +2656,7 @@ func TestStorageReadObjectsTwoDistinctArgs(t *testing.T) {
 		UserId:     uid1.String(),
 	}}
 
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 2, "readData length was not 2")
 	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
@@ -2673,7 +2674,7 @@ func TestStorageReadObjectsTwoDistinctArgs(t *testing.T) {
 		UserId:     uid2.String(),
 	}}
 
-	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 2, "readData length was not 2")
 	assert.Equal(t, "testcollection1", readData.Objects[0].Collection, "collection did not match")
@@ -2691,7 +2692,7 @@ func TestStorageReadObjectsTwoDistinctArgs(t *testing.T) {
 		UserId:     uid2.String(),
 	}}
 
-	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	readData, err = StorageReadObjects(context.Background(), logger, db, uid1, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 2, "readData length was not 2")
 	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
@@ -2735,7 +2736,7 @@ func TestStorageReadObjectsAllDistinctArgs(t *testing.T) {
 		},
 	}
 
-	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
+	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops, nil)
 
 	assert.Nil(t, err, "err was not nil")
 	assert.Equal(t, codes.OK, code, "code was not 0")
@@ -2751,10 +2752,122 @@ func TestStorageReadObjectsAllDistinctArgs(t *testing.T) {
 		UserId:     uid2.String(),
 	}}
 
-	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids)
+	readData, err := StorageReadObjects(context.Background(), logger, db, uid1, ids, nil)
 	assert.Nil(t, err, "err was not nil")
 	assert.Len(t, readData.Objects, 2, "readData length was not 2")
 	assert.ElementsMatch(t, []string{"testcollection1", "testcollection2"}, []string{readData.Objects[0].Collection, readData.Objects[1].Collection}, "collection did not match")
 	assert.ElementsMatch(t, []string{key1, key2}, []string{readData.Objects[0].Key, readData.Objects[1].Key}, "key did not match")
 	assert.ElementsMatch(t, []string{uid1.String(), uid2.String()}, []string{readData.Objects[0].UserId, readData.Objects[1].UserId}, "user id did not match")
+}
+
+func TestStorageTxCommit(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	key := GenerateString()
+	var openTxs sync.Map
+
+	tx, err := txBegin(context.Background(), db, &openTxs)
+	assert.Nil(t, err, "txBegin failed")
+	assert.NotEmpty(t, tx.ID, "tx ID was empty")
+
+	pgxTx, ok := getTx(tx, &openTxs)
+	assert.True(t, ok, "getTx returned false")
+
+	ops := StorageOpWrites{&StorageOpWrite{
+		OwnerID: uuid.Nil.String(),
+		Object: &api.WriteStorageObject{
+			Collection:      "testcollection",
+			Key:             key,
+			Value:           "{\"foo\":\"bar\"}",
+			PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+			PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+		},
+	}}
+	_, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, pgxTx)
+	assert.Nil(t, err, "StorageWriteObjects inside tx failed")
+
+	assert.Nil(t, txCommit(context.Background(), tx, &openTxs), "txCommit failed")
+
+	ids := []*api.ReadStorageObjectId{{Collection: "testcollection", Key: key}}
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
+	assert.Nil(t, err, "read after commit failed")
+	assert.Len(t, readData.Objects, 1, "write should be visible after commit")
+	assert.Equal(t, key, readData.Objects[0].Key, "key did not match")
+}
+
+func TestStorageTxRollback(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	key := GenerateString()
+	var openTxs sync.Map
+
+	tx, err := txBegin(context.Background(), db, &openTxs)
+	assert.Nil(t, err, "txBegin failed")
+
+	pgxTx, ok := getTx(tx, &openTxs)
+	assert.True(t, ok, "getTx returned false")
+
+	ops := StorageOpWrites{&StorageOpWrite{
+		OwnerID: uuid.Nil.String(),
+		Object: &api.WriteStorageObject{
+			Collection:      "testcollection",
+			Key:             key,
+			Value:           "{\"foo\":\"bar\"}",
+			PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+			PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+		},
+	}}
+	_, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops, pgxTx)
+	assert.Nil(t, err, "StorageWriteObjects inside tx failed")
+
+	assert.Nil(t, txRollback(context.Background(), tx, &openTxs), "txRollback failed")
+
+	ids := []*api.ReadStorageObjectId{{Collection: "testcollection", Key: key}}
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
+	assert.Nil(t, err, "read after rollback failed")
+	assert.Len(t, readData.Objects, 0, "rolled-back write should not be visible")
+}
+
+// TestStorageTxContextCancelRollback verifies that cancelling the RPC context
+// automatically rolls back an uncommitted transaction.
+func TestStorageTxContextCancelRollback(t *testing.T) {
+	db := NewDB(t)
+	defer db.Close()
+
+	key := GenerateString()
+	var openTxs sync.Map
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tx, err := txBegin(ctx, db, &openTxs)
+	assert.Nil(t, err, "txBegin failed")
+
+	entry, _ := openTxs.Load(tx.ID)
+	doneCh := entry.(*openTx).doneCh
+
+	pgxTx, _ := getTx(tx, &openTxs)
+
+	_, _, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, StorageOpWrites{&StorageOpWrite{
+		OwnerID: uuid.Nil.String(),
+		Object: &api.WriteStorageObject{
+			Collection:      "testcollection",
+			Key:             key,
+			Value:           "{\"foo\":\"bar\"}",
+			PermissionRead:  &wrapperspb.Int32Value{Value: 2},
+			PermissionWrite: &wrapperspb.Int32Value{Value: 1},
+		},
+	}}, pgxTx)
+	assert.Nil(t, err, "write inside tx failed")
+
+	cancel()
+
+	// wait for Tx to rollback
+	<-doneCh
+
+	ids := []*api.ReadStorageObjectId{{Collection: "testcollection", Key: key}}
+	readData, err := StorageReadObjects(context.Background(), logger, db, uuid.Nil, ids, nil)
+	assert.Nil(t, err, "read after cancel failed")
+	assert.Len(t, readData.Objects, 0, "cancelled tx write should not be visible")
 }

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -33,9 +33,9 @@ import (
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/console"
-	"github.com/jackc/pgx/v5"
 	"github.com/heroiclabs/nakama/v3/internal/cronexpr"
 	"github.com/heroiclabs/nakama/v3/social"
+	"github.com/jackc/pgx/v5"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -2185,7 +2185,10 @@ func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*ru
 	}
 
 	var pgxTx pgx.Tx
-	if len(tx) > 0 {
+	if len(tx) > 1 {
+		return nil, errors.New("expects at most one transaction")
+	}
+	if len(tx) == 1 && tx[0] != nil && tx[0].ID != "" {
 		var ok bool
 		pgxTx, ok = getTx(tx[0], &n.openTxs)
 		if !ok {
@@ -2251,7 +2254,10 @@ func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, objectIDs []*r
 	}
 
 	var pgxTx pgx.Tx
-	if len(tx) > 0 {
+	if len(tx) > 1 {
+		return nil, errors.New("expects at most one transaction")
+	}
+	if len(tx) == 1 && tx[0] != nil && tx[0].ID != "" {
 		var ok bool
 		pgxTx, ok = getTx(tx[0], &n.openTxs)
 		if !ok {
@@ -2355,7 +2361,10 @@ func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, objectIDs []*
 	}
 
 	var pgxTx pgx.Tx
-	if len(tx) > 0 {
+	if len(tx) > 1 {
+		return errors.New("expects at most one transaction")
+	}
+	if len(tx) == 1 && tx[0] != nil && tx[0].ID != "" {
 		var ok bool
 		pgxTx, ok = getTx(tx[0], &n.openTxs)
 		if !ok {
@@ -4601,7 +4610,7 @@ func (n *RuntimeGoNakamaModule) GetFleetManager() runtime.FleetManager {
 }
 
 func (n *RuntimeGoNakamaModule) TxBegin(ctx context.Context) (*runtime.StorageTx, error) {
-	return txBegin(ctx, n.db, &n.openTxs)
+	return txBegin(ctx, n.logger, n.db, &n.openTxs)
 }
 
 func (n *RuntimeGoNakamaModule) TxCommit(ctx context.Context, tx *runtime.StorageTx) error {

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -2152,6 +2152,7 @@ func (n *RuntimeGoNakamaModule) StorageList(ctx context.Context, callerID, userI
 // @summary Fetch one or more records by their bucket/collection/keyname and optional user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param objectIDs(type=[]*runtime.StorageRead) An array of object identifiers to be fetched.
+// @param tx(type=...*runtime.StorageTx, optional=true) An optional transaction handle from TxBegin.
 // @return objects([]*api.StorageObject) A list of storage objects matching the parameters criteria.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*runtime.StorageRead, tx ...*runtime.StorageTx) ([]*api.StorageObject, error) {
@@ -2208,6 +2209,7 @@ func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*ru
 // @summary Write one or more objects by their collection/keyname and optional user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param objectIDs(type=[]*runtime.StorageWrite) An array of object identifiers to be written.
+// @param tx(type=...*runtime.StorageTx, optional=true) An optional transaction handle from TxBegin.
 // @return acks([]*api.StorageObjectAck) A list of acks with the version of the written objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, objectIDs []*runtime.StorageWrite, tx ...*runtime.StorageTx) ([]*api.StorageObjectAck, error) {
@@ -2277,6 +2279,7 @@ func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, objectIDs []*r
 // @summary Write a set of storage object changes with retries.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param objectIDs(type=[]*runtime.StorageRead) An array of object identifiers to be fetched.
+// @param tx(type=...*runtime.StorageTx, optional=true) An optional transaction handle from TxBegin.
 // @param updateFn(type=function) A function that applies changes to the read storage objects.
 // @param maxRetries(type=int) Maximum number of retries to attempt if a version conflict is detected. Must be a value between 0 and 10.
 // @return acks([]*api.StorageObjectAck) A list of acks with the version of the written objects.
@@ -2322,6 +2325,7 @@ func (n *RuntimeGoNakamaModule) StorageWriteRetry(ctx context.Context, objectIDs
 // @summary Remove one or more objects by their collection/keyname and optional user.
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param objectIDs(type=[]*runtime.StorageDelete) An array of object identifiers to be deleted.
+// @param tx(type=...*runtime.StorageTx, optional=true) An optional transaction handle from TxBegin.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, objectIDs []*runtime.StorageDelete, tx ...*runtime.StorageTx) error {
 	size := len(objectIDs)

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -33,6 +33,7 @@ import (
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/console"
+	"github.com/jackc/pgx/v5"
 	"github.com/heroiclabs/nakama/v3/internal/cronexpr"
 	"github.com/heroiclabs/nakama/v3/social"
 	"go.uber.org/zap"
@@ -66,6 +67,7 @@ type RuntimeGoNakamaModule struct {
 	satori               runtime.Satori
 	fleetManager         runtime.FleetManager
 	storageIndex         StorageIndex
+	openTxs              sync.Map
 }
 
 func NewRuntimeGoNakamaModule(logger *zap.Logger, db *sql.DB, protojsonMarshaler *protojson.MarshalOptions, config Config, socialClient *social.Client, leaderboardCache LeaderboardCache, leaderboardRankCache LeaderboardRankCache, leaderboardScheduler LeaderboardScheduler, sessionRegistry SessionRegistry, sessionCache SessionCache, statusRegistry StatusRegistry, matchRegistry MatchRegistry, partyRegistry PartyRegistry, tracker Tracker, metrics Metrics, streamManager StreamManager, router MessageRouter, storageIndex StorageIndex, satoriClient runtime.Satori) *RuntimeGoNakamaModule {
@@ -2152,7 +2154,7 @@ func (n *RuntimeGoNakamaModule) StorageList(ctx context.Context, callerID, userI
 // @param objectIDs(type=[]*runtime.StorageRead) An array of object identifiers to be fetched.
 // @return objects([]*api.StorageObject) A list of storage objects matching the parameters criteria.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*runtime.StorageRead) ([]*api.StorageObject, error) {
+func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*runtime.StorageRead, tx ...*runtime.StorageTx) ([]*api.StorageObject, error) {
 	size := len(objectIDs)
 	if size == 0 {
 		return make([]*api.StorageObject, 0), nil
@@ -2182,7 +2184,16 @@ func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*ru
 		}
 	}
 
-	objects, err := StorageReadObjects(ctx, n.logger, n.db, uuid.Nil, reads)
+	var pgxTx pgx.Tx
+	if len(tx) > 0 {
+		var ok bool
+		pgxTx, ok = getTx(tx[0], &n.openTxs)
+		if !ok {
+			return nil, errors.New("transaction not found or already closed")
+		}
+	}
+
+	objects, err := StorageReadObjects(ctx, n.logger, n.db, uuid.Nil, reads, pgxTx)
 	if err != nil {
 		return nil, err
 	}
@@ -2196,7 +2207,7 @@ func (n *RuntimeGoNakamaModule) StorageRead(ctx context.Context, objectIDs []*ru
 // @param objectIDs(type=[]*runtime.StorageWrite) An array of object identifiers to be written.
 // @return acks([]*api.StorageObjectAck) A list of acks with the version of the written objects.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, objectIDs []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, objectIDs []*runtime.StorageWrite, tx ...*runtime.StorageTx) ([]*api.StorageObjectAck, error) {
 	size := len(objectIDs)
 	if size == 0 {
 		return make([]*api.StorageObjectAck, 0), nil
@@ -2239,7 +2250,16 @@ func (n *RuntimeGoNakamaModule) StorageWrite(ctx context.Context, objectIDs []*r
 		ops = append(ops, op)
 	}
 
-	acks, _, err := StorageWriteObjects(ctx, n.logger, n.db, n.metrics, n.storageIndex, true, ops)
+	var pgxTx pgx.Tx
+	if len(tx) > 0 {
+		var ok bool
+		pgxTx, ok = getTx(tx[0], &n.openTxs)
+		if !ok {
+			return nil, errors.New("transaction not found or already closed")
+		}
+	}
+
+	acks, _, err := StorageWriteObjects(ctx, n.logger, n.db, n.metrics, n.storageIndex, true, ops, pgxTx)
 	if err != nil {
 		return nil, err
 	}
@@ -2297,7 +2317,7 @@ func (n *RuntimeGoNakamaModule) StorageWriteRetry(ctx context.Context, objectIDs
 // @param ctx(type=context.Context) The context object represents information about the server and requester.
 // @param objectIDs(type=[]*runtime.StorageDelete) An array of object identifiers to be deleted.
 // @return error(error) An optional error value if an error occurred.
-func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, objectIDs []*runtime.StorageDelete) error {
+func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, objectIDs []*runtime.StorageDelete, tx ...*runtime.StorageTx) error {
 	size := len(objectIDs)
 	if size == 0 {
 		return nil
@@ -2334,7 +2354,16 @@ func (n *RuntimeGoNakamaModule) StorageDelete(ctx context.Context, objectIDs []*
 		ops = append(ops, op)
 	}
 
-	_, err := StorageDeleteObjects(ctx, n.logger, n.db, n.storageIndex, true, ops)
+	var pgxTx pgx.Tx
+	if len(tx) > 0 {
+		var ok bool
+		pgxTx, ok = getTx(tx[0], &n.openTxs)
+		if !ok {
+			return errors.New("transaction not found or already closed")
+		}
+	}
+
+	_, err := StorageDeleteObjects(ctx, n.logger, n.db, n.storageIndex, true, ops, pgxTx)
 
 	return err
 }
@@ -4569,4 +4598,16 @@ func (n *RuntimeGoNakamaModule) GetSatori() runtime.Satori {
 // @return fleetManager(runtime.FleetManager) The Fleet Manager client.
 func (n *RuntimeGoNakamaModule) GetFleetManager() runtime.FleetManager {
 	return n.fleetManager
+}
+
+func (n *RuntimeGoNakamaModule) TxBegin(ctx context.Context) (*runtime.StorageTx, error) {
+	return txBegin(ctx, n.db, &n.openTxs)
+}
+
+func (n *RuntimeGoNakamaModule) TxCommit(ctx context.Context, tx *runtime.StorageTx) error {
+	return txCommit(ctx, tx, &n.openTxs)
+}
+
+func (n *RuntimeGoNakamaModule) TxRollback(ctx context.Context, tx *runtime.StorageTx) error {
+	return txRollback(ctx, tx, &n.openTxs)
 }

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -38,11 +38,13 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
 	"github.com/dop251/goja"
 	"github.com/gofrs/uuid/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/rtapi"
@@ -86,7 +88,8 @@ type RuntimeJavascriptNakamaModule struct {
 	matchCreateFn RuntimeMatchCreateFunction
 	eventFn       RuntimeEventCustomFunction
 
-	satori runtime.Satori
+	satori  runtime.Satori
+	openTxs sync.Map
 }
 
 func NewRuntimeJavascriptNakamaModule(logger *zap.Logger, db *sql.DB, protojsonMarshaler *protojson.MarshalOptions, protojsonUnmarshaler *protojson.UnmarshalOptions, config Config, socialClient *social.Client, leaderboardCache LeaderboardCache, rankCache LeaderboardRankCache, storageIndex StorageIndex, localCache *RuntimeJavascriptLocalCache, leaderboardScheduler LeaderboardScheduler, sessionRegistry SessionRegistry, sessionCache SessionCache, statusRegistry StatusRegistry, matchRegistry MatchRegistry, partyRegistry PartyRegistry, tracker Tracker, metrics Metrics, streamManager StreamManager, router MessageRouter, satoriClient runtime.Satori, eventFn RuntimeEventCustomFunction, matchCreateFn RuntimeMatchCreateFunction) *RuntimeJavascriptNakamaModule {
@@ -247,6 +250,9 @@ func (n *RuntimeJavascriptNakamaModule) mappings(r *goja.Runtime) map[string]fun
 		"storageWrite":                         n.storageWrite(r),
 		"storageWriteRetry":                    n.storageWriteRetry(r),
 		"storageDelete":                        n.storageDelete(r),
+		"txBegin":                              n.txBegin(r),
+		"txCommit":                             n.txCommit(r),
+		"txRollback":                           n.txRollback(r),
 		"multiUpdate":                          n.multiUpdate(r),
 		"leaderboardCreate":                    n.leaderboardCreate(r),
 		"leaderboardDelete":                    n.leaderboardDelete(r),
@@ -4925,7 +4931,19 @@ func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.F
 			objectIDsMap = append(objectIDsMap, objectID)
 		}
 
-		objects, err := StorageReadObjects(n.ctx, n.logger, n.db, uuid.Nil, objectIDsMap)
+		var pgxTx pgx.Tx
+		if txArg := f.Argument(1); txArg != goja.Undefined() && txArg != goja.Null() {
+			txID, ok := txArg.Export().(string)
+			if !ok || txID == "" {
+				panic(r.NewTypeError("expects tx to be a string"))
+			}
+			pgxTx, ok = getTx(&runtime.StorageTx{ID: txID}, &n.openTxs)
+			if !ok {
+				panic(r.NewGoError(fmt.Errorf("transaction not found or already closed")))
+			}
+		}
+
+		objects, err := StorageReadObjects(n.ctx, n.logger, n.db, uuid.Nil, objectIDsMap, pgxTx)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to read storage objects: %s", err.Error())))
 		}
@@ -4984,7 +5002,19 @@ func (n *RuntimeJavascriptNakamaModule) storageWrite(r *goja.Runtime) func(goja.
 			panic(r.NewTypeError(err.Error()))
 		}
 
-		acks, _, err := StorageWriteObjects(n.ctx, n.logger, n.db, n.metrics, n.storageIndex, true, ops)
+		var pgxTx pgx.Tx
+		if txArg := f.Argument(1); txArg != goja.Undefined() && txArg != goja.Null() {
+			txID, ok := txArg.Export().(string)
+			if !ok || txID == "" {
+				panic(r.NewTypeError("expects tx to be a string"))
+			}
+			pgxTx, ok = getTx(&runtime.StorageTx{ID: txID}, &n.openTxs)
+			if !ok {
+				panic(r.NewGoError(fmt.Errorf("transaction not found or already closed")))
+			}
+		}
+
+		acks, _, err := StorageWriteObjects(n.ctx, n.logger, n.db, n.metrics, n.storageIndex, true, ops, pgxTx)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to write storage objects: %s", err.Error())))
 		}
@@ -5433,10 +5463,78 @@ func (n *RuntimeJavascriptNakamaModule) storageDelete(r *goja.Runtime) func(goja
 			})
 		}
 
-		if _, err := StorageDeleteObjects(n.ctx, n.logger, n.db, n.storageIndex, true, ops); err != nil {
+		var pgxTx pgx.Tx
+		if txArg := f.Argument(1); txArg != goja.Undefined() && txArg != goja.Null() {
+			txID, ok := txArg.Export().(string)
+			if !ok || txID == "" {
+				panic(r.NewTypeError("expects tx to be a string"))
+			}
+			pgxTx, ok = getTx(&runtime.StorageTx{ID: txID}, &n.openTxs)
+			if !ok {
+				panic(r.NewGoError(fmt.Errorf("transaction not found or already closed")))
+			}
+		}
+
+		if _, err := StorageDeleteObjects(n.ctx, n.logger, n.db, n.storageIndex, true, ops, pgxTx); err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to remove storage: %s", err.Error())))
 		}
 
+		return goja.Undefined()
+	}
+}
+
+// @group storage
+// @summary Begin a new database transaction for use with storage operations.
+// @return tx(type=string) A transaction handle to pass to storageRead, storageWrite, storageDelete, txCommit, or txRollback.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeJavascriptNakamaModule) txBegin(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(f goja.FunctionCall) goja.Value {
+		tx, err := txBegin(n.ctx, n.db, &n.openTxs)
+		if err != nil {
+			panic(r.NewGoError(fmt.Errorf("failed to begin transaction: %s", err.Error())))
+		}
+		return r.ToValue(tx.ID)
+	}
+}
+
+// @group storage
+// @summary Commit an open database transaction.
+// @param tx(type=string) The transaction handle returned by txBegin.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeJavascriptNakamaModule) txCommit(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(f goja.FunctionCall) goja.Value {
+		txArg := f.Argument(0)
+		if txArg == goja.Undefined() || txArg == goja.Null() {
+			panic(r.NewTypeError("expects a transaction id"))
+		}
+		txID, ok := txArg.Export().(string)
+		if !ok || txID == "" {
+			panic(r.NewTypeError("expects tx to be a non-empty string"))
+		}
+		if err := txCommit(n.ctx, &runtime.StorageTx{ID: txID}, &n.openTxs); err != nil {
+			panic(r.NewGoError(fmt.Errorf("failed to commit transaction: %s", err.Error())))
+		}
+		return goja.Undefined()
+	}
+}
+
+// @group storage
+// @summary Roll back an open database transaction.
+// @param tx(type=string) The transaction handle returned by txBegin.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeJavascriptNakamaModule) txRollback(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
+	return func(f goja.FunctionCall) goja.Value {
+		txArg := f.Argument(0)
+		if txArg == goja.Undefined() || txArg == goja.Null() {
+			panic(r.NewTypeError("expects a transaction id"))
+		}
+		txID, ok := txArg.Export().(string)
+		if !ok || txID == "" {
+			panic(r.NewTypeError("expects tx to be a non-empty string"))
+		}
+		if err := txRollback(n.ctx, &runtime.StorageTx{ID: txID}, &n.openTxs); err != nil {
+			panic(r.NewGoError(fmt.Errorf("failed to rollback transaction: %s", err.Error())))
+		}
 		return goja.Undefined()
 	}
 }

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -4870,6 +4870,7 @@ func (n *RuntimeJavascriptNakamaModule) storageList(r *goja.Runtime) func(goja.F
 // @group storage
 // @summary Fetch one or more records by their bucket/collection/keyname and optional user.
 // @param objectIDs(type=nkruntime.StorageReadRequest[]) An array of object identifiers to be fetched.
+// @param tx(type=string, optional=true) An optional transaction handle from txBegin.
 // @return objects(nkruntime.StorageObject[]) A list of storage records matching the parameters criteria.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -4983,6 +4984,7 @@ func (n *RuntimeJavascriptNakamaModule) storageRead(r *goja.Runtime) func(goja.F
 // @group storage
 // @summary Write one or more objects by their collection/keyname and optional user.
 // @param objectIDs(type=nkruntime.StorageWriteRequest[]) An array of object identifiers to be written.
+// @param tx(type=string, optional=true) An optional transaction handle from txBegin.
 // @return acks(nkruntime.StorageWriteAck[]) A list of acks with the version of the written objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageWrite(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
@@ -5389,6 +5391,7 @@ func jsArrayToStorageOpWrites(dataSlice []map[string]any) (StorageOpWrites, erro
 // @group storage
 // @summary Remove one or more objects by their collection/keyname and optional user.
 // @param objectIDs(type=nkruntime.StorageDeleteRequest[]) An array of object identifiers to be deleted.
+// @param tx(type=string, optional=true) An optional transaction handle from txBegin.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) storageDelete(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {

--- a/server/runtime_javascript_nakama.go
+++ b/server/runtime_javascript_nakama.go
@@ -5489,7 +5489,7 @@ func (n *RuntimeJavascriptNakamaModule) storageDelete(r *goja.Runtime) func(goja
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeJavascriptNakamaModule) txBegin(r *goja.Runtime) func(goja.FunctionCall) goja.Value {
 	return func(f goja.FunctionCall) goja.Value {
-		tx, err := txBegin(n.ctx, n.db, &n.openTxs)
+		tx, err := txBegin(n.ctx, n.logger, n.db, &n.openTxs)
 		if err != nil {
 			panic(r.NewGoError(fmt.Errorf("failed to begin transaction: %s", err.Error())))
 		}

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/heroiclabs/nakama-common/api"
+	"github.com/jackc/pgx/v5"
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/console"
@@ -93,6 +94,8 @@ type RuntimeLuaNakamaModule struct {
 	eventFn       RuntimeEventCustomFunction
 
 	satori runtime.Satori
+
+	openTxs sync.Map
 }
 
 func NewRuntimeLuaNakamaModule(logger *zap.Logger, db *sql.DB, protojsonMarshaler *protojson.MarshalOptions, protojsonUnmarshaler *protojson.UnmarshalOptions, config Config, version string, socialClient *social.Client, leaderboardCache LeaderboardCache, rankCache LeaderboardRankCache, leaderboardScheduler LeaderboardScheduler, sessionRegistry SessionRegistry, sessionCache SessionCache, statusRegistry StatusRegistry, matchRegistry MatchRegistry, partyRegistry PartyRegistry, tracker Tracker, metrics Metrics, streamManager StreamManager, router MessageRouter, once *sync.Once, localCache *RuntimeLuaLocalCache, storageIndex StorageIndex, satoriClient runtime.Satori, matchCreateFn RuntimeMatchCreateFunction, eventFn RuntimeEventCustomFunction, registerCallbackFn func(RuntimeExecutionMode, string, *lua.LFunction), announceCallbackFn func(RuntimeExecutionMode, string)) *RuntimeLuaNakamaModule {
@@ -263,6 +266,9 @@ func (n *RuntimeLuaNakamaModule) Loader(l *lua.LState) int {
 		"storage_write":                      n.storageWrite,
 		"storage_write_retry":                n.storageWriteRetry,
 		"storage_delete":                     n.storageDelete,
+		"tx_begin":                           n.txBegin,
+		"tx_commit":                          n.txCommit,
+		"tx_rollback":                        n.txRollback,
 		"multi_update":                       n.multiUpdate,
 		"leaderboard_create":                 n.leaderboardCreate,
 		"leaderboard_delete":                 n.leaderboardDelete,
@@ -6197,6 +6203,7 @@ func (n *RuntimeLuaNakamaModule) storageList(l *lua.LState) int {
 // @group storage
 // @summary Fetch one or more records by their bucket/collection/keyname and optional user.
 // @param keys(type=table) A table of object identifiers to be fetched.
+// @param tx(type=string, optional=true) An optional transaction handle from tx_begin.
 // @return objects(table) A list of storage objects matching the parameters criteria.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) storageRead(l *lua.LState) int {
@@ -6298,7 +6305,17 @@ func (n *RuntimeLuaNakamaModule) storageRead(l *lua.LState) int {
 		return 0
 	}
 
-	objects, err := StorageReadObjects(l.Context(), n.logger, n.db, uuid.Nil, objectIDs)
+	var pgxTx pgx.Tx
+	if txID := l.OptString(2, ""); txID != "" {
+		var ok bool
+		pgxTx, ok = getTx(&runtime.StorageTx{ID: txID}, &n.openTxs)
+		if !ok {
+			l.RaiseError("transaction not found or already closed")
+			return 0
+		}
+	}
+
+	objects, err := StorageReadObjects(l.Context(), n.logger, n.db, uuid.Nil, objectIDs, pgxTx)
 	if err != nil {
 		l.RaiseError("failed to read storage objects: %s", err.Error())
 		return 0
@@ -6338,6 +6355,7 @@ func (n *RuntimeLuaNakamaModule) storageRead(l *lua.LState) int {
 // @group storage
 // @summary Write one or more objects by their collection/keyname and optional user.
 // @param keys(type=table) A table of object identifiers to be written.
+// @param tx(type=string, optional=true) An optional transaction handle from tx_begin.
 // @return acks(table) A list of acks with the version of the written objects.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) storageWrite(l *lua.LState) int {
@@ -6358,7 +6376,17 @@ func (n *RuntimeLuaNakamaModule) storageWrite(l *lua.LState) int {
 		return 0
 	}
 
-	acks, _, err := StorageWriteObjects(l.Context(), n.logger, n.db, n.metrics, n.storageIndex, true, ops)
+	var pgxTx pgx.Tx
+	if txID := l.OptString(2, ""); txID != "" {
+		var ok bool
+		pgxTx, ok = getTx(&runtime.StorageTx{ID: txID}, &n.openTxs)
+		if !ok {
+			l.RaiseError("transaction not found or already closed")
+			return 0
+		}
+	}
+
+	acks, _, err := StorageWriteObjects(l.Context(), n.logger, n.db, n.metrics, n.storageIndex, true, ops, pgxTx)
 	if err != nil {
 		l.RaiseError("failed to write storage objects: %s", err.Error())
 		return 0
@@ -6853,6 +6881,7 @@ func tableToStorageOpWrites(l *lua.LState, dataTable *lua.LTable) (StorageOpWrit
 // @group storage
 // @summary Remove one or more objects by their collection/keyname and optional user.
 // @param keys(type=table) A list of object identifiers to be deleted.
+// @param tx(type=string, optional=true) An optional transaction handle from tx_begin.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) storageDelete(l *lua.LState) int {
 	keys := l.CheckTable(1)
@@ -6962,10 +6991,66 @@ func (n *RuntimeLuaNakamaModule) storageDelete(l *lua.LState) int {
 		return 0
 	}
 
-	if _, err := StorageDeleteObjects(l.Context(), n.logger, n.db, n.storageIndex, true, ops); err != nil {
+	var pgxTx pgx.Tx
+	if txID := l.OptString(2, ""); txID != "" {
+		var ok bool
+		pgxTx, ok = getTx(&runtime.StorageTx{ID: txID}, &n.openTxs)
+		if !ok {
+			l.RaiseError("transaction not found or already closed")
+			return 0
+		}
+	}
+
+	if _, err := StorageDeleteObjects(l.Context(), n.logger, n.db, n.storageIndex, true, ops, pgxTx); err != nil {
 		l.RaiseError("failed to remove storage: %s", err.Error())
 	}
 
+	return 0
+}
+
+// @group storage
+// @summary Begin a database transaction for use with storage tx functions. The transaction is automatically rolled back if the RPC ends without a commit.
+// @return tx(string) A transaction handle to pass to storage_read_tx, storage_write_tx, storage_delete_tx, tx_commit, or tx_rollback.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeLuaNakamaModule) txBegin(l *lua.LState) int {
+	tx, err := txBegin(l.Context(), n.db, &n.openTxs)
+	if err != nil {
+		l.RaiseError("failed to begin transaction: %s", err.Error())
+		return 0
+	}
+	l.Push(lua.LString(tx.ID))
+	return 1
+}
+
+// @group storage
+// @summary Commit an open database transaction.
+// @param tx(type=string) The transaction handle returned by tx_begin.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeLuaNakamaModule) txCommit(l *lua.LState) int {
+	txID := l.CheckString(1)
+	if txID == "" {
+		l.ArgError(1, "expects a transaction id")
+		return 0
+	}
+	if err := txCommit(l.Context(), &runtime.StorageTx{ID: txID}, &n.openTxs); err != nil {
+		l.RaiseError("failed to commit transaction: %s", err.Error())
+	}
+	return 0
+}
+
+// @group storage
+// @summary Roll back an open database transaction.
+// @param tx(type=string) The transaction handle returned by tx_begin.
+// @return error(error) An optional error value if an error occurred.
+func (n *RuntimeLuaNakamaModule) txRollback(l *lua.LState) int {
+	txID := l.CheckString(1)
+	if txID == "" {
+		l.ArgError(1, "expects a transaction id")
+		return 0
+	}
+	if err := txRollback(l.Context(), &runtime.StorageTx{ID: txID}, &n.openTxs); err != nil {
+		l.RaiseError("failed to rollback transaction: %s", err.Error())
+	}
 	return 0
 }
 

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -7009,8 +7009,8 @@ func (n *RuntimeLuaNakamaModule) storageDelete(l *lua.LState) int {
 }
 
 // @group storage
-// @summary Begin a database transaction for use with storage tx functions. The transaction is automatically rolled back if the RPC ends without a commit.
-// @return tx(string) A transaction handle to pass to storage_read_tx, storage_write_tx, storage_delete_tx, tx_commit, or tx_rollback.
+// @summary Begin a database transaction for use with storage functions. The transaction is automatically rolled back if the RPC ends without a commit.
+// @return tx(string) A transaction handle to pass to storage_read, storage_write, storage_delete, tx_commit, or tx_rollback.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) txBegin(l *lua.LState) int {
 	tx, err := txBegin(l.Context(), n.logger, n.db, &n.openTxs)

--- a/server/runtime_lua_nakama.go
+++ b/server/runtime_lua_nakama.go
@@ -7013,7 +7013,7 @@ func (n *RuntimeLuaNakamaModule) storageDelete(l *lua.LState) int {
 // @return tx(string) A transaction handle to pass to storage_read_tx, storage_write_tx, storage_delete_tx, tx_commit, or tx_rollback.
 // @return error(error) An optional error value if an error occurred.
 func (n *RuntimeLuaNakamaModule) txBegin(l *lua.LState) int {
-	tx, err := txBegin(l.Context(), n.db, &n.openTxs)
+	tx, err := txBegin(l.Context(), n.logger, n.db, &n.openTxs)
 	if err != nil {
 		l.RaiseError("failed to begin transaction: %s", err.Error())
 		return 0

--- a/server/storage_index.go
+++ b/server/storage_index.go
@@ -364,7 +364,7 @@ func (si *LocalStorageIndex) List(ctx context.Context, callerID uuid.UUID, index
 		})
 	}
 
-	objects, err := StorageReadObjects(ctx, si.logger, si.db, callerID, storageReads)
+	objects, err := StorageReadObjects(ctx, si.logger, si.db, callerID, storageReads, nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/server/storage_index_test.go
+++ b/server/storage_index_test.go
@@ -135,7 +135,7 @@ func TestLocalStorageIndex_Write(t *testing.T) {
 
 		writeOps := StorageOpWrites{so1, so2, so3, so4, so5, so6}
 
-		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps); err != nil {
+		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps, nil); err != nil {
 			t.Fatal(err.Error())
 		}
 
@@ -161,7 +161,7 @@ func TestLocalStorageIndex_Write(t *testing.T) {
 				},
 			})
 		}
-		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps); err != nil {
+		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps, nil); err != nil {
 			t.Fatalf("Failed to teardown: %s", err.Error())
 		}
 	})
@@ -182,7 +182,7 @@ func TestLocalStorageIndex_Write(t *testing.T) {
 			},
 		}
 
-		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, StorageOpWrites{so1}); err != nil {
+		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, StorageOpWrites{so1}, nil); err != nil {
 			t.Fatal(err.Error())
 		}
 
@@ -201,7 +201,7 @@ func TestLocalStorageIndex_Write(t *testing.T) {
 				},
 			},
 		}
-		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, deletes); err != nil {
+		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, deletes, nil); err != nil {
 			t.Fatalf("Failed to teardown: %s", err.Error())
 		}
 	})
@@ -285,7 +285,7 @@ func TestLocalStorageIndex_Write(t *testing.T) {
 
 		writeOps := StorageOpWrites{so1, so2, so3, so4}
 
-		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps); err != nil {
+		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps, nil); err != nil {
 			t.Fatal(err.Error())
 		}
 
@@ -309,7 +309,7 @@ func TestLocalStorageIndex_Write(t *testing.T) {
 				},
 			})
 		}
-		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps); err != nil {
+		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps, nil); err != nil {
 			t.Fatalf("Failed to teardown: %s", err.Error())
 		}
 	})
@@ -381,7 +381,7 @@ func TestLocalStorageIndex_List(t *testing.T) {
 
 		writeOps := StorageOpWrites{so1, so2, so3}
 
-		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps); err != nil {
+		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps, nil); err != nil {
 			t.Fatal(err.Error())
 		}
 
@@ -419,7 +419,7 @@ func TestLocalStorageIndex_List(t *testing.T) {
 				},
 			})
 		}
-		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps); err != nil {
+		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps, nil); err != nil {
 			t.Fatalf("Failed to teardown: %s", err.Error())
 		}
 	})
@@ -489,7 +489,7 @@ func TestLocalStorageIndex_List(t *testing.T) {
 
 		writeOps := StorageOpWrites{so1, so2, so3}
 
-		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps); err != nil {
+		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps, nil); err != nil {
 			t.Fatal(err.Error())
 		}
 
@@ -512,7 +512,7 @@ func TestLocalStorageIndex_List(t *testing.T) {
 				},
 			})
 		}
-		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps); err != nil {
+		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps, nil); err != nil {
 			t.Fatalf("Failed to teardown: %s", err.Error())
 		}
 	})
@@ -585,7 +585,7 @@ func TestLocalStorageIndex_List(t *testing.T) {
 
 		writeOps := StorageOpWrites{so1, so2, so3}
 
-		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps); err != nil {
+		if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps, nil); err != nil {
 			t.Fatal(err.Error())
 		}
 
@@ -624,7 +624,7 @@ func TestLocalStorageIndex_List(t *testing.T) {
 				},
 			})
 		}
-		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps); err != nil {
+		if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps, nil); err != nil {
 			t.Fatalf("Failed to teardown: %s", err.Error())
 		}
 	})
@@ -677,7 +677,7 @@ func TestLocalStorageIndex_Delete(t *testing.T) {
 
 	writeOps := StorageOpWrites{so1, so2}
 
-	if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps); err != nil {
+	if _, _, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, writeOps, nil); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -694,7 +694,7 @@ func TestLocalStorageIndex_Delete(t *testing.T) {
 			Key:        "key2",
 		},
 	}
-	if _, err := StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, StorageOpDeletes{delOp}); err != nil {
+	if _, err := StorageDeleteObjects(context.Background(), logger, db, storageIdx, true, StorageOpDeletes{delOp}, nil); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -715,7 +715,7 @@ func TestLocalStorageIndex_Delete(t *testing.T) {
 			},
 		})
 	}
-	if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps); err != nil {
+	if _, err = StorageDeleteObjects(ctx, logger, db, storageIdx, true, delOps, nil); err != nil {
 		t.Fatalf("Failed to teardown: %s", err.Error())
 	}
 }


### PR DESCRIPTION
https://github.com/heroiclabs/nakama/issues/2394

Implement storage transaction lifecycle across Go, Lua, and JavaScript runtimes

When writing complex RPCs it's often necessary to group multiple storage operations into a single atomic transaction. Previously the storage APIs each managed their own transaction internally, making this impossible.

This adds txBegin/txCommit/txRollback functions to all three runtimes (Go, Lua, JS) and updates storageRead, storageWrite, and storageDelete to accept an optional transaction handle.

All existing call sites are unchanged in behaviour — they pass nil and continue using the internal auto-transaction path.