### PR TITLE
fix: validate WebSocket sessions with token ID on connect

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -231,9 +231,10 @@ func NewAPIServer(t *testing.T, runtime *Runtime) (*ApiServer, *Pipeline) {
 	router := &DummyMessageRouter{}
 	sessionCache := NewLocalSessionCache(3_600, 7_200)
 	sessionRegistry := NewLocalSessionRegistry(metrics)
+	statusRegistry := NewLocalStatusRegistry(logger, cfg, sessionRegistry, protojsonMarshaler)
 	tracker := &LocalTracker{sessionRegistry: sessionRegistry}
-	pipeline := NewPipeline(logger, cfg, db, protojsonMarshaler, protojsonUnmarshaler, sessionRegistry, nil, nil, nil, nil, tracker, router, runtime, metrics)
-	apiServer := StartApiServer(logger, logger, db, protojsonMarshaler, protojsonUnmarshaler, cfg, "3.0.0", nil, storageIdx, nil, nil, sessionRegistry, sessionCache, nil, nil, nil, nil, tracker, router, nil, metrics, pipeline, runtime)
+	pipeline := NewPipeline(logger, cfg, db, protojsonMarshaler, protojsonUnmarshaler, sessionRegistry, statusRegistry, nil, nil, nil, tracker, router, runtime, metrics)
+	apiServer := StartApiServer(logger, logger, db, protojsonMarshaler, protojsonUnmarshaler, cfg, "3.0.0", nil, storageIdx, nil, nil, sessionRegistry, sessionCache, statusRegistry, nil, nil, nil, tracker, router, nil, metrics, pipeline, runtime)
 
 	WaitForSocket(nil, cfg)
 	return apiServer, pipeline

--- a/server/socket_ws.go
+++ b/server/socket_ws.go
@@ -73,7 +73,7 @@ func NewSocketWsAcceptor(logger *zap.Logger, config Config, sessionRegistry Sess
 			return
 		}
 		userID, username, vars, expiry, tokenId, issuedAt, ok := parseToken([]byte(config.GetSession().EncryptionKey), token)
-		if !ok || !sessionCache.IsValidSession(userID, expiry, token) {
+		if !ok || !sessionCache.IsValidSession(userID, expiry, tokenId) {
 			http.Error(w, "Missing or invalid token", http.StatusUnauthorized)
 			return
 		}

--- a/server/socket_ws_test.go
+++ b/server/socket_ws_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The Nakama Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/gorilla/websocket"
+	"github.com/heroiclabs/nakama-common/api"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// End-to-end: after single-session logout, WebSocket must reject the same JWT using tokenId
+// blacklist semantics (see issue #2506). Requires Postgres (TEST_DB_URL or default local nakama DB).
+func TestWebSocketRejectsSessionAfterLogout(t *testing.T) {
+	runtime, _, err := runtimeWithModules(t, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	apiServer, _ := NewAPIServer(t, runtime)
+	defer apiServer.Stop()
+
+	conn, client, session, ctx := NewAuthenticatedAPIClient(t, uuid.Must(uuid.NewV4()).String())
+	defer conn.Close()
+
+	wsConn, resp, err := dialGameWebSocket(session.Token, "")
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("expected websocket upgrade before logout, got status %d: %v", resp.StatusCode, err)
+		}
+		t.Fatalf("expected websocket upgrade before logout: %v", err)
+	}
+	wsConn.Close()
+
+	_, err = client.SessionLogout(ctx, &api.SessionLogoutRequest{
+		Token: session.Token,
+	})
+	if err != nil {
+		t.Fatalf("session logout failed: %v", err)
+	}
+
+	_, err = client.GetAccount(ctx, &emptypb.Empty{})
+	if err == nil {
+		t.Fatal("expected GetAccount to fail after session logout")
+	}
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated from GetAccount, got %v", err)
+	}
+
+	_, resp, err = dialGameWebSocket(session.Token, "")
+	if err == nil {
+		t.Fatal("expected websocket dial to fail after session logout")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		if resp != nil {
+			t.Fatalf("expected websocket HTTP 401 after logout, got status %d: %v", resp.StatusCode, err)
+		}
+		t.Fatalf("expected websocket HTTP 401 response after logout: %v", err)
+	}
+
+	// Query-string token auth must follow the same session cache rules.
+	_, resp, err = dialGameWebSocket("", session.Token)
+	if err == nil {
+		t.Fatal("expected websocket dial with query token to fail after session logout")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		if resp != nil {
+			t.Fatalf("expected query-token websocket HTTP 401, got status %d: %v", resp.StatusCode, err)
+		}
+		t.Fatalf("expected query-token websocket HTTP 401: %v", err)
+	}
+}
+
+func dialGameWebSocket(bearerToken, queryToken string) (*websocket.Conn, *http.Response, error) {
+	wsURL := fmt.Sprintf("ws://127.0.0.1:%d/ws", cfg.GetSocket().Port)
+	if queryToken != "" {
+		wsURL = fmt.Sprintf("%s?token=%s", wsURL, url.QueryEscape(queryToken))
+	}
+
+	header := http.Header{}
+	if bearerToken != "" {
+		header.Set("Authorization", "Bearer "+bearerToken)
+	}
+
+	return websocket.DefaultDialer.Dial(wsURL, header)
+}


### PR DESCRIPTION
## Summary
- WebSocket acceptor now passes JWT `tokenId` (not the full bearer string) to `IsValidSession`, aligning with HTTP/gRPC and fixing per-session logout for socket connections ([#2506](https://github.com/heroiclabs/nakama/issues/2506)).
- Adds `TestWebSocketRejectsSessionAfterLogout` (Postgres-backed integration test via `TEST_DB_URL`).
- Test helper `NewAPIServer` wires `statusRegistry` so WebSocket upgrade does not panic in tests.

## Test plan
- [x] `go test ./server/ -run TestWebSocketRejectsSessionAfterLogout` (with Postgres; e.g. `TEST_DB_URL`)
- [x] Local Podman Postgres + WSL (integration test)

Fixes #2506
