### PR TITLE
Discourage seqscan when performing account search

### DIFF
--- a/server/console_account.go
+++ b/server/console_account.go
@@ -442,6 +442,9 @@ func (s *ConsoleServer) ListAccounts(ctx context.Context, in *console.ListAccoun
 		// Exact match based on username or social identifiers, if any.
 		params := []interface{}{in.Filter}
 		query := `
+			/*+
+			  NoSeqScan(users)
+			 */
 			SELECT id, username, display_name, avatar_url, lang_tag, location, timezone, metadata, apple_id, facebook_id, facebook_instant_game_id, google_id, gamecenter_id, steam_id, edge_count, create_time, update_time
 				FROM users
 				WHERE username = $1

--- a/server/console_account.go
+++ b/server/console_account.go
@@ -459,12 +459,13 @@ func (s *ConsoleServer) ListAccounts(ctx context.Context, in *console.ListAccoun
       	WHERE ud.id = $1
 		`
 		if len(in.Filter) >= 3 && !s.config.GetConsole().DisableDisplayNameSearch {
+			// LIMIT 400 is chosen to bias Postgres toward users_display_name_idx (GIN/pg_trgm) and away from seqscan
 			query += `
 				UNION
 				(SELECT id, username, display_name, avatar_url, lang_tag, location, timezone, metadata, apple_id, facebook_id, facebook_instant_game_id, google_id, gamecenter_id, steam_id, edge_count, create_time, update_time
 					FROM users
 					WHERE display_name ILIKE CONCAT('%', replace(replace(replace($1, '\', '\\'), '%', '\%'), '_', '\_'), '%')
-           LIMIT 100)
+           LIMIT 400)
 			`
 		}
 		if userIDFilter != nil {


### PR DESCRIPTION
Small LIMIT sometimes makes PG query plan to take sequential scan
+ filter route. Raising limit to 400 favours index scan over seqscan on both CloudSQL and Aurora RDS.