### PR TITLE
fix: return RESOURCE_EXHAUSTED for oversized RPC HTTP bodies

### DIFF
--- a/server/api_rpc.go
+++ b/server/api_rpc.go
@@ -41,7 +41,7 @@ var (
 	rpcFunctionNotFoundBytes = []byte(`{"error":"RPC function not found","message":"RPC function not found","code":5}`)
 	internalServerErrorBytes = []byte(`{"error":"Internal Server Error","message":"Internal Server Error","code":13}`)
 	badJSONBytes             = []byte(`{"error":"json: cannot unmarshal object into Go value of type string","message":"json: cannot unmarshal object into Go value of type string","code":3}`)
-	requestBodyTooLargeBytes = []byte(`{"code":3, "message":"http: request body too large"}`)
+	requestBodyTooLargeBytes = []byte(`{"code":8, "message":"http: request body too large"}`)
 )
 
 func (s *ApiServer) RpcFuncHttp(w http.ResponseWriter, r *http.Request) {

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -296,6 +296,17 @@ func UserIDFromSession(session *api.Session) (uuid.UUID, error) {
 	return uuid.FromString(data["uid"].(string))
 }
 
+func TestRequestBodyTooLargeResponseUsesResourceExhaustedCode(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(string(requestBodyTooLargeBytes), `"code":8`) {
+		t.Fatalf("expected ResourceExhausted (8) in RPC body-too-large payload, got %q", string(requestBodyTooLargeBytes))
+	}
+	if !strings.Contains(string(requestBodyTooLargeBytes), "http: request body too large") {
+		t.Fatalf("expected body-too-large message in payload, got %q", string(requestBodyTooLargeBytes))
+	}
+}
+
 func TestWWWAuthenticateHeaderOnUnauthenticated(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- HTTP RPC (`/v2/rpc/...` POST): oversized request bodies now return gRPC status **8 (`RESOURCE_EXHAUSTED`)** in the JSON error payload instead of **3 (`INVALID_ARGUMENT`)** ([#2450](https://github.com/heroiclabs/nakama/issues/2450)).
- Adds a unit test asserting the `requestBodyTooLargeBytes` payload uses code 8.

## Scope note
This PR only covers the **RPC HTTP** path in `api_rpc.go`. Storage write version failures ([#2449](https://github.com/heroiclabs/nakama/issues/2449)) and gRPC-Gateway `/v2/storage` body limits are **not** included here (separate follow-up).

## Test plan
- [x] `go test ./server/ -run TestRequestBodyTooLargeResponseUsesResourceExhaustedCode`

Fixes #2450
