### PR TITLE
Use slices.Reverse for paginated list reversals

### DIFF
--- a/server/core_channel.go
+++ b/server/core_channel.go
@@ -22,6 +22,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -230,9 +231,7 @@ WHERE stream_mode = $1 AND stream_subject = $2::UUID AND stream_descriptor = $3:
 			prevCursor.IsNext = !prevCursor.IsNext
 		}
 
-		for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
-			messages[i], messages[j] = messages[j], messages[i]
-		}
+		slices.Reverse(messages)
 	}
 
 	var cacheableCursor *channelMessageListCursor

--- a/server/core_leaderboard.go
+++ b/server/core_leaderboard.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/gob"
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -266,9 +267,7 @@ func LeaderboardRecordsList(ctx context.Context, logger *zap.Logger, db *sql.DB,
 				nextCursor.IsNext = !nextCursor.IsNext
 			}
 
-			for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
-				records[i], records[j] = records[j], records[i]
-			}
+			slices.Reverse(records)
 		}
 
 		if nextCursor != nil {
@@ -801,9 +800,7 @@ func getLeaderboardRecordsHaystack(ctx context.Context, logger *zap.Logger, db *
 		}
 
 		// We went 'up' on the leaderboard, so reverse the first half of records.
-		for left, right := 0, len(firstRecords)-1; left < right; left, right = left+1, right-1 {
-			firstRecords[left], firstRecords[right] = firstRecords[right], firstRecords[left]
-		}
+		slices.Reverse(firstRecords)
 
 		secondQuery := query
 		if sortOrder == LeaderboardSortOrderAscending {

--- a/server/core_subscription.go
+++ b/server/core_subscription.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -243,9 +244,7 @@ func ListSubscriptions(ctx context.Context, logger *zap.Logger, db *sql.DB, user
 			nextCursor.IsNext = !nextCursor.IsNext
 		}
 
-		for i, j := 0, len(subscriptions)-1; i < j; i, j = i+1, j-1 {
-			subscriptions[i], subscriptions[j] = subscriptions[j], subscriptions[i]
-		}
+		slices.Reverse(subscriptions)
 	}
 
 	var nextCursorStr string

--- a/server/core_wallet.go
+++ b/server/core_wallet.go
@@ -22,6 +22,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -415,9 +416,7 @@ func ListWalletLedger(ctx context.Context, logger *zap.Logger, db *sql.DB, userI
 			nextCursor.IsNext = !nextCursor.IsNext
 		}
 
-		for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
-			results[i], results[j] = results[j], results[i]
-		}
+		slices.Reverse(results)
 	}
 
 	var nextCursorStr string


### PR DESCRIPTION
## Summary

Replace five manual in-place reversal loops with the standard library `slices.Reverse` (Go 1.21+), matching the style already used in `core_purchase.go`, `console_audit.go`, and `console_notification.go`.

## Changes

- `server/core_leaderboard.go` — previous-page records reversal in `LeaderboardRecordsList` and first-half reversal in `getLeaderboardRecordsHaystack`
- `server/core_channel.go` — previous-page messages reversal in message list
- `server/core_wallet.go` — previous-page wallet ledger reversal
- `server/core_subscription.go` — previous-page subscriptions reversal

## Why

All five sites are full-slice, in-place reversals — `slices.Reverse` is a drop-in equivalent with identical semantics (verified: empty, single-element, even/odd lengths). The codebase already uses `slices.Reverse` in three other files, so this standardizes the house style and removes 15 lines of boilerplate.

## Verification

- `go build ./server/` passes
- `go vet ./server/` clean (pre-existing warning in `shutdown.go` unrelated to this change)
- `golangci-lint run --new-from-rev=master ./server/` — 0 issues
- `go test -race` — `TestUpdateWallet*`, `TestApiLeaderboard/create_and_list_leaderboard`, and related suites pass. `TestApiLeaderboard` subtests beyond the first fail with "Auth token invalid" due to a pre-existing environment issue (60s test session tokens vs. slow local Docker; reproduced identically on clean `master`, unrelated to this change).
- Behavior equivalence of `slices.Reverse` vs. the manual loop verified with a dedicated test.

No behavior change — pure refactor.