### PR TITLE
annotations for hooks.

### DIFF
--- a/server/runtime_go.go
+++ b/server/runtime_go.go
@@ -122,7 +122,7 @@ func (ri *RuntimeGoInitializer) RegisterEventSessionEnd(fn func(ctx context.Cont
 }
 
 // @group rpc
-// @summary Register a function for RPC calls by its ID. The ID can be used from client code to send an RPC message to execute the function and return the result. Results are always returned as a JSON string or an empty string.
+// @summary Register a function for RPC calls by its ID. The ID can be used from client code to send an RPC message to execute the function and return the result. Results are always returned as a JSON string or an empty string. If there is an issue with the RPC call, return an empty string and the associated error which will be returned to the client.
 // @param id(type=string) The unique identifier of the RPC function. Converted to lowercase.
 // @param fn(type=function) The function to execute when the RPC is called.
 // @return error(error) An optional error value if an error occurred.
@@ -148,6 +148,11 @@ func (ri *RuntimeGoInitializer) RegisterRpc(id string, fn func(ctx context.Conte
 	return nil
 }
 
+// @group hooks
+// @summary Register a function for a message. Any function may be registered to intercept a message received from a client and operate on it (or reject it) based on custom logic. This is useful to enforce specific rules on top of the standard features in the server. You can return `nil` instead of the `rtapi.Envelope` and this will disable that particular server functionality. Message names can be found here: https://heroiclabs.com/docs/nakama/guides/server-framework/using-hooks/#message-names
+// @param id(type=string) The message type identifier.
+// @param fn(type=function) The function to execute before the realtime message is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeRt(id string, fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, envelope *rtapi.Envelope) (*rtapi.Envelope, error)) error {
 	apiID := strings.ToLower(id)
 	id = strings.ToLower(RTAPI_PREFIX) + apiID
@@ -159,6 +164,11 @@ func (ri *RuntimeGoInitializer) RegisterBeforeRt(id string, fn func(ctx context.
 	return nil
 }
 
+// @group hooks
+// @summary Register a function for a message. The registered function will be called after the message has been processed in the pipeline. The custom code will be executed asynchronously after the response message has been sent to a client. Message names can be found here: https://heroiclabs.com/docs/nakama/guides/server-framework/using-hooks/#message-names
+// @param id(type=string) The message type identifier.
+// @param fn(type=function) The function to execute after the realtime message is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterRt(id string, fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out, in *rtapi.Envelope) error) error {
 	apiID := strings.ToLower(id)
 	id = strings.ToLower(RTAPI_PREFIX) + apiID
@@ -170,6 +180,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterRt(id string, fn func(ctx context.C
 	return nil
 }
 
+// @group accounts
+// @summary Register a function invoked when the server receives the relevant request.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeGetAccount(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) error) error {
 	ri.beforeReq.beforeGetAccountFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string) (error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -192,6 +206,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeGetAccount(fn func(ctx context.Con
 	return nil
 }
 
+// @group accounts
+// @summary Register a function invoked after the server processes the relevant request.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterGetAccount(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Account) error) error {
 	ri.afterReq.afterGetAccountFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Account) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -201,6 +219,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterGetAccount(fn func(ctx context.Cont
 	return nil
 }
 
+// @group accounts
+// @summary Register a function invoked when the server receives the relevant request.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUpdateAccount(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.UpdateAccountRequest) (*api.UpdateAccountRequest, error)) error {
 	ri.beforeReq.beforeUpdateAccountFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.UpdateAccountRequest) (*api.UpdateAccountRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -223,6 +245,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUpdateAccount(fn func(ctx context.
 	return nil
 }
 
+// @group accounts
+// @summary Register a function invoked after the server processes the relevant request.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUpdateAccount(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.UpdateAccountRequest) error) error {
 	ri.afterReq.afterUpdateAccountFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.UpdateAccountRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -232,6 +258,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUpdateAccount(fn func(ctx context.C
 	return nil
 }
 
+// @group accounts
+// @summary Register a function invoked when the server receives the relevant request.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDeleteAccount(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) error) error {
 	ri.beforeReq.beforeDeleteAccountFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string) (error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -254,6 +284,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDeleteAccount(fn func(ctx context.
 	return nil
 }
 
+// @group accounts
+// @summary Register a function invoked after the server processes the relevant request.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDeleteAccount(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) error) error {
 	ri.afterReq.afterDeleteAccountFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -263,6 +297,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDeleteAccount(fn func(ctx context.C
 	return nil
 }
 
+// @group sessions
+// @summary Register a function to perform pre-refresh checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeSessionRefresh(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.SessionRefreshRequest) (*api.SessionRefreshRequest, error)) error {
 	ri.beforeReq.beforeSessionRefreshFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.SessionRefreshRequest) (*api.SessionRefreshRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -285,6 +323,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeSessionRefresh(fn func(ctx context
 	return nil
 }
 
+// @group sessions
+// @summary Register a function to perform after successful refresh checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterSessionRefresh(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.SessionRefreshRequest) error) error {
 	ri.afterReq.afterSessionRefreshFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.SessionRefreshRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -294,6 +336,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterSessionRefresh(fn func(ctx context.
 	return nil
 }
 
+// @group sessions
+// @summary Register a function to perform pre-logout checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeSessionLogout(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.SessionLogoutRequest) (*api.SessionLogoutRequest, error)) error {
 	ri.beforeReq.beforeSessionLogoutFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.SessionLogoutRequest) (*api.SessionLogoutRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -316,6 +362,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeSessionLogout(fn func(ctx context.
 	return nil
 }
 
+// @group sessions
+// @summary Register a function to perform after successful logout checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterSessionLogout(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.SessionLogoutRequest) error) error {
 	ri.afterReq.afterSessionLogoutFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.SessionLogoutRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -325,6 +375,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterSessionLogout(fn func(ctx context.C
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateAppleRequest) (*api.AuthenticateAppleRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateAppleRequest) (*api.AuthenticateAppleRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -347,6 +401,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateApple(fn func(ctx cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateAppleRequest) error) error {
 	ri.afterReq.afterAuthenticateAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateAppleRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -356,6 +414,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateApple(fn func(ctx conte
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks. You can use this to process the input (such as decoding custom tokens) and ensure inter-compatibility between Nakama and your own custom system.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateCustom(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateCustomRequest) (*api.AuthenticateCustomRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateCustomFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateCustomRequest) (*api.AuthenticateCustomRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -378,6 +440,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateCustom(fn func(ctx con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks. For instance, you can run special logic if the account was just created like adding them to newcomers leaderboard.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateCustom(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateCustomRequest) error) error {
 	ri.afterReq.afterAuthenticateCustomFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateCustomRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -387,6 +453,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateCustom(fn func(ctx cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateDevice(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateDeviceRequest) (*api.AuthenticateDeviceRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateDeviceFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateDeviceRequest) (*api.AuthenticateDeviceRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -409,6 +479,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateDevice(fn func(ctx con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateDevice(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateDeviceRequest) error) error {
 	ri.afterReq.afterAuthenticateDeviceFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateDeviceRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -418,6 +492,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateDevice(fn func(ctx cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateEmail(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateEmailRequest) (*api.AuthenticateEmailRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateEmailFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateEmailRequest) (*api.AuthenticateEmailRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -440,6 +518,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateEmail(fn func(ctx cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateEmail(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateEmailRequest) error) error {
 	ri.afterReq.afterAuthenticateEmailFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateEmailRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -449,6 +531,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateEmail(fn func(ctx conte
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateFacebook(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateFacebookRequest) (*api.AuthenticateFacebookRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateFacebookFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateFacebookRequest) (*api.AuthenticateFacebookRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -471,6 +557,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateFacebook(fn func(ctx c
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateFacebook(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateFacebookRequest) error) error {
 	ri.afterReq.afterAuthenticateFacebookFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateFacebookRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -480,6 +570,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateFacebook(fn func(ctx co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateFacebookInstantGame(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateFacebookInstantGameRequest) (*api.AuthenticateFacebookInstantGameRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateFacebookInstantGameFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateFacebookInstantGameRequest) (*api.AuthenticateFacebookInstantGameRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -502,6 +596,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateFacebookInstantGame(fn
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateFacebookInstantGame(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateFacebookInstantGameRequest) error) error {
 	ri.afterReq.afterAuthenticateFacebookInstantGameFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateFacebookInstantGameRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -511,6 +609,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateFacebookInstantGame(fn 
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateGameCenter(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateGameCenterRequest) (*api.AuthenticateGameCenterRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateGameCenterFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateGameCenterRequest) (*api.AuthenticateGameCenterRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -533,6 +635,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateGameCenter(fn func(ctx
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateGameCenter(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateGameCenterRequest) error) error {
 	ri.afterReq.afterAuthenticateGameCenterFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateGameCenterRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -542,6 +648,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateGameCenter(fn func(ctx 
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateGoogleRequest) (*api.AuthenticateGoogleRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateGoogleRequest) (*api.AuthenticateGoogleRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -564,6 +674,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateGoogle(fn func(ctx con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateGoogleRequest) error) error {
 	ri.afterReq.afterAuthenticateGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateGoogleRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -573,6 +687,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateGoogle(fn func(ctx cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform pre-authentication checks.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateSteam(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AuthenticateSteamRequest) (*api.AuthenticateSteamRequest, error)) error {
 	ri.beforeReq.beforeAuthenticateSteamFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AuthenticateSteamRequest) (*api.AuthenticateSteamRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -595,6 +713,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAuthenticateSteam(fn func(ctx cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform after successful authentication checks.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateSteam(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Session, in *api.AuthenticateSteamRequest) error) error {
 	ri.afterReq.afterAuthenticateSteamFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Session, in *api.AuthenticateSteamRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -604,6 +726,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAuthenticateSteam(fn func(ctx conte
 	return nil
 }
 
+// @group chat
+// @summary Register a function to perform additional logic before listing messages on a channel.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListChannelMessages(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListChannelMessagesRequest) (*api.ListChannelMessagesRequest, error)) error {
 	ri.beforeReq.beforeListChannelMessagesFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListChannelMessagesRequest) (*api.ListChannelMessagesRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -626,6 +752,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListChannelMessages(fn func(ctx co
 	return nil
 }
 
+// @group chat
+// @summary Register a function to perform additional logic after messages for a channel are listed.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListChannelMessages(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ChannelMessageList, in *api.ListChannelMessagesRequest) error) error {
 	ri.afterReq.afterListChannelMessagesFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ChannelMessageList, in *api.ListChannelMessagesRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -635,6 +765,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListChannelMessages(fn func(ctx con
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic before listing friends.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListFriendsRequest) (*api.ListFriendsRequest, error)) error {
 	ri.beforeReq.beforeListFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListFriendsRequest) (*api.ListFriendsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -657,6 +791,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListFriends(fn func(ctx context.Co
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic after friends are listed.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.FriendList) error) error {
 	ri.afterReq.afterListFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.FriendList) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -666,6 +804,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListFriends(fn func(ctx context.Con
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic before listing friends of friends.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListFriendsOfFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListFriendsOfFriendsRequest) (*api.ListFriendsOfFriendsRequest, error)) error {
 	ri.beforeReq.beforeListFriendsOfFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListFriendsOfFriendsRequest) (*api.ListFriendsOfFriendsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -688,6 +830,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListFriendsOfFriends(fn func(ctx c
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic after listing friends of friends.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListFriendsOfFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.FriendsOfFriendsList) error) error {
 	ri.afterReq.afterListFriendsOfFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.FriendsOfFriendsList) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -697,6 +843,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListFriendsOfFriends(fn func(ctx co
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic before friends are added.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAddFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AddFriendsRequest) (*api.AddFriendsRequest, error)) error {
 	ri.beforeReq.beforeAddFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AddFriendsRequest) (*api.AddFriendsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -719,6 +869,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAddFriends(fn func(ctx context.Con
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic after friends are added.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAddFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AddFriendsRequest) error) error {
 	ri.afterReq.afterAddFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AddFriendsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -728,6 +882,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAddFriends(fn func(ctx context.Cont
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic before friends are deleted.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDeleteFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteFriendsRequest) (*api.DeleteFriendsRequest, error)) error {
 	ri.beforeReq.beforeDeleteFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteFriendsRequest) (*api.DeleteFriendsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -750,6 +908,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDeleteFriends(fn func(ctx context.
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic after friends are deleted.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDeleteFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteFriendsRequest) error) error {
 	ri.afterReq.afterDeleteFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteFriendsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -759,6 +921,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDeleteFriends(fn func(ctx context.C
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic before friends are blocked.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeBlockFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.BlockFriendsRequest) (*api.BlockFriendsRequest, error)) error {
 	ri.beforeReq.beforeBlockFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.BlockFriendsRequest) (*api.BlockFriendsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -781,6 +947,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeBlockFriends(fn func(ctx context.C
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic after friends are blocked.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterBlockFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.BlockFriendsRequest) error) error {
 	ri.afterReq.afterBlockFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.BlockFriendsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -790,6 +960,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterBlockFriends(fn func(ctx context.Co
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic before Facebook friends are imported.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeImportFacebookFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ImportFacebookFriendsRequest) (*api.ImportFacebookFriendsRequest, error)) error {
 	ri.beforeReq.beforeImportFacebookFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ImportFacebookFriendsRequest) (*api.ImportFacebookFriendsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -812,6 +986,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeImportFacebookFriends(fn func(ctx 
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic after Facebook friends are imported.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterImportFacebookFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ImportFacebookFriendsRequest) error) error {
 	ri.afterReq.afterImportFacebookFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ImportFacebookFriendsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -821,6 +999,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterImportFacebookFriends(fn func(ctx c
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic before Steam friends are imported.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeImportSteamFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ImportSteamFriendsRequest) (*api.ImportSteamFriendsRequest, error)) error {
 	ri.beforeReq.beforeImportSteamFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ImportSteamFriendsRequest) (*api.ImportSteamFriendsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -843,6 +1025,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeImportSteamFriends(fn func(ctx con
 	return nil
 }
 
+// @group friends
+// @summary Register a function to perform additional logic after Steam friends are imported.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterImportSteamFriends(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ImportSteamFriendsRequest) error) error {
 	ri.afterReq.afterImportSteamFriendsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ImportSteamFriendsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -852,6 +1038,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterImportSteamFriends(fn func(ctx cont
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a group is created.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeCreateGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.CreateGroupRequest) (*api.CreateGroupRequest, error)) error {
 	ri.beforeReq.beforeCreateGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.CreateGroupRequest) (*api.CreateGroupRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -874,6 +1064,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeCreateGroup(fn func(ctx context.Co
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a group is created.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterCreateGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Group, in *api.CreateGroupRequest) error) error {
 	ri.afterReq.afterCreateGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Group, in *api.CreateGroupRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -883,6 +1077,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterCreateGroup(fn func(ctx context.Con
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a group is updated.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUpdateGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.UpdateGroupRequest) (*api.UpdateGroupRequest, error)) error {
 	ri.beforeReq.beforeUpdateGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.UpdateGroupRequest) (*api.UpdateGroupRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -905,6 +1103,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUpdateGroup(fn func(ctx context.Co
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a group is updated.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUpdateGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.UpdateGroupRequest) error) error {
 	ri.afterReq.afterUpdateGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.UpdateGroupRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -914,6 +1116,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUpdateGroup(fn func(ctx context.Con
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a group is deleted.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDeleteGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteGroupRequest) (*api.DeleteGroupRequest, error)) error {
 	ri.beforeReq.beforeDeleteGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteGroupRequest) (*api.DeleteGroupRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -936,6 +1142,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDeleteGroup(fn func(ctx context.Co
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a group is deleted.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDeleteGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteGroupRequest) error) error {
 	ri.afterReq.afterDeleteGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteGroupRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -945,6 +1155,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDeleteGroup(fn func(ctx context.Con
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a user joins a group.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeJoinGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.JoinGroupRequest) (*api.JoinGroupRequest, error)) error {
 	ri.beforeReq.beforeJoinGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.JoinGroupRequest) (*api.JoinGroupRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -967,6 +1181,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeJoinGroup(fn func(ctx context.Cont
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a user joins a group.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterJoinGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.JoinGroupRequest) error) error {
 	ri.afterReq.afterJoinGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.JoinGroupRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -976,6 +1194,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterJoinGroup(fn func(ctx context.Conte
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a user leaves a group.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLeaveGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.LeaveGroupRequest) (*api.LeaveGroupRequest, error)) error {
 	ri.beforeReq.beforeLeaveGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.LeaveGroupRequest) (*api.LeaveGroupRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -998,6 +1220,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLeaveGroup(fn func(ctx context.Con
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a user leaves a group.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLeaveGroup(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.LeaveGroupRequest) error) error {
 	ri.afterReq.afterLeaveGroupFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.LeaveGroupRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1007,6 +1233,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLeaveGroup(fn func(ctx context.Cont
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a user is added to a group.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeAddGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AddGroupUsersRequest) (*api.AddGroupUsersRequest, error)) error {
 	ri.beforeReq.beforeAddGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AddGroupUsersRequest) (*api.AddGroupUsersRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1029,6 +1259,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeAddGroupUsers(fn func(ctx context.
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a user is added to a group.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterAddGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AddGroupUsersRequest) error) error {
 	ri.afterReq.afterAddGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AddGroupUsersRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1038,6 +1272,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterAddGroupUsers(fn func(ctx context.C
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a user is banned from a group.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeBanGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.BanGroupUsersRequest) (*api.BanGroupUsersRequest, error)) error {
 	ri.beforeReq.beforeBanGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.BanGroupUsersRequest) (*api.BanGroupUsersRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1060,6 +1298,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeBanGroupUsers(fn func(ctx context.
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a user is banned from a group.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterBanGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.BanGroupUsersRequest) error) error {
 	ri.afterReq.afterBanGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.BanGroupUsersRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1069,6 +1311,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterBanGroupUsers(fn func(ctx context.C
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a user is kicked from a group.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeKickGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.KickGroupUsersRequest) (*api.KickGroupUsersRequest, error)) error {
 	ri.beforeReq.beforeKickGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.KickGroupUsersRequest) (*api.KickGroupUsersRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1091,6 +1337,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeKickGroupUsers(fn func(ctx context
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a user is kicked from a group.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterKickGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.KickGroupUsersRequest) error) error {
 	ri.afterReq.afterKickGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.KickGroupUsersRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1100,6 +1350,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterKickGroupUsers(fn func(ctx context.
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a user is promoted.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforePromoteGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.PromoteGroupUsersRequest) (*api.PromoteGroupUsersRequest, error)) error {
 	ri.beforeReq.beforePromoteGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.PromoteGroupUsersRequest) (*api.PromoteGroupUsersRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1122,6 +1376,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforePromoteGroupUsers(fn func(ctx cont
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a user is promoted.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterPromoteGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.PromoteGroupUsersRequest) error) error {
 	ri.afterReq.afterPromoteGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.PromoteGroupUsersRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1131,6 +1389,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterPromoteGroupUsers(fn func(ctx conte
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before a user is demoted.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDemoteGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DemoteGroupUsersRequest) (*api.DemoteGroupUsersRequest, error)) error {
 	ri.beforeReq.beforeDemoteGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DemoteGroupUsersRequest) (*api.DemoteGroupUsersRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1153,6 +1415,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDemoteGroupUsers(fn func(ctx conte
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after a user is demoted.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDemoteGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DemoteGroupUsersRequest) error) error {
 	ri.afterReq.afterDemoteGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DemoteGroupUsersRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1162,6 +1428,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDemoteGroupUsers(fn func(ctx contex
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before users in a group are listed.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListGroupUsersRequest) (*api.ListGroupUsersRequest, error)) error {
 	ri.beforeReq.beforeListGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListGroupUsersRequest) (*api.ListGroupUsersRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1184,6 +1454,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListGroupUsers(fn func(ctx context
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after users in a group are listed.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListGroupUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.GroupUserList, in *api.ListGroupUsersRequest) error) error {
 	ri.afterReq.afterListGroupUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.GroupUserList, in *api.ListGroupUsersRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1193,6 +1467,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListGroupUsers(fn func(ctx context.
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before groups for a user are listed.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListUserGroups(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListUserGroupsRequest) (*api.ListUserGroupsRequest, error)) error {
 	ri.beforeReq.beforeListUserGroupsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListUserGroupsRequest) (*api.ListUserGroupsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1215,6 +1493,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListUserGroups(fn func(ctx context
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after groups for a user are listed.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListUserGroups(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.UserGroupList, in *api.ListUserGroupsRequest) error) error {
 	ri.afterReq.afterListUserGroupsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.UserGroupList, in *api.ListUserGroupsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1224,6 +1506,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListUserGroups(fn func(ctx context.
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic before groups are listed.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListGroups(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListGroupsRequest) (*api.ListGroupsRequest, error)) error {
 	ri.beforeReq.beforeListGroupsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListGroupsRequest) (*api.ListGroupsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1246,6 +1532,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListGroups(fn func(ctx context.Con
 	return nil
 }
 
+// @group groups
+// @summary Register a function to perform additional logic after groups are listed.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListGroups(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.GroupList, in *api.ListGroupsRequest) error) error {
 	ri.afterReq.afterListGroupsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.GroupList, in *api.ListGroupsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1255,6 +1545,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListGroups(fn func(ctx context.Cont
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic before deleting a record from a leaderboard.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDeleteLeaderboardRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteLeaderboardRecordRequest) (*api.DeleteLeaderboardRecordRequest, error)) error {
 	ri.beforeReq.beforeDeleteLeaderboardRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteLeaderboardRecordRequest) (*api.DeleteLeaderboardRecordRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1277,6 +1571,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDeleteLeaderboardRecord(fn func(ct
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic after deleting a record from a leaderboard.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDeleteLeaderboardRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteLeaderboardRecordRequest) error) error {
 	ri.afterReq.afterDeleteLeaderboardRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteLeaderboardRecordRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1286,6 +1584,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDeleteLeaderboardRecord(fn func(ctx
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic before deleting a record from a tournament.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDeleteTournamentRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteTournamentRecordRequest) (*api.DeleteTournamentRecordRequest, error)) error {
 	ri.beforeReq.beforeDeleteTournamentRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteTournamentRecordRequest) (*api.DeleteTournamentRecordRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1308,6 +1610,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDeleteTournamentRecord(fn func(ctx
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic after deleting a record from a tournament.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDeleteTournamentRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteTournamentRecordRequest) error) error {
 	ri.afterReq.afterDeleteTournamentRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteTournamentRecordRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1317,6 +1623,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDeleteTournamentRecord(fn func(ctx 
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic before listing records from a leaderboard.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListLeaderboardRecords(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListLeaderboardRecordsRequest) (*api.ListLeaderboardRecordsRequest, error)) error {
 	ri.beforeReq.beforeListLeaderboardRecordsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListLeaderboardRecordsRequest) (*api.ListLeaderboardRecordsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1339,6 +1649,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListLeaderboardRecords(fn func(ctx
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic after listing records from a leaderboard.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListLeaderboardRecords(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.LeaderboardRecordList, in *api.ListLeaderboardRecordsRequest) error) error {
 	ri.afterReq.afterListLeaderboardRecordsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.LeaderboardRecordList, in *api.ListLeaderboardRecordsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1348,6 +1662,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListLeaderboardRecords(fn func(ctx 
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic before submitting a new record to a leaderboard.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeWriteLeaderboardRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.WriteLeaderboardRecordRequest) (*api.WriteLeaderboardRecordRequest, error)) error {
 	ri.beforeReq.beforeWriteLeaderboardRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.WriteLeaderboardRecordRequest) (*api.WriteLeaderboardRecordRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1370,6 +1688,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeWriteLeaderboardRecord(fn func(ctx
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic after submitting a new record to a leaderboard.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterWriteLeaderboardRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.LeaderboardRecord, in *api.WriteLeaderboardRecordRequest) error) error {
 	ri.afterReq.afterWriteLeaderboardRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.LeaderboardRecord, in *api.WriteLeaderboardRecordRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1379,6 +1701,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterWriteLeaderboardRecord(fn func(ctx 
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic before listing leaderboard records around an owner.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListLeaderboardRecordsAroundOwner(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListLeaderboardRecordsAroundOwnerRequest) (*api.ListLeaderboardRecordsAroundOwnerRequest, error)) error {
 	ri.beforeReq.beforeListLeaderboardRecordsAroundOwnerFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListLeaderboardRecordsAroundOwnerRequest) (*api.ListLeaderboardRecordsAroundOwnerRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1401,6 +1727,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListLeaderboardRecordsAroundOwner(
 	return nil
 }
 
+// @group leaderboards
+// @summary Register a function to perform additional logic after listing leaderboard records around an owner.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListLeaderboardRecordsAroundOwner(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.LeaderboardRecordList, in *api.ListLeaderboardRecordsAroundOwnerRequest) error) error {
 	ri.afterReq.afterListLeaderboardRecordsAroundOwnerFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.LeaderboardRecordList, in *api.ListLeaderboardRecordsAroundOwnerRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1410,6 +1740,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListLeaderboardRecordsAroundOwner(f
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking Apple ID to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountApple) (*api.AccountApple, error)) error {
 	ri.beforeReq.beforeLinkAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountApple) (*api.AccountApple, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1432,6 +1766,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkApple(fn func(ctx context.Cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking Apple ID to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountApple) error) error {
 	ri.afterReq.afterLinkAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountApple) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1441,6 +1779,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkApple(fn func(ctx context.Conte
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking custom ID to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkCustom(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountCustom) (*api.AccountCustom, error)) error {
 	ri.beforeReq.beforeLinkCustomFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountCustom) (*api.AccountCustom, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1463,6 +1805,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkCustom(fn func(ctx context.Con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking custom ID to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkCustom(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountCustom) error) error {
 	ri.afterReq.afterLinkCustomFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountCustom) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1472,6 +1818,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkCustom(fn func(ctx context.Cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking device ID to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkDevice(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountDevice) (*api.AccountDevice, error)) error {
 	ri.beforeReq.beforeLinkDeviceFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountDevice) (*api.AccountDevice, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1494,6 +1844,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkDevice(fn func(ctx context.Con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking device ID to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkDevice(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountDevice) error) error {
 	ri.afterReq.afterLinkDeviceFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountDevice) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1503,6 +1857,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkDevice(fn func(ctx context.Cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking email to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkEmail(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountEmail) (*api.AccountEmail, error)) error {
 	ri.beforeReq.beforeLinkEmailFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountEmail) (*api.AccountEmail, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1525,6 +1883,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkEmail(fn func(ctx context.Cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking email to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkEmail(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountEmail) error) error {
 	ri.afterReq.afterLinkEmailFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountEmail) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1534,6 +1896,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkEmail(fn func(ctx context.Conte
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking Facebook to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkFacebook(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.LinkFacebookRequest) (*api.LinkFacebookRequest, error)) error {
 	ri.beforeReq.beforeLinkFacebookFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.LinkFacebookRequest) (*api.LinkFacebookRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1556,6 +1922,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkFacebook(fn func(ctx context.C
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking Facebook to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkFacebook(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.LinkFacebookRequest) error) error {
 	ri.afterReq.afterLinkFacebookFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.LinkFacebookRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1565,6 +1935,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkFacebook(fn func(ctx context.Co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking Facebook Instant Game profile to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkFacebookInstantGame(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountFacebookInstantGame) (*api.AccountFacebookInstantGame, error)) error {
 	ri.beforeReq.beforeLinkFacebookInstantGameFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountFacebookInstantGame) (*api.AccountFacebookInstantGame, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1587,6 +1961,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkFacebookInstantGame(fn func(ct
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking Facebook Instant Game profile to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkFacebookInstantGame(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountFacebookInstantGame) error) error {
 	ri.afterReq.afterLinkFacebookInstantGameFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountFacebookInstantGame) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1596,6 +1974,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkFacebookInstantGame(fn func(ctx
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking GameCenter to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkGameCenter(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGameCenter) (*api.AccountGameCenter, error)) error {
 	ri.beforeReq.beforeLinkGameCenterFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGameCenter) (*api.AccountGameCenter, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1618,6 +2000,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkGameCenter(fn func(ctx context
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking GameCenter to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkGameCenter(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGameCenter) error) error {
 	ri.afterReq.afterLinkGameCenterFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGameCenter) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1627,6 +2013,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkGameCenter(fn func(ctx context.
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking Google to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGoogle) (*api.AccountGoogle, error)) error {
 	ri.beforeReq.beforeLinkGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGoogle) (*api.AccountGoogle, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1649,6 +2039,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkGoogle(fn func(ctx context.Con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking Google to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGoogle) error) error {
 	ri.afterReq.afterLinkGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGoogle) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1658,6 +2052,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkGoogle(fn func(ctx context.Cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before linking Steam to an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeLinkSteam(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.LinkSteamRequest) (*api.LinkSteamRequest, error)) error {
 	ri.beforeReq.beforeLinkSteamFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.LinkSteamRequest) (*api.LinkSteamRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1680,6 +2078,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeLinkSteam(fn func(ctx context.Cont
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after linking Steam to an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterLinkSteam(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.LinkSteamRequest) error) error {
 	ri.afterReq.afterLinkSteamFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.LinkSteamRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1689,6 +2091,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterLinkSteam(fn func(ctx context.Conte
 	return nil
 }
 
+// @group matches
+// @summary Register a function to perform additional logic before listing matches.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListMatches(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListMatchesRequest) (*api.ListMatchesRequest, error)) error {
 	ri.beforeReq.beforeListMatchesFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListMatchesRequest) (*api.ListMatchesRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1711,6 +2117,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListMatches(fn func(ctx context.Co
 	return nil
 }
 
+// @group matches
+// @summary Register a function to perform additional logic after listing matches.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListMatches(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.MatchList, in *api.ListMatchesRequest) error) error {
 	ri.afterReq.afterListMatchesFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.MatchList, in *api.ListMatchesRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1720,6 +2130,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListMatches(fn func(ctx context.Con
 	return nil
 }
 
+// @group notifications
+// @summary Register a function to perform additional logic before listing notifications for a user.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListNotifications(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListNotificationsRequest) (*api.ListNotificationsRequest, error)) error {
 	ri.beforeReq.beforeListNotificationsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListNotificationsRequest) (*api.ListNotificationsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1742,6 +2156,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListNotifications(fn func(ctx cont
 	return nil
 }
 
+// @group notifications
+// @summary Register a function to perform additional logic after listing notifications for a user.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListNotifications(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.NotificationList, in *api.ListNotificationsRequest) error) error {
 	ri.afterReq.afterListNotificationsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.NotificationList, in *api.ListNotificationsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1751,6 +2169,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListNotifications(fn func(ctx conte
 	return nil
 }
 
+// @group notifications
+// @summary Register a function to perform additional logic before deleting notifications.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDeleteNotifications(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteNotificationsRequest) (*api.DeleteNotificationsRequest, error)) error {
 	ri.beforeReq.beforeDeleteNotificationsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteNotificationsRequest) (*api.DeleteNotificationsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1773,6 +2195,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDeleteNotifications(fn func(ctx co
 	return nil
 }
 
+// @group notifications
+// @summary Register a function to perform additional logic after deleting notifications.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDeleteNotifications(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteNotificationsRequest) error) error {
 	ri.afterReq.afterDeleteNotificationsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteNotificationsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1782,6 +2208,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDeleteNotifications(fn func(ctx con
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic before listing storage objects.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListStorageObjectsRequest) (*api.ListStorageObjectsRequest, error)) error {
 	ri.beforeReq.beforeListStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListStorageObjectsRequest) (*api.ListStorageObjectsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1804,6 +2234,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListStorageObjects(fn func(ctx con
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic after listing storage objects.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.StorageObjectList, in *api.ListStorageObjectsRequest) error) error {
 	ri.afterReq.afterListStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.StorageObjectList, in *api.ListStorageObjectsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1813,6 +2247,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListStorageObjects(fn func(ctx cont
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic before reading storage objects.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeReadStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ReadStorageObjectsRequest) (*api.ReadStorageObjectsRequest, error)) error {
 	ri.beforeReq.beforeReadStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ReadStorageObjectsRequest) (*api.ReadStorageObjectsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1835,6 +2273,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeReadStorageObjects(fn func(ctx con
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic after reading storage objects.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterReadStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.StorageObjects, in *api.ReadStorageObjectsRequest) error) error {
 	ri.afterReq.afterReadStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.StorageObjects, in *api.ReadStorageObjectsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1844,6 +2286,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterReadStorageObjects(fn func(ctx cont
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic before writing storage objects.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeWriteStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.WriteStorageObjectsRequest) (*api.WriteStorageObjectsRequest, error)) error {
 	ri.beforeReq.beforeWriteStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.WriteStorageObjectsRequest) (*api.WriteStorageObjectsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1866,6 +2312,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeWriteStorageObjects(fn func(ctx co
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic after writing storage objects.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterWriteStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.StorageObjectAcks, in *api.WriteStorageObjectsRequest) error) error {
 	ri.afterReq.afterWriteStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.StorageObjectAcks, in *api.WriteStorageObjectsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1875,6 +2325,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterWriteStorageObjects(fn func(ctx con
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic before deleting storage objects.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeDeleteStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteStorageObjectsRequest) (*api.DeleteStorageObjectsRequest, error)) error {
 	ri.beforeReq.beforeDeleteStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteStorageObjectsRequest) (*api.DeleteStorageObjectsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1897,6 +2351,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeDeleteStorageObjects(fn func(ctx c
 	return nil
 }
 
+// @group storage
+// @summary Register a function to perform additional logic after deleting storage objects.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterDeleteStorageObjects(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.DeleteStorageObjectsRequest) error) error {
 	ri.afterReq.afterDeleteStorageObjectsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.DeleteStorageObjectsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1906,6 +2364,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterDeleteStorageObjects(fn func(ctx co
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic before a user joins a tournament.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeJoinTournament(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.JoinTournamentRequest) (*api.JoinTournamentRequest, error)) error {
 	ri.beforeReq.beforeJoinTournamentFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.JoinTournamentRequest) (*api.JoinTournamentRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1928,6 +2390,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeJoinTournament(fn func(ctx context
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic after a user joins a tournament.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterJoinTournament(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.JoinTournamentRequest) error) error {
 	ri.afterReq.afterJoinTournamentFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.JoinTournamentRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1937,6 +2403,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterJoinTournament(fn func(ctx context.
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic before listing tournament records.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListTournamentRecords(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListTournamentRecordsRequest) (*api.ListTournamentRecordsRequest, error)) error {
 	ri.beforeReq.beforeListTournamentRecordsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListTournamentRecordsRequest) (*api.ListTournamentRecordsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1959,6 +2429,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListTournamentRecords(fn func(ctx 
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic after listing tournament records.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListTournamentRecords(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.TournamentRecordList, in *api.ListTournamentRecordsRequest) error) error {
 	ri.afterReq.afterListTournamentRecordsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.TournamentRecordList, in *api.ListTournamentRecordsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1968,6 +2442,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListTournamentRecords(fn func(ctx c
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic before listing tournaments.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListTournaments(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListTournamentsRequest) (*api.ListTournamentsRequest, error)) error {
 	ri.beforeReq.beforeListTournamentsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListTournamentsRequest) (*api.ListTournamentsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1990,6 +2468,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListTournaments(fn func(ctx contex
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic after listing tournaments.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListTournaments(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.TournamentList, in *api.ListTournamentsRequest) error) error {
 	ri.afterReq.afterListTournamentsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.TournamentList, in *api.ListTournamentsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -1999,6 +2481,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListTournaments(fn func(ctx context
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic before writing tournament records.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeWriteTournamentRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.WriteTournamentRecordRequest) (*api.WriteTournamentRecordRequest, error)) error {
 	ri.beforeReq.beforeWriteTournamentRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.WriteTournamentRecordRequest) (*api.WriteTournamentRecordRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2021,6 +2507,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeWriteTournamentRecord(fn func(ctx 
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic after writing tournament records.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterWriteTournamentRecord(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.LeaderboardRecord, in *api.WriteTournamentRecordRequest) error) error {
 	ri.afterReq.afterWriteTournamentRecordFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.LeaderboardRecord, in *api.WriteTournamentRecordRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2030,6 +2520,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterWriteTournamentRecord(fn func(ctx c
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic before listing tournament records around an owner.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListTournamentRecordsAroundOwner(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListTournamentRecordsAroundOwnerRequest) (*api.ListTournamentRecordsAroundOwnerRequest, error)) error {
 	ri.beforeReq.beforeListTournamentRecordsAroundOwnerFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListTournamentRecordsAroundOwnerRequest) (*api.ListTournamentRecordsAroundOwnerRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2052,6 +2546,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListTournamentRecordsAroundOwner(f
 	return nil
 }
 
+// @group tournaments
+// @summary Register a function to perform additional logic after listing tournament records around an owner.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListTournamentRecordsAroundOwner(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.TournamentRecordList, in *api.ListTournamentRecordsAroundOwnerRequest) error) error {
 	ri.afterReq.afterListTournamentRecordsAroundOwnerFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.TournamentRecordList, in *api.ListTournamentRecordsAroundOwnerRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2061,6 +2559,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListTournamentRecordsAroundOwner(fn
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before Apple ID is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountApple) (*api.AccountApple, error)) error {
 	ri.beforeReq.beforeUnlinkAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountApple) (*api.AccountApple, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2083,6 +2585,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkApple(fn func(ctx context.Co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after Apple ID is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountApple) error) error {
 	ri.afterReq.afterUnlinkAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountApple) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2092,6 +2598,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkApple(fn func(ctx context.Con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before custom ID is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkCustom(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountCustom) (*api.AccountCustom, error)) error {
 	ri.beforeReq.beforeUnlinkCustomFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountCustom) (*api.AccountCustom, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2114,6 +2624,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkCustom(fn func(ctx context.C
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after custom ID is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkCustom(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountCustom) error) error {
 	ri.afterReq.afterUnlinkCustomFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountCustom) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2123,6 +2637,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkCustom(fn func(ctx context.Co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before device ID is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkDevice(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountDevice) (*api.AccountDevice, error)) error {
 	ri.beforeReq.beforeUnlinkDeviceFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountDevice) (*api.AccountDevice, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2145,6 +2663,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkDevice(fn func(ctx context.C
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after device ID is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkDevice(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountDevice) error) error {
 	ri.afterReq.afterUnlinkDeviceFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountDevice) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2154,6 +2676,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkDevice(fn func(ctx context.Co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before email is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkEmail(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountEmail) (*api.AccountEmail, error)) error {
 	ri.beforeReq.beforeUnlinkEmailFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountEmail) (*api.AccountEmail, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2176,6 +2702,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkEmail(fn func(ctx context.Co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after email is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkEmail(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountEmail) error) error {
 	ri.afterReq.afterUnlinkEmailFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountEmail) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2185,6 +2715,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkEmail(fn func(ctx context.Con
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before Facebook is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkFacebook(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountFacebook) (*api.AccountFacebook, error)) error {
 	ri.beforeReq.beforeUnlinkFacebookFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountFacebook) (*api.AccountFacebook, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2207,6 +2741,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkFacebook(fn func(ctx context
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after Facebook is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkFacebook(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountFacebook) error) error {
 	ri.afterReq.afterUnlinkFacebookFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountFacebook) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2216,6 +2754,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkFacebook(fn func(ctx context.
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before Facebook Instant Game profile is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkFacebookInstantGame(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountFacebookInstantGame) (*api.AccountFacebookInstantGame, error)) error {
 	ri.beforeReq.beforeUnlinkFacebookInstantGameFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountFacebookInstantGame) (*api.AccountFacebookInstantGame, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2238,6 +2780,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkFacebookInstantGame(fn func(
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after Facebook Instant Game profile is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkFacebookInstantGame(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountFacebookInstantGame) error) error {
 	ri.afterReq.afterUnlinkFacebookInstantGameFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountFacebookInstantGame) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2247,6 +2793,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkFacebookInstantGame(fn func(c
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before GameCenter is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkGameCenter(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGameCenter) (*api.AccountGameCenter, error)) error {
 	ri.beforeReq.beforeUnlinkGameCenterFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGameCenter) (*api.AccountGameCenter, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2269,6 +2819,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkGameCenter(fn func(ctx conte
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after GameCenter is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkGameCenter(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGameCenter) error) error {
 	ri.afterReq.afterUnlinkGameCenterFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGameCenter) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2278,6 +2832,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkGameCenter(fn func(ctx contex
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before Google is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGoogle) (*api.AccountGoogle, error)) error {
 	ri.beforeReq.beforeUnlinkGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGoogle) (*api.AccountGoogle, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2300,6 +2858,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkGoogle(fn func(ctx context.C
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after Google is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountGoogle) error) error {
 	ri.afterReq.afterUnlinkGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountGoogle) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2309,6 +2871,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkGoogle(fn func(ctx context.Co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic before Steam is unlinked from an account.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkSteam(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountSteam) (*api.AccountSteam, error)) error {
 	ri.beforeReq.beforeUnlinkSteamFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountSteam) (*api.AccountSteam, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2331,6 +2897,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeUnlinkSteam(fn func(ctx context.Co
 	return nil
 }
 
+// @group authenticate
+// @summary Register a function to perform additional logic after Steam is unlinked from an account.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterUnlinkSteam(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.AccountSteam) error) error {
 	ri.afterReq.afterUnlinkSteamFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.AccountSteam) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2340,6 +2910,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterUnlinkSteam(fn func(ctx context.Con
 	return nil
 }
 
+// @group users
+// @summary Register a function to perform additional logic before retrieving users.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeGetUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.GetUsersRequest) (*api.GetUsersRequest, error)) error {
 	ri.beforeReq.beforeGetUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.GetUsersRequest) (*api.GetUsersRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2362,6 +2936,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeGetUsers(fn func(ctx context.Conte
 	return nil
 }
 
+// @group users
+// @summary Register a function to perform additional logic after retrieving users.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterGetUsers(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.Users, in *api.GetUsersRequest) error) error {
 	ri.afterReq.afterGetUsersFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.Users, in *api.GetUsersRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2371,6 +2949,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterGetUsers(fn func(ctx context.Contex
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic before validating an Apple Store IAP receipt.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ValidatePurchaseAppleRequest) (*api.ValidatePurchaseAppleRequest, error)) error {
 	ri.beforeReq.beforeValidatePurchaseAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ValidatePurchaseAppleRequest) (*api.ValidatePurchaseAppleRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2393,6 +2975,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseApple(fn func(ctx 
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic after validating an Apple Store IAP receipt.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseAppleRequest) error) error {
 	ri.afterReq.afterValidatePurchaseAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseAppleRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2402,6 +2988,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseApple(fn func(ctx c
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic before validating an Apple Store Subscription receipt.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeValidateSubscriptionApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ValidateSubscriptionAppleRequest) (*api.ValidateSubscriptionAppleRequest, error)) error {
 	ri.beforeReq.beforeValidateSubscriptionAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ValidateSubscriptionAppleRequest) (*api.ValidateSubscriptionAppleRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2424,6 +3014,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeValidateSubscriptionApple(fn func(
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic after validating an Apple Store Subscription receipt.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterValidateSubscriptionApple(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ValidateSubscriptionResponse, in *api.ValidateSubscriptionAppleRequest) error) error {
 	ri.afterReq.afterValidateSubscriptionAppleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ValidateSubscriptionResponse, in *api.ValidateSubscriptionAppleRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2433,6 +3027,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterValidateSubscriptionApple(fn func(c
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic before validating a Google Store Subscription receipt.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeValidateSubscriptionGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ValidateSubscriptionGoogleRequest) (*api.ValidateSubscriptionGoogleRequest, error)) error {
 	ri.beforeReq.beforeValidateSubscriptionGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ValidateSubscriptionGoogleRequest) (*api.ValidateSubscriptionGoogleRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2455,6 +3053,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeValidateSubscriptionGoogle(fn func
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic after validating a Google Store Subscription receipt.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterValidateSubscriptionGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ValidateSubscriptionResponse, in *api.ValidateSubscriptionGoogleRequest) error) error {
 	ri.afterReq.afterValidateSubscriptionGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ValidateSubscriptionResponse, in *api.ValidateSubscriptionGoogleRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2464,6 +3066,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterValidateSubscriptionGoogle(fn func(
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic before listing subscriptions.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListSubscriptions(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListSubscriptionsRequest) (*api.ListSubscriptionsRequest, error)) error {
 	ri.beforeReq.beforeListSubscriptionsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListSubscriptionsRequest) (*api.ListSubscriptionsRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2486,6 +3092,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListSubscriptions(fn func(ctx cont
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic after listing subscriptions.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListSubscriptions(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.SubscriptionList, in *api.ListSubscriptionsRequest) error) error {
 	ri.afterReq.afterListSubscriptionsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.SubscriptionList, in *api.ListSubscriptionsRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2495,6 +3105,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterListSubscriptions(fn func(ctx conte
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic before getting a subscription.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeGetSubscription(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.GetSubscriptionRequest) (*api.GetSubscriptionRequest, error)) error {
 	ri.beforeReq.beforeGetSubscriptionFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.GetSubscriptionRequest) (*api.GetSubscriptionRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2517,6 +3131,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeGetSubscription(fn func(ctx contex
 	return nil
 }
 
+// @group subscriptions
+// @summary Register a function to perform additional logic after getting a subscription.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterGetSubscription(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ValidatedSubscription, in *api.GetSubscriptionRequest) error) error {
 	ri.afterReq.afterGetSubscriptionFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ValidatedSubscription, in *api.GetSubscriptionRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2526,6 +3144,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterGetSubscription(fn func(ctx context
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic before validating a Google Play Store IAP receipt.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ValidatePurchaseGoogleRequest) (*api.ValidatePurchaseGoogleRequest, error)) error {
 	ri.beforeReq.beforeValidatePurchaseGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ValidatePurchaseGoogleRequest) (*api.ValidatePurchaseGoogleRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2548,6 +3170,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseGoogle(fn func(ctx
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic after validating a Google Play Store IAP receipt.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseGoogle(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseGoogleRequest) error) error {
 	ri.afterReq.afterValidatePurchaseGoogleFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseGoogleRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2557,6 +3183,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseGoogle(fn func(ctx 
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic before validating a Huawei App Gallery IAP receipt.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseHuawei(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ValidatePurchaseHuaweiRequest) (*api.ValidatePurchaseHuaweiRequest, error)) error {
 	ri.beforeReq.beforeValidatePurchaseHuaweiFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ValidatePurchaseHuaweiRequest) (*api.ValidatePurchaseHuaweiRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2579,6 +3209,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseHuawei(fn func(ctx
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic after validating a Huawei App Gallery IAP receipt.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseHuawei(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseHuaweiRequest) error) error {
 	ri.afterReq.afterValidatePurchaseHuaweiFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseHuaweiRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2588,6 +3222,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseHuawei(fn func(ctx 
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic before validating a Facebook Instant IAP receipt.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseFacebookInstant(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ValidatePurchaseFacebookInstantRequest) (*api.ValidatePurchaseFacebookInstantRequest, error)) error {
 	ri.beforeReq.beforeValidatePurchaseFacebookInstantFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ValidatePurchaseFacebookInstantRequest) (*api.ValidatePurchaseFacebookInstantRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2610,6 +3248,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeValidatePurchaseFacebookInstant(fn
 	return nil
 }
 
+// @group purchases
+// @summary Register a function to perform additional logic after validating a Facebook Instant IAP receipt.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseFacebookInstant(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseFacebookInstantRequest) error) error {
 	ri.afterReq.afterValidatePurchaseFacebookInstantFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.ValidatePurchaseResponse, in *api.ValidatePurchaseFacebookInstantRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2619,6 +3261,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterValidatePurchaseFacebookInstant(fn 
 	return nil
 }
 
+// @group events
+// @summary Register a function invoked when the server receives an event.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeEvent(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.Event) (*api.Event, error)) error {
 	ri.beforeReq.beforeEventFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.Event) (*api.Event, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2641,6 +3287,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeEvent(fn func(ctx context.Context,
 	return nil
 }
 
+// @group events
+// @summary Register a function invoked after the server processes an event.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterEvent(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.Event) error) error {
 	ri.afterReq.afterEventFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.Event) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2650,6 +3300,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterEvent(fn func(ctx context.Context, 
 	return nil
 }
 
+// @group matches
+// @summary Register a function invoked when the server receives the relevant request.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeGetMatchmakerStats(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) error) error {
 	ri.beforeReq.beforeGetMatchmakerStatsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string) (error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2672,6 +3326,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeGetMatchmakerStats(fn func(ctx con
 	return nil
 }
 
+// @group matches
+// @summary Register a function invoked after the server processes the relevant request.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterGetMatchmakerStats(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.MatchmakerStats) error) error {
 	ri.afterReq.afterGetMatchmakerStatsFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.MatchmakerStats) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2681,6 +3339,10 @@ func (ri *RuntimeGoInitializer) RegisterAfterGetMatchmakerStats(fn func(ctx cont
 	return nil
 }
 
+// @group parties
+// @summary Register a function to perform additional logic before retrieving parties.
+// @param fn(type=function) The function to execute before the request is processed. It can modify the input or reject the request.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterBeforeListParties(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, in *api.ListPartiesRequest) (*api.ListPartiesRequest, error)) error {
 	ri.beforeReq.beforeListPartiesFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, in *api.ListPartiesRequest) (*api.ListPartiesRequest, error, codes.Code) {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeBefore, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")
@@ -2703,6 +3365,10 @@ func (ri *RuntimeGoInitializer) RegisterBeforeListParties(fn func(ctx context.Co
 	return nil
 }
 
+// @group parties
+// @summary Register a function to perform additional logic after retrieving parties.
+// @param fn(type=function) The function to execute after the request is processed.
+// @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterAfterListParties(fn func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, out *api.PartyList, in *api.ListPartiesRequest) error) error {
 	ri.afterReq.afterListPartiesFunction = func(ctx context.Context, logger *zap.Logger, traceID, userID, username string, vars map[string]string, expiry int64, clientIP, clientPort string, out *api.PartyList, in *api.ListPartiesRequest) error {
 		ctx = NewRuntimeGoContext(ctx, ri.node, ri.version, ri.env, RuntimeExecutionModeAfter, nil, nil, traceID, expiry, userID, username, vars, "", clientIP, clientPort, "")


### PR DESCRIPTION
Add annotations to before/after hook registration methods. 

 Source of annotations:
  - @summary text derived from the doc comments on the Initializer interface in nakama-common/runtime/runtime.go 
  - @group names cross-referenced against `runtime_go_nakama.go`
  - @param/@return from function signatures

 Groups:
  - 17 groups match existing groups in `runtime_go_nakama.go`: accounts, authenticate, chat, events, fleetmanager, friends, groups, leaderboards, matches, notifications, parties, purchases, sessions, storage, subscriptions, tournaments, users
  - 6 groups are initializer-specific (no NakamaModule equivalent): config, http, matchmaker, rpc, shutdown, hooks

___________________________
Group | Status | Hook Functions
-- | -- | --
accounts | Matches runtime | RegisterBeforeGetAccount, RegisterAfterGetAccount, RegisterBeforeUpdateAccount, RegisterAfterUpdateAccount, RegisterBeforeDeleteAccount, RegisterAfterDeleteAccount
authenticate | Matches runtime | RegisterBeforeAuthenticateApple, RegisterAfterAuthenticateApple, RegisterBeforeAuthenticateCustom, RegisterAfterAuthenticateCustom, RegisterBeforeAuthenticateDevice, RegisterAfterAuthenticateDevice, RegisterBeforeAuthenticateEmail, RegisterAfterAuthenticateEmail, RegisterBeforeAuthenticateFacebook, RegisterAfterAuthenticateFacebook, RegisterBeforeAuthenticateFacebookInstantGame, RegisterAfterAuthenticateFacebookInstantGame, RegisterBeforeAuthenticateGameCenter, RegisterAfterAuthenticateGameCenter, RegisterBeforeAuthenticateGoogle, RegisterAfterAuthenticateGoogle, RegisterBeforeAuthenticateSteam, RegisterAfterAuthenticateSteam, RegisterBeforeLinkApple, RegisterAfterLinkApple, RegisterBeforeLinkCustom, RegisterAfterLinkCustom, RegisterBeforeLinkDevice, RegisterAfterLinkDevice, RegisterBeforeLinkEmail, RegisterAfterLinkEmail, RegisterBeforeLinkFacebook, RegisterAfterLinkFacebook, RegisterBeforeLinkFacebookInstantGame, RegisterAfterLinkFacebookInstantGame, RegisterBeforeLinkGameCenter, RegisterAfterLinkGameCenter, RegisterBeforeLinkGoogle, RegisterAfterLinkGoogle, RegisterBeforeLinkSteam, RegisterAfterLinkSteam, RegisterBeforeUnlinkApple, RegisterAfterUnlinkApple, RegisterBeforeUnlinkCustom, RegisterAfterUnlinkCustom, RegisterBeforeUnlinkDevice, RegisterAfterUnlinkDevice, RegisterBeforeUnlinkEmail, RegisterAfterUnlinkEmail, RegisterBeforeUnlinkFacebook, RegisterAfterUnlinkFacebook, RegisterBeforeUnlinkFacebookInstantGame, RegisterAfterUnlinkFacebookInstantGame, RegisterBeforeUnlinkGameCenter, RegisterAfterUnlinkGameCenter, RegisterBeforeUnlinkGoogle, RegisterAfterUnlinkGoogle, RegisterBeforeUnlinkSteam, RegisterAfterUnlinkSteam
chat | Matches runtime | RegisterBeforeListChannelMessages, RegisterAfterListChannelMessages
config | New (initializer-only) | GetConfig
events | Matches runtime | RegisterEvent, RegisterEventSessionStart, RegisterEventSessionEnd, RegisterBeforeEvent, RegisterAfterEvent
fleetmanager | Matches runtime | RegisterFleetManager
friends | Matches runtime | RegisterBeforeListFriends, RegisterAfterListFriends, RegisterBeforeListFriendsOfFriends, RegisterAfterListFriendsOfFriends, RegisterBeforeAddFriends, RegisterAfterAddFriends, RegisterBeforeDeleteFriends, RegisterAfterDeleteFriends, RegisterBeforeBlockFriends, RegisterAfterBlockFriends, RegisterBeforeImportFacebookFriends, RegisterAfterImportFacebookFriends, RegisterBeforeImportSteamFriends, RegisterAfterImportSteamFriends
groups | Matches runtime | RegisterBeforeCreateGroup, RegisterAfterCreateGroup, RegisterBeforeUpdateGroup, RegisterAfterUpdateGroup, RegisterBeforeDeleteGroup, RegisterAfterDeleteGroup, RegisterBeforeJoinGroup, RegisterAfterJoinGroup, RegisterBeforeLeaveGroup, RegisterAfterLeaveGroup, RegisterBeforeAddGroupUsers, RegisterAfterAddGroupUsers, RegisterBeforeBanGroupUsers, RegisterAfterBanGroupUsers, RegisterBeforeKickGroupUsers, RegisterAfterKickGroupUsers, RegisterBeforePromoteGroupUsers, RegisterAfterPromoteGroupUsers, RegisterBeforeDemoteGroupUsers, RegisterAfterDemoteGroupUsers, RegisterBeforeListGroupUsers, RegisterAfterListGroupUsers, RegisterBeforeListUserGroups, RegisterAfterListUserGroups, RegisterBeforeListGroups, RegisterAfterListGroups
http | New (initializer-only) | RegisterHttp, RegisterConsoleHttp
leaderboards | Matches runtime | RegisterBeforeDeleteLeaderboardRecord, RegisterAfterDeleteLeaderboardRecord, RegisterBeforeListLeaderboardRecords, RegisterAfterListLeaderboardRecords, RegisterBeforeWriteLeaderboardRecord, RegisterAfterWriteLeaderboardRecord, RegisterBeforeListLeaderboardRecordsAroundOwner, RegisterAfterListLeaderboardRecordsAroundOwner, RegisterLeaderboardReset
matches | Matches runtime | RegisterBeforeListMatches, RegisterAfterListMatches, RegisterBeforeGetMatchmakerStats, RegisterAfterGetMatchmakerStats, RegisterMatch
matchmaker | New (initializer-only) | RegisterMatchmakerMatched, RegisterMatchmakerOverride, RegisterMatchmakerProcessor
notifications | Matches runtime | RegisterBeforeListNotifications, RegisterAfterListNotifications, RegisterBeforeDeleteNotifications, RegisterAfterDeleteNotifications
parties | Matches runtime | RegisterBeforeListParties, RegisterAfterListParties
purchases | Matches runtime | RegisterBeforeValidatePurchaseApple, RegisterAfterValidatePurchaseApple, RegisterBeforeValidatePurchaseGoogle, RegisterAfterValidatePurchaseGoogle, RegisterBeforeValidatePurchaseHuawei, RegisterAfterValidatePurchaseHuawei, RegisterBeforeValidatePurchaseFacebookInstant, RegisterAfterValidatePurchaseFacebookInstant, RegisterPurchaseNotificationApple, RegisterPurchaseNotificationGoogle
hooks | New (initializer-only) | RegisterBeforeRt, RegisterAfterRt
rpc | New (initializer-only) | RegisterRpc
sessions | Matches runtime | RegisterBeforeSessionRefresh, RegisterAfterSessionRefresh, RegisterBeforeSessionLogout, RegisterAfterSessionLogout
shutdown | New (initializer-only) | RegisterShutdown
storage | Matches runtime | RegisterBeforeListStorageObjects, RegisterAfterListStorageObjects, RegisterBeforeReadStorageObjects, RegisterAfterReadStorageObjects, RegisterBeforeWriteStorageObjects, RegisterAfterWriteStorageObjects, RegisterBeforeDeleteStorageObjects, RegisterAfterDeleteStorageObjects, RegisterStorageIndex, RegisterStorageIndexFilter
subscriptions | Matches runtime | RegisterBeforeValidateSubscriptionApple, RegisterAfterValidateSubscriptionApple, RegisterBeforeValidateSubscriptionGoogle, RegisterAfterValidateSubscriptionGoogle, RegisterBeforeListSubscriptions, RegisterAfterListSubscriptions, RegisterBeforeGetSubscription, RegisterAfterGetSubscription, RegisterSubscriptionNotificationApple, RegisterSubscriptionNotificationGoogle
tournaments | Matches runtime | RegisterBeforeDeleteTournamentRecord, RegisterAfterDeleteTournamentRecord, RegisterBeforeJoinTournament, RegisterAfterJoinTournament, RegisterBeforeListTournamentRecords, RegisterAfterListTournamentRecords, RegisterBeforeListTournaments, RegisterAfterListTournaments, RegisterBeforeWriteTournamentRecord, RegisterAfterWriteTournamentRecord, RegisterBeforeListTournamentRecordsAroundOwner, RegisterAfterListTournamentRecordsAroundOwner, RegisterTournamentEnd, RegisterTournamentReset
users | Matches runtime | RegisterBeforeGetUsers, RegisterAfterGetUsers


