### PR TITLE
Add Github Action to trigger Docs Update on Nakama Release

### DIFF
--- a/.github/workflows/trigger_docs_update.yaml
+++ b/.github/workflows/trigger_docs_update.yaml
@@ -1,0 +1,17 @@
+name: Trigger Docs Update
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  trigger-docs-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch nakama-release event to docs repo
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_PAT }}
+        run: |
+          gh api -X POST /repos/heroiclabs/docs/dispatches \
+            -f event_type=nakama-release


### PR DESCRIPTION
Adds a GitHub Actions workflow that notifies heroiclabs/docs whenever a Nakama release is published, so the docs (e.g. version compatibility matrix) stay in sync automatically.