### PR TITLE
fix: use valid WWW-Authenticate header for REST 401 responses

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -172,6 +172,7 @@ func StartApiServer(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, p
 	// Should start after GRPC server itself because RegisterNakamaHandlerFromEndpoint below tries to dial GRPC.
 	ctx := context.Background()
 	grpcGateway := grpcgw.NewServeMux(
+		grpcgw.WithErrorHandler(handleHTTPError),
 		grpcgw.WithRoutingErrorHandler(handleRoutingError),
 		grpcgw.WithMetadata(func(ctx context.Context, r *http.Request) metadata.MD {
 			// For RPC GET operations pass through any custom query parameters.
@@ -825,5 +826,21 @@ func handleRoutingError(ctx context.Context, mux *grpcgw.ServeMux, marshaler grp
 	}
 
 	// Set empty ServerMetadata to prevent logging error on nil metadata.
-	grpcgw.DefaultHTTPErrorHandler(grpcgw.NewServerMetadataContext(ctx, grpcgw.ServerMetadata{}), mux, marshaler, w, r, sterr)
+	handleHTTPError(grpcgw.NewServerMetadataContext(ctx, grpcgw.ServerMetadata{}), mux, marshaler, w, r, sterr)
+}
+
+func handleHTTPError(ctx context.Context, mux *grpcgw.ServeMux, marshaler grpcgw.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
+	grpcgw.DefaultHTTPErrorHandler(ctx, mux, marshaler, &wwwAuthenticateFixWriter{ResponseWriter: w}, r, err)
+}
+
+type wwwAuthenticateFixWriter struct {
+	http.ResponseWriter
+}
+
+func (w *wwwAuthenticateFixWriter) WriteHeader(statusCode int) {
+	if statusCode == http.StatusUnauthorized {
+		w.ResponseWriter.Header().Del("WWW-Authenticate")
+		w.ResponseWriter.Header().Set("WWW-Authenticate", `Bearer realm="nakama"`)
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -33,12 +35,15 @@ import (
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/apigrpc"
+	grpcgw "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -288,4 +293,33 @@ func UserIDFromSession(session *api.Session) (uuid.UUID, error) {
 	}
 
 	return uuid.FromString(data["uid"].(string))
+}
+
+func TestWWWAuthenticateHeaderOnUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	mux := grpcgw.NewServeMux()
+	marshaler := &grpcgw.JSONPb{}
+	req := httptest.NewRequest(http.MethodPost, "/v2/session/logout", nil)
+	rec := httptest.NewRecorder()
+
+	err := status.Error(codes.Unauthenticated, "Auth token required")
+	handleHTTPError(context.Background(), mux, marshaler, rec, req, err)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	auth := rec.Header().Get("WWW-Authenticate")
+	if auth == "Auth token required" {
+		t.Fatal("WWW-Authenticate must not contain the raw gRPC error message")
+	}
+	if auth != `Bearer realm="nakama"` {
+		t.Fatalf("expected Bearer realm header, got %q", auth)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Auth token required") {
+		t.Fatalf("expected JSON error body to contain message, got %q", body)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #1264

When the REST API returns 401 Unauthenticated, grpc-gateway's default error handler sets `WWW-Authenticate` to the raw gRPC error message (e.g. `Auth token required`), which is not a valid challenge per RFC 7235 / RFC 6750. Some HTTP clients (e.g. Dart HttpClient) fail to parse the response.

This PR registers a custom grpc-gateway error handler that replaces the invalid header with `Bearer realm="nakama"` on 401 responses.

## Changes

- Add `handleHTTPError` and `wwwAuthenticateFixWriter` in `server/api.go`
- Wire `grpcgw.WithErrorHandler(handleHTTPError)` on the API gateway
- Route `handleRoutingError` through the same handler for consistency

## Test plan

- [x] `go test ./server/ -run TestWWWAuthenticateHeaderOnUnauthenticated -v` passes locally
- [x] `go build -trimpath -mod=vendor` passes locally
- [ ] CI integration tests (docker-compose-tests)
