### PR TITLE
Fix orphaned group admin edges after account delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented below.
 The format is based on [keep a changelog](http://keepachangelog.com) and this project uses [semantic versioning](http://semver.org).
 
 ## [Unreleased]
+### Added
+- Improve logic in Apple JWS receipts validation.
+### Fixed
+- Fix an issue where group admin account deletion could leave orphaned group edges.
 
 ## [3.39.0] - 2026-05-20
 ### Added

--- a/iap/iap.go
+++ b/iap/iap.go
@@ -920,7 +920,10 @@ func ValidateReceiptFacebookInstant(appSecret, signedRequest string) (*FacebookI
 }
 
 func ValidateAppleJwsSignature(receipt string) error {
-	jwsTokens := strings.Split(receipt, ".") // Length has already been validated.
+	jwsTokens := strings.Split(receipt, ".")
+	if len(jwsTokens) != 3 {
+		return fmt.Errorf("invalid jws format: expected 3 parts, got %d", len(jwsTokens))
+	}
 	header := jwsTokens[0]
 	payload := jwsTokens[1]
 	signature := jwsTokens[2]

--- a/iap/iap.go
+++ b/iap/iap.go
@@ -920,12 +920,12 @@ func ValidateReceiptFacebookInstant(appSecret, signedRequest string) (*FacebookI
 }
 
 func ValidateAppleJwsSignature(receipt string) error {
-	jwsTokens := strings.Split(receipt, ".")
+	jwsTokens := strings.Split(receipt, ".") // Length has already been validated.
 	header := jwsTokens[0]
 	payload := jwsTokens[1]
 	signature := jwsTokens[2]
 
-	headerByte, err := base64.RawStdEncoding.DecodeString(header)
+	headerByte, err := base64.RawURLEncoding.DecodeString(header)
 	if err != nil {
 		return err
 	}
@@ -937,6 +937,10 @@ func ValidateAppleJwsSignature(receipt string) error {
 	var jwsHeader Header
 	if err = json.Unmarshal(headerByte, &jwsHeader); err != nil {
 		return err
+	}
+
+	if len(jwsHeader.X5c) < 3 {
+		return fmt.Errorf("invalid jws header: x5c field must contain at least 3 certificates")
 	}
 
 	certs := make([][]byte, 0)
@@ -951,7 +955,7 @@ func ValidateAppleJwsSignature(receipt string) error {
 	rootCert := x509.NewCertPool()
 	ok := rootCert.AppendCertsFromPEM([]byte(AppleRootPEM))
 	if !ok {
-		return err
+		return errors.New("failed to parse AppleRootPEM")
 	}
 
 	leafCert, err := x509.ParseCertificate(certs[0])
@@ -966,7 +970,7 @@ func ValidateAppleJwsSignature(receipt string) error {
 	intermediates := x509.NewCertPool()
 	intermediates.AddCert(interCert)
 
-	cert, err := x509.ParseCertificate(certs[2])
+	_, err = x509.ParseCertificate(certs[2])
 	if err != nil {
 		return err
 	}
@@ -976,7 +980,7 @@ func ValidateAppleJwsSignature(receipt string) error {
 		Intermediates: intermediates,
 	}
 
-	_, err = cert.Verify(opts)
+	_, err = leafCert.Verify(opts)
 	if err != nil {
 		return err
 	}

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -2068,9 +2068,9 @@ func deleteRelationship(ctx context.Context, logger *zap.Logger, tx *sql.Tx, use
 DELETE FROM group_edge
 WHERE
 	(
-		(source_id = $1::UUID AND destination_id = $2::UUID AND state > 1)
+		(source_id = $1::UUID AND destination_id = $2::UUID AND state > 0)
 		OR
-		(source_id = $2::UUID AND destination_id = $1::UUID AND state > 1)
+		(source_id = $2::UUID AND destination_id = $1::UUID AND state > 0)
 	)
 RETURNING state`
 

--- a/server/core_group.go
+++ b/server/core_group.go
@@ -2077,10 +2077,12 @@ RETURNING state`
 	var deletedState sql.NullInt64
 	logger.Debug("Removing relationship from group.", zap.String("query", query), zap.String("group_id", groupID.String()), zap.String("user_id", userID.String()))
 	if err := tx.QueryRowContext(ctx, query, userID, groupID).Scan(&deletedState); err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			logger.Debug("Could not delete relationship from group_edge.", zap.Error(err), zap.String("group_id", groupID.String()), zap.String("user_id", userID.String()))
-			return err
+		if errors.Is(err, sql.ErrNoRows) {
+			// If no edges were deleted, then the user was not in the group or was a superadmin (state 0). In either case, we do not need to update the edge count of the group.
+			return nil
 		}
+		logger.Debug("Could not delete relationship from group_edge.", zap.Error(err), zap.String("group_id", groupID.String()), zap.String("user_id", userID.String()))
+		return err
 	}
 
 	if deletedState.Int64 < 3 {


### PR DESCRIPTION
Fix an issue where an admin member of a group deleting his account would not remove the corresponding group membership edges, leaving them orphaned.
Fix Apple IAP JWS certificate chain validation.