### PR TITLE
Fix leaderboard scheduler discarding expiry deadlines at a tournament's end_time

### DIFF
--- a/server/leaderboard_scheduler.go
+++ b/server/leaderboard_scheduler.go
@@ -274,7 +274,7 @@ func (ls *LocalLeaderboardScheduler) computeNext(now time.Time) (endActiveTs, ex
 					}
 				}
 
-				if expiry > 0 {
+				if expiry > 0 && nowUnix < expiry {
 					if expiryTs < 0 || expiry < expiryTs {
 						expiryTs = expiry
 						expiryIds = []string{l.Id}

--- a/server/leaderboard_scheduler_test.go
+++ b/server/leaderboard_scheduler_test.go
@@ -7,9 +7,67 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama/v3/internal/cronexpr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 )
+
+func TestLeaderboardSchedulerEndedTournamentHidesLiveExpiry(t *testing.T) {
+	// Tournament with an explicit end_time and no reset schedule, so its expiry is the end_time.
+	const tournamentEnd int64 = 1_700_000_000
+
+	hourly, err := cronexpr.Parse("0 * * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ls := &LocalLeaderboardScheduler{
+		cache: &LocalLeaderboardCache{
+			allList: []*Leaderboard{
+				{Id: "ending-tournament", Duration: 3600, StartTime: tournamentEnd - 7200, EndTime: tournamentEnd},
+				{Id: "hourly-leaderboard", ResetScheduleStr: "0 * * * *", ResetSchedule: hourly},
+			},
+		},
+	}
+
+	liveExpiry := hourly.Next(time.Unix(tournamentEnd, 0).UTC()).UTC().Unix()
+
+	// A second before the boundary the tournament's final expiry is legitimately the next deadline.
+	_, expiryTs, _, expiryIds := ls.computeNext(time.Unix(tournamentEnd-1, 0).UTC())
+	assert.Equal(t, tournamentEnd, expiryTs)
+	assert.Equal(t, []string{"ending-tournament"}, expiryIds)
+
+	// scheduleLoop fires at tournamentEnd then recomputes inside the same second, where the ended
+	// tournament must drop out or it wins the earliest-deadline reduction and hides every live expiry.
+	_, expiryTs, _, expiryIds = ls.computeNext(time.Unix(tournamentEnd, 0).UTC())
+	assert.Equal(t, liveExpiry, expiryTs)
+	assert.Equal(t, []string{"hourly-leaderboard"}, expiryIds)
+}
+
+func TestLeaderboardSchedulerEndedTournamentHidesSuccessorExpiry(t *testing.T) {
+	// Consecutive 24h tournaments with no reset schedule, so endActive and expiry both land on end_time.
+	const day1End int64 = 1_700_042_400
+	const day2End int64 = day1End + 86400
+
+	ls := &LocalLeaderboardScheduler{
+		cache: &LocalLeaderboardCache{
+			allList: []*Leaderboard{
+				{Id: "day-1", Duration: 86400, StartTime: day1End - 86400, EndTime: day1End},
+				{Id: "day-2", Duration: 86400, StartTime: day1End, EndTime: day2End},
+			},
+		},
+	}
+
+	// scheduleLoop fires both hooks at day1End, then recomputes inside that same second.
+	endActiveTs, expiryTs, endActiveIds, expiryIds := ls.computeNext(time.Unix(day1End, 0).UTC())
+
+	assert.Equal(t, day2End, endActiveTs)
+	assert.Equal(t, []string{"day-2"}, endActiveIds)
+
+	// day-1's stale expiry must not win, or lastFireUnix filters it to -1 and day-2's reset hook never fires.
+	assert.Equal(t, day2End, expiryTs)
+	assert.Equal(t, []string{"day-2"}, expiryIds)
+}
 
 func TestLeaderboardScheduler(t *testing.T) {
 	t.Skip("auxiliary test for scheduling logic, but too finicky to be part of the test suite")


### PR DESCRIPTION
`calculateTournamentDeadlines` caps a tournament's expiry to its `end_time`, and the "tournament has ended permanently" guard in computeNext uses a strict less-than, so at the exact second a tournament reaches its `end_time` it is still scanned and reports an expiry equal to the current second.

The expiry branch had no future check, unlike the endActive branch directly above it. That already-elapsed deadline therefore won the earliest-deadline reduction and replaced the ID list, hiding every live leaderboard's expiry. The `lastFireUnix` filter then discarded it as already processed, leaving the loop armed with an expiry of -1 and no expiry work queued for the following cycle, so leaderboard and tournament reset hooks silently did not fire.

I've guard the expiry branch the same way endActive is guarded. Verified against a running server: every rotation of a daily tournament series previously left the scheduler armed with `expiry_ts` -1. 