### PR TITLE
Fix matchmaker remainder eviction to preserve longest-waiting tickets

### DIFF
--- a/server/matchmaker_process.go
+++ b/server/matchmaker_process.go
@@ -256,7 +256,7 @@ func (m *LocalMatchmaker) processDefault(activeIndexCount int, activeIndexesCopy
 					}
 					// Sort to ensure we keep as many of the longest-waiting tickets as possible.
 					sort.Slice(eligibleGroups, func(i, j int) bool {
-						return eligibleGroups[i].avgCreatedAt < eligibleGroups[j].avgCreatedAt
+						return eligibleGroups[i].avgCreatedAt > eligibleGroups[j].avgCreatedAt
 					})
 					// The most eligible group is removed from the combo.
 					for _, egIndex := range eligibleGroups[0].indexes {

--- a/server/matchmaker_test.go
+++ b/server/matchmaker_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -2353,6 +2354,74 @@ func TestMatchmakerMaxSessionTracking(t *testing.T) {
 	err = createTicketFunc(sessionID1)
 	if !errors.Is(err, runtime.ErrMatchmakerTooManyTickets) {
 		t.Fatalf("exected error too many tickets, got: %v", err)
+	}
+}
+
+func TestMatchmakerCountMultipleLongestWaitingPriority(t *testing.T) {
+	consoleLogger := loggerForTest(t)
+	matchesSeen := make(map[string]*rtapi.MatchmakerMatched)
+	matchMaker, cleanup, err := createTestMatchmaker(t, consoleLogger, false, func(presences []*PresenceID, envelope *rtapi.Envelope) {
+		if len(presences) == 1 {
+			matchesSeen[presences[0].SessionID.String()] = envelope.GetMatchmakerMatched()
+		}
+	})
+	if err != nil {
+		t.Fatalf("error creating test matchmaker: %v", err)
+	}
+	defer cleanup()
+
+	// Add 5 players with strictly ascending CreatedAt timestamps.
+	// Player 0 (initiator) + 4 candidate players (Player 1..4).
+	// MinCount=4, MaxCount=5, CountMultiple=2.
+	// Total players gathered = 5 (matches MaxCount).
+	// Remainder = 5 % 2 = 1 player must be removed to satisfy CountMultiple=2.
+	// Player 1 (oldest candidate) waited longest, Player 4 (newest candidate) just joined.
+	// We want to KEEP the longest-waiting players (Player 0, 1, 2, 3) and REMOVE the newest (Player 4).
+	sessionIDs := make([]uuid.UUID, 5)
+	for i := 0; i < 5; i++ {
+		sessionID, _ := uuid.NewV4()
+		sessionIDs[i] = sessionID
+		_, _, err := matchMaker.Add(context.Background(), []*MatchmakerPresence{
+			{
+				UserId:    fmt.Sprintf("user_%d", i),
+				SessionId: sessionID.String(),
+				Username:  fmt.Sprintf("user_%d", i),
+				Node:      "node",
+				SessionID: sessionID,
+			},
+		}, sessionID.String(), "", "*", 4, 5, 2, map[string]string{}, map[string]float64{})
+		if err != nil {
+			t.Fatalf("error adding ticket %d: %v", i, err)
+		}
+		time.Sleep(10 * time.Millisecond) // Ensure distinct CreatedAt timestamps
+	}
+
+	// Make Player 0 the sole activeIndex to deterministically test the eviction of foundCombo candidates
+	matchMaker.Lock()
+	for k, v := range matchMaker.activeIndexes {
+		if v.SessionID != sessionIDs[0].String() {
+			delete(matchMaker.activeIndexes, k)
+		}
+	}
+	matchMaker.Unlock()
+
+	matchMaker.Process()
+
+	// Assert exactly 4 players were matched
+	if len(matchesSeen) != 4 {
+		t.Fatalf("expected 4 matched presences, got %d", len(matchesSeen))
+	}
+
+	// Player 0 (initiator) + Player 1, 2, 3 (oldest candidates) MUST be matched
+	for i := 0; i < 4; i++ {
+		if _, ok := matchesSeen[sessionIDs[i].String()]; !ok {
+			t.Fatalf("expected player %d (session %s) to be matched, but was evicted", i, sessionIDs[i].String())
+		}
+	}
+
+	// Player 4 (newest candidate) MUST have been evicted (remains in queue)
+	if _, ok := matchesSeen[sessionIDs[4].String()]; ok {
+		t.Fatalf("expected newest player 4 (session %s) to be evicted, but was matched", sessionIDs[4].String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes an inverted sort comparison in `processDefault` when adjusting candidate match combinations to satisfy `CountMultiple`:

```go
// before
sort.Slice(eligibleGroups, func(i, j int) bool {
    return eligibleGroups[i].avgCreatedAt < eligibleGroups[j].avgCreatedAt
})
// after
sort.Slice(eligibleGroups, func(i, j int) bool {
    return eligibleGroups[i].avgCreatedAt > eligibleGroups[j].avgCreatedAt
})
```

## Context & Problem

When a candidate match group's player count does not divide evenly into `CountMultiple` (e.g. 5 players found for a 4-player 2v2 game with `CountMultiple = 2`), the matchmaker invokes `groupIndexes` to find candidate ticket combinations that sum to the excess remainder `rem = 1`.

The code explicitly notes its intention:
```go
// Sort to ensure we keep as many of the longest-waiting tickets as possible.
// The most eligible group is removed from the combo.
for _, egIndex := range eligibleGroups[0].indexes {
    // ... evicts egIndex from foundCombo ...
}
```

Because `CreatedAt` is an epoch timestamp where older tickets have smaller numerical values:
1. Sorting ascending (`<`) placed the **oldest** ticket group (smallest `avgCreatedAt`) at `eligibleGroups[0]`.
2. `eligibleGroups[0]` is then **evicted from the match room**.

As a result, the longest-waiting player was systematically removed from the match to accommodate newer arrivals.

Inverting the comparison to `>` places the newest ticket group (largest `avgCreatedAt`) at index `0` for eviction, ensuring the longest-waiting players remain in the match.

## Test

Adds `TestMatchmakerCountMultipleLongestWaitingPriority` in `server/matchmaker_test.go`:
- Creates 5 solo players with strictly ascending `CreatedAt` timestamps ($T_0 < T_1 < T_2 < T_3 < T_4$) requesting a 4-player match with `CountMultiple = 2`.
- Verifies that the formed 4-player match consists of the oldest candidates (Players 0, 1, 2, 3) and that the newest candidate (Player 4) is evicted.

**Red-Green Verification**:
- **Before Fix (`<`)**: Test consistently FAILS (Player 1 is evicted, Player 4 is matched).
- **After Fix (`>`)**: Test PASSES (Player 4 is evicted, Players 0..3 are matched).

## Verification

- `go build ./server/` — passes
- `go vet ./server/` — clean
- `golangci-lint run --new-from-rev=master ./server/` — 0 issues
- All 24 matchmaker tests in `server/matchmaker_test.go` pass