### PR TITLE
Add named multi FleetManager support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project are documented below.
 
 The format is based on [keep a changelog](http://keepachangelog.com) and this project uses [semantic versioning](http://semver.org).
 
+[Unreleased]
+### Added
+- Add support for namespaced multi fleet manager registration.
+
 ## [3.40.0] - 2026-07-13
 ### Added
 - Add Samsung Galaxy Store purchase validation request type and `SAMSUNG_GALAXY_STORE` store provider enum.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
-	github.com/heroiclabs/nakama-common v1.47.0
+	github.com/heroiclabs/nakama-common v1.47.1-0.20260819164846-bb20b5e08d21
 	github.com/heroiclabs/sql-migrate v0.0.0-20241125131053-95a7949783b0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/heroiclabs/nakama-common v1.47.0 h1:WjdVZ4MGmX0j/sCaLgQAUgJr7v0uA9PX5mKCDcX6CSU=
-github.com/heroiclabs/nakama-common v1.47.0/go.mod h1:GC6A2meBYNwrsDuQ7pSO2TiznSIK5+ogR5VBVZCmBSs=
+github.com/heroiclabs/nakama-common v1.47.1-0.20260819164846-bb20b5e08d21 h1:WEUj1by8lvkG5PHPuWLlAI/AEjv7pY9CWtX8wJxZIPc=
+github.com/heroiclabs/nakama-common v1.47.1-0.20260819164846-bb20b5e08d21/go.mod h1:GC6A2meBYNwrsDuQ7pSO2TiznSIK5+ogR5VBVZCmBSs=
 github.com/heroiclabs/sql-migrate v0.0.0-20241125131053-95a7949783b0 h1:hHJcYOP6L2/wZIEnYjjkJM+rOk/bK0uaYkDAejYpLhI=
 github.com/heroiclabs/sql-migrate v0.0.0-20241125131053-95a7949783b0/go.mod h1:uwcmopkVQIfb/JQqul5zmGI9ounclRC08j9S9lLcpRQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/server/runtime.go
+++ b/server/runtime.go
@@ -802,6 +802,10 @@ func NewRuntime(ctx context.Context, logger, startupLogger *zap.Logger, db *sql.
 		startupLogger.Info("Registered Go runtime RPC function invocation", zap.String("id", id))
 	}
 
+	for id, _ := range fleetManagers {
+		startupLogger.Info("Registered Fleet Manager", zap.String("id", id))
+	}
+
 	allBeforeRtFunctions := make(map[string]RuntimeBeforeRtFunction, len(jsBeforeRtFns)+len(luaBeforeRtFns)+len(goBeforeRtFns))
 	for id, fn := range jsBeforeRtFns {
 		allBeforeRtFunctions[id] = fn

--- a/server/runtime.go
+++ b/server/runtime.go
@@ -802,7 +802,7 @@ func NewRuntime(ctx context.Context, logger, startupLogger *zap.Logger, db *sql.
 		startupLogger.Info("Registered Go runtime RPC function invocation", zap.String("id", id))
 	}
 
-	for id, _ := range fleetManagers {
+	for id := range fleetManagers {
 		startupLogger.Info("Registered Fleet Manager", zap.String("id", id))
 	}
 

--- a/server/runtime.go
+++ b/server/runtime.go
@@ -565,7 +565,7 @@ type Runtime struct {
 
 	shutdownFunction RuntimeShutdownFunction
 
-	fleetManager runtime.FleetManager
+	fleetManagers map[string]runtime.FleetManager
 }
 
 type MatchNamesListFunction func() []string
@@ -715,7 +715,7 @@ func NewRuntime(ctx context.Context, logger, startupLogger *zap.Logger, db *sql.
 		goPurchaseNotificationGoogleFn,
 		goSubscriptionNotificationGoogleFn,
 		goIndexFilterFns,
-		fleetManager,
+		fleetManagers,
 		httpHandlers,
 		consoleHttpHandlers,
 		allEventFns,
@@ -2836,7 +2836,7 @@ func NewRuntime(ctx context.Context, logger, startupLogger *zap.Logger, db *sql.
 
 		shutdownFunction: allShutdownFunction,
 
-		fleetManager: fleetManager,
+		fleetManagers: fleetManagers,
 
 		eventFunctions: allEventFns,
 	}, rInfo, nil

--- a/server/runtime_go.go
+++ b/server/runtime_go.go
@@ -3625,9 +3625,6 @@ func (ri *RuntimeGoInitializer) RegisterFleetManagerByName(name string, fleetMan
 	if fleetManager == nil {
 		return errors.New("fleet manager cannot be nil")
 	}
-	if _, found := ri.fleetManagers[name]; found {
-		return fmt.Errorf("fleet manager %q is already registered", name)
-	}
 	if err := fleetManager.Init(ri.nk, ri.fmCallbackHandler); err != nil {
 		return fmt.Errorf("failed to run fleet manager Init function: %s", err.Error())
 	}
@@ -3765,7 +3762,7 @@ func NewRuntimeProviderGo(ctx context.Context, logger, startupLogger *zap.Logger
 
 		fmCallbackHandler: fmCallbackHandler,
 
-		fleetManagers: nk.fleetManagers,
+		fleetManagers: make(map[string]runtime.FleetManager),
 	}
 
 	// The baseline context that will be passed to all InitModule calls.

--- a/server/runtime_go.go
+++ b/server/runtime_go.go
@@ -3628,7 +3628,11 @@ func (ri *RuntimeGoInitializer) RegisterFleetManagerByName(name string, fleetMan
 	if err := fleetManager.Init(ri.nk, ri.fmCallbackHandler); err != nil {
 		return fmt.Errorf("failed to run fleet manager Init function: %s", err.Error())
 	}
+
 	ri.fleetManagers[name] = fleetManager
+	if nk, ok := ri.nk.(*RuntimeGoNakamaModule); ok {
+		nk.fleetManagers[name] = fleetManager
+	}
 
 	return nil
 }
@@ -3761,8 +3765,7 @@ func NewRuntimeProviderGo(ctx context.Context, logger, startupLogger *zap.Logger
 		matchLock: matchLock,
 
 		fmCallbackHandler: fmCallbackHandler,
-
-		fleetManagers: make(map[string]runtime.FleetManager),
+		fleetManagers:     make(map[string]runtime.FleetManager),
 	}
 
 	// The baseline context that will be passed to all InitModule calls.

--- a/server/runtime_go.go
+++ b/server/runtime_go.go
@@ -3630,10 +3630,6 @@ func (ri *RuntimeGoInitializer) RegisterFleetManagerByName(name string, fleetMan
 	}
 
 	ri.fleetManagers[name] = fleetManager
-	if nk, ok := ri.nk.(*RuntimeGoNakamaModule); ok {
-		nk.fleetManagers[name] = fleetManager
-	}
-
 	return nil
 }
 
@@ -3765,7 +3761,7 @@ func NewRuntimeProviderGo(ctx context.Context, logger, startupLogger *zap.Logger
 		matchLock: matchLock,
 
 		fmCallbackHandler: fmCallbackHandler,
-		fleetManagers:     make(map[string]runtime.FleetManager),
+		fleetManagers:     nk.fleetManagers,
 	}
 
 	// The baseline context that will be passed to all InitModule calls.

--- a/server/runtime_go.go
+++ b/server/runtime_go.go
@@ -68,7 +68,7 @@ type RuntimeGoInitializer struct {
 	httpHandlers                   []*RuntimeHttpHandler
 	consoleHttpHandlers            []*RuntimeHttpHandler
 
-	fleetManager runtime.FleetManager
+	fleetManagers map[string]runtime.FleetManager
 
 	eventFunctions        []RuntimeEventFunction
 	sessionStartFunctions []RuntimeEventFunction
@@ -3613,16 +3613,25 @@ func (ri *RuntimeGoInitializer) RegisterStorageIndexFilter(indexName string, fn 
 // @param fleetManager(type=runtime.FleetManagerInitializer) The fleet manager implementation to register.
 // @return error(error) An optional error value if an error occurred.
 func (ri *RuntimeGoInitializer) RegisterFleetManager(fleetManager runtime.FleetManagerInitializer) error {
+	return ri.RegisterFleetManagerByName("", fleetManager)
+}
+
+// @group fleetmanager
+// @summary Register a FleetManager implementation under the given name. The fleet manager can be retrieved later from the runtime using GetFleetManagerByName().
+// @param name(type=string) The name to register the fleet manager under. The empty name is the default.
+// @param fleetManager(type=runtime.FleetManagerInitializer) The fleet manager implementation to register.
+// @return error(error) An optional error value if an error occurred.
+func (ri *RuntimeGoInitializer) RegisterFleetManagerByName(name string, fleetManager runtime.FleetManagerInitializer) error {
 	if fleetManager == nil {
 		return errors.New("fleet manager cannot be nil")
+	}
+	if _, found := ri.fleetManagers[name]; found {
+		return fmt.Errorf("fleet manager %q is already registered", name)
 	}
 	if err := fleetManager.Init(ri.nk, ri.fmCallbackHandler); err != nil {
 		return fmt.Errorf("failed to run fleet manager Init function: %s", err.Error())
 	}
-	ri.fleetManager = fleetManager
-	if nk, ok := ri.nk.(*RuntimeGoNakamaModule); ok {
-		nk.fleetManager = fleetManager
-	}
+	ri.fleetManagers[name] = fleetManager
 
 	return nil
 }
@@ -3684,7 +3693,7 @@ func (ri *RuntimeGoInitializer) RegisterMatch(name string, fn func(ctx context.C
 	return nil
 }
 
-func NewRuntimeProviderGo(ctx context.Context, logger, startupLogger *zap.Logger, db *sql.DB, protojsonMarshaler *protojson.MarshalOptions, config Config, version string, socialClient *social.Client, leaderboardCache LeaderboardCache, leaderboardRankCache LeaderboardRankCache, leaderboardScheduler LeaderboardScheduler, sessionRegistry SessionRegistry, sessionCache SessionCache, statusRegistry StatusRegistry, matchRegistry MatchRegistry, partyRegistry PartyRegistry, tracker Tracker, metrics Metrics, streamManager StreamManager, router MessageRouter, storageIndex StorageIndex, satoriClient runtime.Satori, rootPath string, paths []string, eventQueue *RuntimeEventQueue, matchProvider *MatchProvider, fmCallbackHandler runtime.FmCallbackHandler) ([]string, map[string]RuntimeRpcFunction, map[string]RuntimeBeforeRtFunction, map[string]RuntimeAfterRtFunction, *RuntimeBeforeReqFunctions, *RuntimeAfterReqFunctions, RuntimeMatchmakerMatchedFunction, RuntimeMatchmakerOverrideFunction, RuntimeMatchmakerProcessorFunction, RuntimeTournamentEndFunction, RuntimeTournamentResetFunction, RuntimeLeaderboardResetFunction, RuntimeShutdownFunction, RuntimePurchaseNotificationAppleFunction, RuntimeSubscriptionNotificationAppleFunction, RuntimePurchaseNotificationGoogleFunction, RuntimeSubscriptionNotificationGoogleFunction, map[string]RuntimeStorageIndexFilterFunction, runtime.FleetManager, []*RuntimeHttpHandler, []*RuntimeHttpHandler, *RuntimeEventFunctions, func() []string, error) {
+func NewRuntimeProviderGo(ctx context.Context, logger, startupLogger *zap.Logger, db *sql.DB, protojsonMarshaler *protojson.MarshalOptions, config Config, version string, socialClient *social.Client, leaderboardCache LeaderboardCache, leaderboardRankCache LeaderboardRankCache, leaderboardScheduler LeaderboardScheduler, sessionRegistry SessionRegistry, sessionCache SessionCache, statusRegistry StatusRegistry, matchRegistry MatchRegistry, partyRegistry PartyRegistry, tracker Tracker, metrics Metrics, streamManager StreamManager, router MessageRouter, storageIndex StorageIndex, satoriClient runtime.Satori, rootPath string, paths []string, eventQueue *RuntimeEventQueue, matchProvider *MatchProvider, fmCallbackHandler runtime.FmCallbackHandler) ([]string, map[string]RuntimeRpcFunction, map[string]RuntimeBeforeRtFunction, map[string]RuntimeAfterRtFunction, *RuntimeBeforeReqFunctions, *RuntimeAfterReqFunctions, RuntimeMatchmakerMatchedFunction, RuntimeMatchmakerOverrideFunction, RuntimeMatchmakerProcessorFunction, RuntimeTournamentEndFunction, RuntimeTournamentResetFunction, RuntimeLeaderboardResetFunction, RuntimeShutdownFunction, RuntimePurchaseNotificationAppleFunction, RuntimeSubscriptionNotificationAppleFunction, RuntimePurchaseNotificationGoogleFunction, RuntimeSubscriptionNotificationGoogleFunction, map[string]RuntimeStorageIndexFilterFunction, map[string]runtime.FleetManager, []*RuntimeHttpHandler, []*RuntimeHttpHandler, *RuntimeEventFunctions, func() []string, error) {
 	runtimeLogger := NewRuntimeGoLogger(logger)
 	node := config.GetName()
 	env := config.GetRuntime().Environment
@@ -3755,6 +3764,8 @@ func NewRuntimeProviderGo(ctx context.Context, logger, startupLogger *zap.Logger
 		matchLock: matchLock,
 
 		fmCallbackHandler: fmCallbackHandler,
+
+		fleetManagers: nk.fleetManagers,
 	}
 
 	// The baseline context that will be passed to all InitModule calls.
@@ -3829,7 +3840,7 @@ func NewRuntimeProviderGo(ctx context.Context, logger, startupLogger *zap.Logger
 		}
 	}
 
-	return modulePaths, initializer.rpc, initializer.beforeRt, initializer.afterRt, initializer.beforeReq, initializer.afterReq, initializer.matchmakerMatched, initializer.matchmakerOverride, initializer.matchmakerProcessor, initializer.tournamentEnd, initializer.tournamentReset, initializer.leaderboardReset, initializer.shutdownFunction, initializer.purchaseNotificationApple, initializer.subscriptionNotificationApple, initializer.purchaseNotificationGoogle, initializer.subscriptionNotificationGoogle, initializer.storageIndexFunctions, initializer.fleetManager, initializer.httpHandlers, initializer.consoleHttpHandlers, events, matchNamesListFn, nil
+	return modulePaths, initializer.rpc, initializer.beforeRt, initializer.afterRt, initializer.beforeReq, initializer.afterReq, initializer.matchmakerMatched, initializer.matchmakerOverride, initializer.matchmakerProcessor, initializer.tournamentEnd, initializer.tournamentReset, initializer.leaderboardReset, initializer.shutdownFunction, initializer.purchaseNotificationApple, initializer.subscriptionNotificationApple, initializer.purchaseNotificationGoogle, initializer.subscriptionNotificationGoogle, initializer.storageIndexFunctions, initializer.fleetManagers, initializer.httpHandlers, initializer.consoleHttpHandlers, events, matchNamesListFn, nil
 }
 
 func CheckRuntimeProviderGo(logger *zap.Logger, rootPath string, paths []string) error {

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -64,7 +64,7 @@ type RuntimeGoNakamaModule struct {
 	node                 string
 	matchCreateFn        RuntimeMatchCreateFunction
 	satori               runtime.Satori
-	fleetManager         runtime.FleetManager
+	fleetManagers        map[string]runtime.FleetManager
 	storageIndex         StorageIndex
 }
 
@@ -92,6 +92,8 @@ func NewRuntimeGoNakamaModule(logger *zap.Logger, db *sql.DB, protojsonMarshaler
 		node: config.GetName(),
 
 		satori: satoriClient,
+
+		fleetManagers: make(map[string]runtime.FleetManager),
 	}
 }
 
@@ -4591,8 +4593,16 @@ func (n *RuntimeGoNakamaModule) GetSatori() runtime.Satori {
 }
 
 // @group fleetmanager
-// @symmary Get the Fleet Manager client.
+// @summary Get the Fleet Manager client.
 // @return fleetManager(runtime.FleetManager) The Fleet Manager client.
 func (n *RuntimeGoNakamaModule) GetFleetManager() runtime.FleetManager {
-	return n.fleetManager
+	return n.GetFleetManagerByName("")
+}
+
+// @group fleetmanager
+// @summary Get the Fleet Manager client registered under the given name.
+// @param name(type=string) The name the Fleet Manager was registered under. The empty name is the default.
+// @return fleetManager(runtime.FleetManager) The Fleet Manager client, or nil if none is registered under that name.
+func (n *RuntimeGoNakamaModule) GetFleetManagerByName(name string) runtime.FleetManager {
+	return n.fleetManagers[name]
 }

--- a/vendor/github.com/blugelabs/bluge/search/search.go
+++ b/vendor/github.com/blugelabs/bluge/search/search.go
@@ -140,17 +140,12 @@ func (dm *DocumentMatch) Reset() *DocumentMatch {
 	sortValue := dm.SortValue
 	// remember the FieldTermLocations backing array
 	ftls := dm.FieldTermLocations
-	docValues := dm.docValues
 	// idiom to copy over from empty DocumentMatch (0 allocations)
 	*dm = DocumentMatch{}
 	// reuse the [][]byte already allocated (and reset len to 0)
 	dm.SortValue = sortValue[:0]
 	// reuse the FieldTermLocations already allocated (and reset len to 0)
 	dm.FieldTermLocations = ftls[:0]
-	for key, slice := range docValues {
-		docValues[key] = slice[:0]
-	}
-	dm.docValues = docValues
 	return dm
 }
 

--- a/vendor/github.com/blugelabs/bluge/search/search.go
+++ b/vendor/github.com/blugelabs/bluge/search/search.go
@@ -140,12 +140,17 @@ func (dm *DocumentMatch) Reset() *DocumentMatch {
 	sortValue := dm.SortValue
 	// remember the FieldTermLocations backing array
 	ftls := dm.FieldTermLocations
+	docValues := dm.docValues
 	// idiom to copy over from empty DocumentMatch (0 allocations)
 	*dm = DocumentMatch{}
 	// reuse the [][]byte already allocated (and reset len to 0)
 	dm.SortValue = sortValue[:0]
 	// reuse the FieldTermLocations already allocated (and reset len to 0)
 	dm.FieldTermLocations = ftls[:0]
+	for key, slice := range docValues {
+		docValues[key] = slice[:0]
+	}
+	dm.docValues = docValues
 	return dm
 }
 

--- a/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
+++ b/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
@@ -896,6 +896,9 @@ type Initializer interface {
 	// RegisterFleetManager can be used to register a FleetManager implementation that can be retrieved from the runtime using GetFleetManager().
 	RegisterFleetManager(fleetManagerInit FleetManagerInitializer) error
 
+	// RegisterFleetManagerByName registers a FleetManager implementation under the given name, retrievable using GetFleetManagerByName(). The empty name is the default.
+	RegisterFleetManagerByName(name string, fleetManagerInit FleetManagerInitializer) error
+
 	// RegisterShutdown can be used to register a function that is executed once the server receives a termination signal.
 	// This function only fires if shutdown_grace_sec > 0 and will be terminated early if its execution takes longer than the configured grace seconds.
 	RegisterShutdown(fn func(ctx context.Context, logger Logger, db *sql.DB, nk NakamaModule)) error
@@ -1249,6 +1252,7 @@ type NakamaModule interface {
 
 	GetSatori() Satori
 	GetFleetManager() FleetManager
+	GetFleetManagerByName(name string) FleetManager
 }
 
 /*

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/internal/genopena
 github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options
 github.com/grpc-ecosystem/grpc-gateway/v2/runtime
 github.com/grpc-ecosystem/grpc-gateway/v2/utilities
-# github.com/heroiclabs/nakama-common v1.47.0
+# github.com/heroiclabs/nakama-common v1.47.1-0.20260819164846-bb20b5e08d21
 ## explicit; go 1.26.5
 github.com/heroiclabs/nakama-common/api
 github.com/heroiclabs/nakama-common/rtapi


### PR DESCRIPTION
Add `RegisterFleetManagerByName` and `GetFleetManagerByName` to allow for registering multiple fleet managers and get them by key

Existing `RegisterFleetManager` and `GetFleetManager` register it using an empty string