### PR TITLE
Remove unreachable matchmaker max-count checks

### DIFF
--- a/server/matchmaker_process.go
+++ b/server/matchmaker_process.go
@@ -147,11 +147,6 @@ func (m *LocalMatchmaker) processDefault(activeIndexCount int, activeIndexesCopy
 				}
 			}
 
-			if activeIndex.MaxCount < hitIndex.MaxCount && hitIndex.Intervals <= m.config.GetMatchmaker().MaxIntervals {
-				// This match would be less than the search hit's preferred max, and they can still wait. Let them wait more.
-				continue
-			}
-
 			// Check if there are overlapping session IDs, and if so these tickets are ineligible to match together.
 			var sessionIdConflict bool
 			for sessionID := range activeIndex.SessionIDs {
@@ -445,11 +440,6 @@ func (m *LocalMatchmaker) processOverride(activeIndexesCopy map[string]*Matchmak
 					// This search hit is not a mutual match with the outer ticket.
 					continue
 				}
-			}
-
-			if index.MaxCount < hitIndex.MaxCount && hitIndex.Intervals <= m.config.GetMatchmaker().MaxIntervals {
-				// This match would be less than the search hit's preferred max, and they can still wait. Let them wait more.
-				continue
 			}
 
 			// Check if there are overlapping session IDs, and if so these tickets are ineligible to match together.


### PR DESCRIPTION
## Summary

Removes two unreachable max-count preference checks from the built-in matchmaker:

- `processDefault`
- `processOverride`

No matching behavior is intentionally changed.

## Why

Both functions construct a mandatory Bluge range query before iterating search hits:

```go
maxCountRange := bluge.NewNumericRangeInclusiveQuery(
    math.Inf(-1), float64(activeIndex.MaxCount), true, true).
    SetField("max_count")
indexQuery.AddMust(maxCountRange)
```

`BooleanQuery.AddMust` requires every returned document to match this predicate. `max_count` is indexed directly from `MatchmakerIndex.MaxCount`. Therefore every `hitIndex` considered by `processDefault` satisfies:

```text
hitIndex.MaxCount <= activeIndex.MaxCount
```

The removed condition requires the mutually exclusive relationship:

```text
activeIndex.MaxCount < hitIndex.MaxCount
```

The equivalent contradiction exists in `processOverride`. Consequently, neither branch can execute for a normally indexed ticket.

## Question for Maintainers

The removed comment says a larger-capacity candidate should wait rather than be consumed by a smaller match. This makes sense if compatible ranges are intended to mean interval overlap:

```text
hit.MinCount <= active.MaxCount && hit.MaxCount >= active.MinCount
```

The pre-Bluge implementation used that overlap predicate. The current Bluge query instead requires candidate-range containment:

```text
hit.MinCount >= active.MinCount && hit.MaxCount <= active.MaxCount
```

I have intentionally not changed this behavior in this PR. Could maintainers confirm whether overlap was the original intended semantics? If so, restoring it should be evaluated separately, since it broadens the default matcher candidate set and needs dedicated behavior coverage.

## Verification

- `go test -mod=vendor ./server -run "^TestMatchmaker" -count=1`
- `go test -race -mod=vendor ./server -run "^TestMatchmaker" -count=1`
- `go build -trimpath -mod=vendor`
- `gofmt -w server/matchmaker_process.go`
- `git diff --check`

The repository-wide integration suite was not run locally because Docker is unavailable in this environment; CI uses `docker compose -f ./docker-compose-tests.yml up --build --abort-on-container-exit`.