### PR TITLE
Optimize matchmaker remainder selection (up to 1,770x faster)

### DIFF
--- a/server/matchmaker.go
+++ b/server/matchmaker.go
@@ -17,6 +17,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"sort"
 	"sync"
 	"time"
 
@@ -130,46 +132,112 @@ type MatchmakerExtract struct {
 	Node              string
 }
 
-type MatchmakerIndexGroup struct {
-	indexes      []*MatchmakerIndex
-	avgCreatedAt int64
+type matchmakerRemovalStateKey struct {
+	playerCount int
+	ticketCount int
 }
 
-func groupIndexes(indexes []*MatchmakerIndex, required int) []*MatchmakerIndexGroup {
+type matchmakerRemovalState struct {
+	createdAtTotal *big.Int
+	previous       *matchmakerRemovalState
+	index          *MatchmakerIndex
+}
+
+type matchmakerRemovalStateSnapshot struct {
+	key   matchmakerRemovalStateKey
+	state *matchmakerRemovalState
+}
+
+// selectIndexesToRemove returns the exact-size ticket group with the newest average creation time.
+func selectIndexesToRemove(indexes []*MatchmakerIndex, required int) []*MatchmakerIndex {
 	if len(indexes) == 0 || required <= 0 {
 		return nil
 	}
 
-	current, others := indexes[0], indexes[1:]
-
-	if current.Count > required {
-		// Current index is too large for the requirement, and cannot be used at all.
-		return groupIndexes(others, required)
+	eligibleIndexes := make([]*MatchmakerIndex, 0, len(indexes))
+	for _, index := range indexes {
+		if index.Count > 0 && index.Count <= required {
+			eligibleIndexes = append(eligibleIndexes, index)
+		}
 	}
+	if len(eligibleIndexes) == 0 {
+		return nil
+	}
+	// The input comes from a map, so order it to make equal-score selection deterministic.
+	sort.Slice(eligibleIndexes, func(i, j int) bool {
+		return eligibleIndexes[i].Ticket < eligibleIndexes[j].Ticket
+	})
 
-	var results []*MatchmakerIndexGroup
+	baseKey := matchmakerRemovalStateKey{}
+	// Keep the newest timestamp total for each removed-player and removed-ticket count pair.
+	states := map[matchmakerRemovalStateKey]*matchmakerRemovalState{
+		baseKey: {createdAtTotal: new(big.Int)},
+	}
+	stateKeys := []matchmakerRemovalStateKey{baseKey}
+	for _, index := range eligibleIndexes {
+		// Snapshot existing states so this index can be selected only once.
+		previousStates := make([]matchmakerRemovalStateSnapshot, len(stateKeys))
+		for i, key := range stateKeys {
+			previousStates[i] = matchmakerRemovalStateSnapshot{key: key, state: states[key]}
+		}
+		createdAt := big.NewInt(index.CreatedAt)
+		for _, previousState := range previousStates {
+			if index.Count > required-previousState.key.playerCount {
+				continue
+			}
+			playerCount := previousState.key.playerCount + index.Count
 
-	if current.Count == required {
-		// 1. The current index by itself satisfies the requirement. No need to combine with anything else.
-		results = append(results, &MatchmakerIndexGroup{
-			indexes:      []*MatchmakerIndex{current},
-			avgCreatedAt: current.CreatedAt,
-		})
-	} else if current.Count < required {
-		// 2. The current index plus some combination(s) of the others.
-		fillResults := groupIndexes(others, required-current.Count)
-		for _, fillResult := range fillResults {
-			indexesCount := int64(len(fillResult.indexes))
-			fillResult.avgCreatedAt = (fillResult.avgCreatedAt*indexesCount + current.CreatedAt) / (indexesCount + 1)
-			fillResult.indexes = append(fillResult.indexes, current)
-			results = append(results, fillResult)
+			key := matchmakerRemovalStateKey{
+				playerCount: playerCount,
+				ticketCount: previousState.key.ticketCount + 1,
+			}
+			createdAtTotal := new(big.Int).Add(previousState.state.createdAtTotal, createdAt)
+			current, ok := states[key]
+			// For an equal player and ticket count, a newer timestamp total dominates.
+			if ok && createdAtTotal.Cmp(current.createdAtTotal) <= 0 {
+				continue
+			}
+
+			states[key] = &matchmakerRemovalState{
+				createdAtTotal: createdAtTotal,
+				previous:       previousState.state,
+				index:          index,
+			}
+			if !ok {
+				stateKeys = append(stateKeys, key)
+			}
 		}
 	}
 
-	// 3. Other combinations not including the current index.
-	results = append(results, groupIndexes(others, required)...)
+	var best *matchmakerRemovalState
+	var bestTicketCount int
+	for _, key := range stateKeys {
+		if key.playerCount != required || key.ticketCount == 0 {
+			continue
+		}
 
-	return results
+		candidate := states[key]
+		if best == nil || hasNewerAverageCreatedAt(candidate, key.ticketCount, best, bestTicketCount) {
+			best = candidate
+			bestTicketCount = key.ticketCount
+		}
+	}
+	if best == nil {
+		return nil
+	}
+
+	indexesToRemove := make([]*MatchmakerIndex, 0, bestTicketCount)
+	for state := best; state.index != nil; state = state.previous {
+		indexesToRemove = append(indexesToRemove, state.index)
+	}
+	return indexesToRemove
+}
+
+func hasNewerAverageCreatedAt(candidate *matchmakerRemovalState, candidateTicketCount int, current *matchmakerRemovalState, currentTicketCount int) bool {
+	var candidateProduct, currentProduct big.Int
+	candidateProduct.Mul(candidate.createdAtTotal, big.NewInt(int64(currentTicketCount)))
+	currentProduct.Mul(current.createdAtTotal, big.NewInt(int64(candidateTicketCount)))
+	return candidateProduct.Cmp(&currentProduct) > 0
 }
 
 type Matchmaker interface {

--- a/server/matchmaker_benchmark_test.go
+++ b/server/matchmaker_benchmark_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"testing"
+)
+
+const legacyRemovalBenchmarkGroupLimit = 200_000
+
+var benchmarkRemovalIndexes []*MatchmakerIndex
+
+func BenchmarkMatchmakerRemainderSelection(b *testing.B) {
+	for _, partyCount := range []int{10, 50, 100, 200} {
+		for _, rem := range []int{2, 3, 5, 10} {
+			indexes := benchmarkRemovalIndexesForSoloTickets(partyCount)
+			name := fmt.Sprintf("parties=%d/rem=%d", partyCount, rem)
+
+			b.Run("dynamic/"+name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					benchmarkRemovalIndexes = selectIndexesToRemove(indexes, rem)
+				}
+			})
+
+			b.Run("legacy/"+name, func(b *testing.B) {
+				groupCount := benchmarkBinomial(partyCount, rem)
+				if groupCount.Cmp(big.NewInt(legacyRemovalBenchmarkGroupLimit)) > 0 {
+					b.Skipf("would materialize %s groups; benchmark limit is %d", groupCount, legacyRemovalBenchmarkGroupLimit)
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					benchmarkRemovalIndexes = legacySelectIndexesToRemove(indexes, rem)
+				}
+			})
+		}
+	}
+}
+
+func benchmarkRemovalIndexesForSoloTickets(partyCount int) []*MatchmakerIndex {
+	indexes := make([]*MatchmakerIndex, partyCount)
+	for i := range indexes {
+		indexes[i] = &MatchmakerIndex{
+			Ticket:    fmt.Sprintf("ticket-%04d", i),
+			Count:     1,
+			CreatedAt: int64(i),
+		}
+	}
+	return indexes
+}
+
+func benchmarkBinomial(n, k int) *big.Int {
+	if k < 0 || k > n {
+		return new(big.Int)
+	}
+	if k > n-k {
+		k = n - k
+	}
+
+	result := big.NewInt(1)
+	for i := 1; i <= k; i++ {
+		result.Mul(result, big.NewInt(int64(n-k+i)))
+		result.Quo(result, big.NewInt(int64(i)))
+	}
+	return result
+}
+
+type legacyMatchmakerIndexGroup struct {
+	indexes      []*MatchmakerIndex
+	avgCreatedAt int64
+}
+
+func legacySelectIndexesToRemove(indexes []*MatchmakerIndex, required int) []*MatchmakerIndex {
+	groups := legacyGroupIndexes(indexes, required)
+	if len(groups) == 0 {
+		return nil
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].avgCreatedAt > groups[j].avgCreatedAt
+	})
+	return groups[0].indexes
+}
+
+func legacyGroupIndexes(indexes []*MatchmakerIndex, required int) []*legacyMatchmakerIndexGroup {
+	if len(indexes) == 0 || required <= 0 {
+		return nil
+	}
+
+	current, others := indexes[0], indexes[1:]
+	if current.Count > required {
+		return legacyGroupIndexes(others, required)
+	}
+
+	var results []*legacyMatchmakerIndexGroup
+	if current.Count == required {
+		results = append(results, &legacyMatchmakerIndexGroup{
+			indexes:      []*MatchmakerIndex{current},
+			avgCreatedAt: current.CreatedAt,
+		})
+	} else {
+		fillResults := legacyGroupIndexes(others, required-current.Count)
+		for _, fillResult := range fillResults {
+			indexesCount := int64(len(fillResult.indexes))
+			fillResult.avgCreatedAt = (fillResult.avgCreatedAt*indexesCount + current.CreatedAt) / (indexesCount + 1)
+			fillResult.indexes = append(fillResult.indexes, current)
+			results = append(results, fillResult)
+		}
+	}
+
+	return append(results, legacyGroupIndexes(others, required)...)
+}

--- a/server/matchmaker_process.go
+++ b/server/matchmaker_process.go
@@ -17,7 +17,6 @@ package server
 import (
 	"math"
 	"math/bits"
-	"sort"
 	"time"
 
 	"github.com/blugelabs/bluge"
@@ -249,17 +248,13 @@ func (m *LocalMatchmaker) processDefault(activeIndexCount int, activeIndexesCopy
 						eligibleIndexes = append(eligibleIndexes, idx)
 					}
 
-					eligibleGroups := groupIndexes(eligibleIndexes, rem)
-					if len(eligibleGroups) <= 0 {
+					indexesToRemove := selectIndexesToRemove(eligibleIndexes, rem)
+					if len(indexesToRemove) <= 0 {
 						// No possible combination to remove, unlikely but guard.
 						continue
 					}
-					// Sort to ensure we keep as many of the longest-waiting tickets as possible.
-					sort.Slice(eligibleGroups, func(i, j int) bool {
-						return eligibleGroups[i].avgCreatedAt > eligibleGroups[j].avgCreatedAt
-					})
-					// The most eligible group is removed from the combo.
-					for _, egIndex := range eligibleGroups[0].indexes {
+					// The newest exact-size group is removed to keep the longest-waiting tickets in the match.
+					for _, egIndex := range indexesToRemove {
 						for i := 0; i < len(foundCombo); i++ {
 							if egIndex.Ticket == foundCombo[i].Ticket {
 								foundCombo[i] = foundCombo[len(foundCombo)-1]

--- a/server/matchmaker_process.go
+++ b/server/matchmaker_process.go
@@ -256,7 +256,7 @@ func (m *LocalMatchmaker) processDefault(activeIndexCount int, activeIndexesCopy
 					}
 					// Sort to ensure we keep as many of the longest-waiting tickets as possible.
 					sort.Slice(eligibleGroups, func(i, j int) bool {
-						return eligibleGroups[i].avgCreatedAt < eligibleGroups[j].avgCreatedAt
+						return eligibleGroups[i].avgCreatedAt > eligibleGroups[j].avgCreatedAt
 					})
 					// The most eligible group is removed from the combo.
 					for _, egIndex := range eligibleGroups[0].indexes {

--- a/server/matchmaker_test.go
+++ b/server/matchmaker_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -2353,6 +2354,74 @@ func TestMatchmakerMaxSessionTracking(t *testing.T) {
 	err = createTicketFunc(sessionID1)
 	if !errors.Is(err, runtime.ErrMatchmakerTooManyTickets) {
 		t.Fatalf("exected error too many tickets, got: %v", err)
+	}
+}
+
+func TestMatchmakerCountMultipleLongestWaitingPriority(t *testing.T) {
+	consoleLogger := loggerForTest(t)
+	matchesSeen := make(map[string]*rtapi.MatchmakerMatched)
+	matchMaker, cleanup, err := createTestMatchmaker(t, consoleLogger, false, func(presences []*PresenceID, envelope *rtapi.Envelope) {
+		if len(presences) == 1 {
+			matchesSeen[presences[0].SessionID.String()] = envelope.GetMatchmakerMatched()
+		}
+	})
+	if err != nil {
+		t.Fatalf("error creating test matchmaker: %v", err)
+	}
+	defer cleanup()
+
+	// Add 5 players with strictly ascending CreatedAt timestamps.
+	// Player 0 (initiator) + 4 candidate players (Player 1..4).
+	// MinCount=4, MaxCount=5, CountMultiple=2.
+	// Total players gathered = 5 (matches MaxCount).
+	// Remainder = 5 % 2 = 1 player must be removed to satisfy CountMultiple=2.
+	// Player 1 (oldest candidate) waited longest, Player 4 (newest candidate) just joined.
+	// We want to KEEP the longest-waiting players (Player 0, 1, 2, 3) and REMOVE the newest (Player 4).
+	sessionIDs := make([]uuid.UUID, 5)
+	for i := 0; i < 5; i++ {
+		sessionID, _ := uuid.NewV4()
+		sessionIDs[i] = sessionID
+		_, _, err := matchMaker.Add(context.Background(), []*MatchmakerPresence{
+			{
+				UserId:    fmt.Sprintf("user_%d", i),
+				SessionId: sessionID.String(),
+				Username:  fmt.Sprintf("user_%d", i),
+				Node:      "node",
+				SessionID: sessionID,
+			},
+		}, sessionID.String(), "", "*", 4, 5, 2, map[string]string{}, map[string]float64{})
+		if err != nil {
+			t.Fatalf("error adding ticket %d: %v", i, err)
+		}
+		time.Sleep(10 * time.Millisecond) // Ensure distinct CreatedAt timestamps
+	}
+
+	// Make Player 0 the sole activeIndex to deterministically test the eviction of foundCombo candidates
+	matchMaker.Lock()
+	for k, v := range matchMaker.activeIndexes {
+		if v.SessionID != sessionIDs[0].String() {
+			delete(matchMaker.activeIndexes, k)
+		}
+	}
+	matchMaker.Unlock()
+
+	matchMaker.Process()
+
+	// Assert exactly 4 players were matched
+	if len(matchesSeen) != 4 {
+		t.Fatalf("expected 4 matched presences, got %d", len(matchesSeen))
+	}
+
+	// Player 0 (initiator) + Player 1, 2, 3 (oldest candidates) MUST be matched
+	for i := 0; i < 4; i++ {
+		if _, ok := matchesSeen[sessionIDs[i].String()]; !ok {
+			t.Fatalf("expected player %d (session %s) to be matched, but was evicted", i, sessionIDs[i].String())
+		}
+	}
+
+	// Player 4 (newest candidate) MUST have been evicted (remains in queue)
+	if _, ok := matchesSeen[sessionIDs[4].String()]; ok {
+		t.Fatalf("expected newest player 4 (session %s) to be evicted, but was matched", sessionIDs[4].String())
 	}
 }
 

--- a/server/matchmaker_test.go
+++ b/server/matchmaker_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"os"
 	"testing"
 	"time"
@@ -1593,25 +1594,191 @@ func TestMatchmakerAddAndMatchAuthoritative(t *testing.T) {
 	}
 }
 
-func TestGroupIndexes(t *testing.T) {
-	a := &MatchmakerIndex{Ticket: "a", Count: 1, CreatedAt: 100}
-	b := &MatchmakerIndex{Ticket: "b", Count: 2, CreatedAt: 110}
-	c := &MatchmakerIndex{Ticket: "c", Count: 1, CreatedAt: 120}
-	d := &MatchmakerIndex{Ticket: "d", Count: 1, CreatedAt: 130}
-	e := &MatchmakerIndex{Ticket: "e", Count: 3, CreatedAt: 140}
-	f := &MatchmakerIndex{Ticket: "f", Count: 2, CreatedAt: 150}
-	indexes := []*MatchmakerIndex{a, b, c, d, e, f}
-	required := 2
+func TestSelectIndexesToRemove(t *testing.T) {
+	tests := []struct {
+		name     string
+		indexes  []*MatchmakerIndex
+		required int
+		expected []string
+	}{
+		{
+			name: "selects the newest per-party average",
+			indexes: []*MatchmakerIndex{
+				{Ticket: "old-party", Count: 2, CreatedAt: 100},
+				{Ticket: "new-solo-1", Count: 1, CreatedAt: 250},
+				{Ticket: "new-solo-2", Count: 1, CreatedAt: 250},
+				{Ticket: "middle-party", Count: 3, CreatedAt: 160},
+			},
+			required: 3,
+			expected: []string{"old-party", "new-solo-1"},
+		},
+		{
+			name: "compares fractional averages exactly",
+			indexes: []*MatchmakerIndex{
+				{Ticket: "party", Count: 2, CreatedAt: 100},
+				{Ticket: "solo-1", Count: 1, CreatedAt: 100},
+				{Ticket: "solo-2", Count: 1, CreatedAt: 101},
+			},
+			required: 2,
+			expected: []string{"solo-1", "solo-2"},
+		},
+		{
+			name: "does not overflow timestamp totals",
+			indexes: []*MatchmakerIndex{
+				{Ticket: "party", Count: 2, CreatedAt: math.MaxInt64 - 2},
+				{Ticket: "solo-1", Count: 1, CreatedAt: math.MaxInt64 - 1},
+				{Ticket: "solo-2", Count: 1, CreatedAt: math.MaxInt64 - 1},
+			},
+			required: 2,
+			expected: []string{"solo-1", "solo-2"},
+		},
+		{
+			name: "breaks equal averages deterministically",
+			indexes: []*MatchmakerIndex{
+				{Ticket: "c", Count: 1, CreatedAt: 100},
+				{Ticket: "b", Count: 1, CreatedAt: 100},
+				{Ticket: "a", Count: 1, CreatedAt: 100},
+			},
+			required: 2,
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "does not reuse an index",
+			indexes: []*MatchmakerIndex{
+				{Ticket: "solo", Count: 1, CreatedAt: 100},
+			},
+			required: 2,
+		},
+		{
+			name: "requires an exact player count",
+			indexes: []*MatchmakerIndex{
+				{Ticket: "party", Count: 2, CreatedAt: 100},
+			},
+			required: 3,
+		},
+	}
 
-	groups := groupIndexes(indexes, required)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected := selectIndexesToRemove(tt.indexes, tt.required)
+			if tt.expected == nil {
+				assert.Nil(t, selected)
+				return
+			}
 
-	assert.EqualValues(t, []*MatchmakerIndexGroup{
-		{indexes: []*MatchmakerIndex{c, a}, avgCreatedAt: 110},
-		{indexes: []*MatchmakerIndex{d, a}, avgCreatedAt: 115},
-		{indexes: []*MatchmakerIndex{b}, avgCreatedAt: 110},
-		{indexes: []*MatchmakerIndex{d, c}, avgCreatedAt: 125},
-		{indexes: []*MatchmakerIndex{f}, avgCreatedAt: 150},
-	}, groups, "groups did not match")
+			selectedTickets := make([]string, 0, len(selected))
+			selectedCount := 0
+			for _, index := range selected {
+				selectedTickets = append(selectedTickets, index.Ticket)
+				selectedCount += index.Count
+			}
+			assert.Equal(t, tt.required, selectedCount)
+			assert.ElementsMatch(t, tt.expected, selectedTickets)
+		})
+	}
+}
+
+func TestSelectIndexesToRemoveHandlesLargeCandidatePool(t *testing.T) {
+	indexes := make([]*MatchmakerIndex, 1_000)
+	for i := range indexes {
+		indexes[i] = &MatchmakerIndex{
+			Ticket:    fmt.Sprintf("ticket-%04d", i),
+			Count:     1,
+			CreatedAt: int64(i),
+		}
+	}
+
+	selected := selectIndexesToRemove(indexes, 5)
+	assert.ElementsMatch(t, []string{"ticket-0995", "ticket-0996", "ticket-0997", "ticket-0998", "ticket-0999"}, removalGroupTickets(selected))
+}
+
+func TestSelectIndexesToRemoveMatchesExhaustiveSearch(t *testing.T) {
+	for candidateCount := 1; candidateCount <= 8; candidateCount++ {
+		for seed := 0; seed < 100; seed++ {
+			indexes := make([]*MatchmakerIndex, candidateCount)
+			for i := range indexes {
+				indexes[i] = &MatchmakerIndex{
+					Ticket:    fmt.Sprintf("ticket-%d", i),
+					Count:     1 + (seed+i)%3,
+					CreatedAt: int64(100 + (seed*17+i*31)%101),
+				}
+			}
+			required := 1 + seed%6
+
+			selected := selectIndexesToRemove(indexes, required)
+			expected := selectIndexesToRemoveExhaustively(indexes, required)
+			assert.Equal(t, removalGroupPlayerCount(expected), removalGroupPlayerCount(selected), "candidate count %d, seed %d", candidateCount, seed)
+			assert.Equal(t, removalGroupAverage(expected), removalGroupAverage(selected), "candidate count %d, seed %d", candidateCount, seed)
+		}
+	}
+}
+
+func selectIndexesToRemoveExhaustively(indexes []*MatchmakerIndex, required int) []*MatchmakerIndex {
+	var best []*MatchmakerIndex
+	for bits := 1; bits < 1<<len(indexes); bits++ {
+		playerCount := 0
+		candidate := make([]*MatchmakerIndex, 0, len(indexes))
+		for i, index := range indexes {
+			if bits&(1<<i) == 0 {
+				continue
+			}
+			playerCount += index.Count
+			candidate = append(candidate, index)
+		}
+		if playerCount != required || !hasNewerAverageCreatedAtForTest(candidate, best) {
+			continue
+		}
+		best = candidate
+	}
+	return best
+}
+
+func hasNewerAverageCreatedAtForTest(candidate, current []*MatchmakerIndex) bool {
+	if len(candidate) == 0 {
+		return false
+	}
+	if len(current) == 0 {
+		return true
+	}
+
+	var candidateTotal, currentTotal, candidateProduct, currentProduct big.Int
+	for _, index := range candidate {
+		candidateTotal.Add(&candidateTotal, big.NewInt(index.CreatedAt))
+	}
+	for _, index := range current {
+		currentTotal.Add(&currentTotal, big.NewInt(index.CreatedAt))
+	}
+	candidateProduct.Mul(&candidateTotal, big.NewInt(int64(len(current))))
+	currentProduct.Mul(&currentTotal, big.NewInt(int64(len(candidate))))
+	return candidateProduct.Cmp(&currentProduct) > 0
+}
+
+func removalGroupPlayerCount(indexes []*MatchmakerIndex) int {
+	var playerCount int
+	for _, index := range indexes {
+		playerCount += index.Count
+	}
+	return playerCount
+}
+
+func removalGroupTickets(indexes []*MatchmakerIndex) []string {
+	tickets := make([]string, 0, len(indexes))
+	for _, index := range indexes {
+		tickets = append(tickets, index.Ticket)
+	}
+	return tickets
+}
+
+func removalGroupAverage(indexes []*MatchmakerIndex) string {
+	if len(indexes) == 0 {
+		return ""
+	}
+
+	var total big.Int
+	for _, index := range indexes {
+		total.Add(&total, big.NewInt(index.CreatedAt))
+	}
+	return new(big.Rat).SetFrac(&total, big.NewInt(int64(len(indexes)))).RatString()
 }
 
 // createTestMatchmaker creates a minimally configured LocalMatchmaker for testing purposes


### PR DESCRIPTION
## Summary

Depends on #2544, which establishes that the newest eligible removal group should be evicted to preserve the longest-waiting tickets.

This PR replaces `groupIndexes`, which materializes every exact-size removal combination, with a sparse 0/1 dynamic-programming selector that returns only the best removal group.

## Why

When a provisional default-match combination does not satisfy `count_multiple`, `processDefault` must remove whole tickets/parties whose player counts add up exactly to the remainder:

```text
rem = proposedMatchSize % activeTicket.CountMultiple
```

The existing `groupIndexes` implementation recursively builds and stores **every** exact-sum ticket group, sorts all of them, then uses only `eligibleGroups[0]`. This is combinatorial: for all-solo candidate tickets, it materializes `C(parties, rem)` groups.

This work occurs inside `processDefault` while it evaluates active tickets and their candidate hits. The benchmark below measures **one removal-selection action only**, not a whole matchmaking pass. A busy `Process()` pass can perform this selection repeatedly for different active tickets and candidate combinations whenever a nonzero remainder is encountered, so the per-selection time and allocation cost compounds.

Examples from the benchmark:

- At 100 singleton parties and `rem=3`, legacy selection takes **44.44 ms**, allocates **125.2 MB**, and creates about **1,000,365 allocations** for a single selection. The DP takes **25.10 us** and **37.4 KB**.
- At 200 singleton parties and `rem=2`, legacy selection takes **6.67 ms** and **24.2 MB** for one selection. The DP takes **34.52 us** and **51.4 KB**.
- At 50 singleton parties and `rem=5`, the legacy algorithm would materialize **2,118,760** groups; the benchmark skips it above a 200,000-group safety limit.

## Solution

The selector keeps tickets/parties atomic and finds one group whose `Count` values sum exactly to `rem`. It retains the best state for each:

```text
(removed player count, removed ticket/party count)
```

The best state has the greatest total `CreatedAt`. At `rem`, candidates are compared by their exact per-ticket/per-party arithmetic mean:

```text
sum(CreatedAt) / ticketCount
```

The selected group is removed, so choosing the greatest mean removes the newest group on average and preserves the longest-waiting tickets. This retains #2544's intended policy while defining the average exactly rather than relying on order-dependent integer truncation.

`big.Int` is used for timestamp totals and cross-multiplied mean comparisons, avoiding overflow from Unix-nanosecond timestamps and preserving fractional mean ordering. Ticket IDs are sorted before selection so equal-score outcomes are deterministic.

## Complexity

```text
Legacy: recursive enumeration and storage of every exact-sum group; exponential in eligible tickets.
DP:     O(n * rem * min(n, rem)) worst-case transitions; one current best state per reachable (playerCount, ticketCount) key.
```

`n` is the number of eligible tickets and `rem` is the required removal player count. The DP does not materialize all exact-sum subsets.

## Benchmarks

Command:

```shell
go test -mod=vendor ./server -run "^$" -bench "^BenchmarkMatchmakerRemainderSelection$" -benchmem -benchtime=1s -count=1
```

Environment: macOS/Darwin arm64, Apple M4, Go 1.26.5. Each case uses the same all-solo-ticket input with ascending creation timestamps. A solo ticket is a one-player party; this workload maximizes the number of exact-sum groups and isolates the selector. `legacy` is skipped when it would materialize more than 200,000 groups.

| Candidate parties | rem | DP | Legacy | Result |
| ---: | ---: | ---: | ---: | --- |
| 10 | 2 | 1.92 us, 2.5 KB | 5.38 us, 6.5 KB | 2.8x faster |
| 10 | 3 | 2.57 us, 3.5 KB | 15.87 us, 24.6 KB | 6.2x faster |
| 10 | 5 | 3.48 us, 5.2 KB | 52.48 us, 79.2 KB | 15.1x faster |
| 10 | 10 | 8.33 us, 7.8 KB | 4.29 us, 384 B | Legacy faster: one exact subset |
| 50 | 2 | 9.10 us, 12.8 KB | 188.61 us, 455 KB | 20.7x faster |
| 50 | 3 | 13.02 us, 18.5 KB | 3.63 ms, 9.0 MB | 279x faster |
| 50 | 5 | 19.76 us, 30.5 KB | skipped | 2,118,760 legacy groups |
| 50 | 10 | 36.91 us, 59.7 KB | skipped | 10,272,278,170 legacy groups |
| 100 | 2 | 18.12 us, 25.7 KB | 1.03 ms, 3.25 MB | 56.6x faster |
| 100 | 3 | 25.10 us, 37.4 KB | 44.44 ms, 125.2 MB | 1,770x faster |
| 100 | 5 | 40.62 us, 62.2 KB | skipped | 75,287,520 legacy groups |
| 100 | 10 | 76.08 us, 124.5 KB | skipped | 17,310,309,456,440 legacy groups |
| 200 | 2 | 34.52 us, 51.4 KB | 6.67 ms, 24.2 MB | 193x faster |
| 200 | 3 | 51.32 us, 75.1 KB | skipped | 1,313,400 legacy groups |
| 200 | 5 | 83.07 us, 125.5 KB | skipped | 2,535,650,040 legacy groups |
| 200 | 10 | 157.79 us, 254.2 KB | skipped | 22,451,004,309,013,280 legacy groups |


**The benchmark measures one removal-selection action only, not the whole matchmaking pass. A single `Process()` pass could perform this action dozens, even hundreds of times.**

## Correctness Verification

The DP result has been verified against the agreed selector contract: choose whole tickets whose counts sum exactly to `rem`, then choose the group with the newest exact per-ticket/per-party average `CreatedAt`.

- Table-driven tests cover exact size, party-vs-solo selection, fractional averages, `int64` timestamp-overflow cases, deterministic ties, no ticket reuse, and no-solution cases.
- `TestSelectIndexesToRemoveMatchesExhaustiveSearch` compares DP output with an independent exhaustive subset enumerator across 800 deterministic small inputs: 1 through 8 candidates and 100 count/timestamp patterns each. It asserts the same exact removal count and rational average; equal-score ticket sets are intentionally allowed to differ.
- `TestSelectIndexesToRemoveHandlesLargeCandidatePool` validates a 1,000-ticket pool.
- The existing end-to-end `TestMatchmakerCountMultipleLongestWaitingPriority` confirms the selected group is removed from a real matchmaker combination and older tickets remain matched.

## Verification

- `go test -mod=vendor ./server -run "^TestMatchmaker" -count=1`
- Selector/FIFO tests repeated 50 times
- Selector/FIFO tests under `-race`, repeated 20 times
- `go build -trimpath -mod=vendor`
- `git diff --check`
- Benchmark command above

The full `go test ./server` suite was attempted but requires CockroachDB at `127.0.0.1:26257`; Docker is unavailable in this environment. `go vet ./server` reports a pre-existing context-cancel diagnostic in `server/shutdown.go:36`, outside this change.