### PR TITLE
fix: return FAILED_PRECONDITION for storage version conflicts

### DIFF
--- a/server/core_storage.go
+++ b/server/core_storage.go
@@ -589,7 +589,10 @@ func StorageWriteObjects(ctx context.Context, logger *zap.Logger, db *sql.DB, me
 		var writeErr error
 		sortedWrites, acks, writeErr = storageWriteObjects(ctx, logger, metrics, tx, authoritativeWrite, ops)
 		if writeErr != nil {
-			if errors.Is(writeErr, runtime.ErrStorageRejectedVersion) || errors.Is(writeErr, runtime.ErrStorageRejectedPermission) {
+			if errors.Is(writeErr, runtime.ErrStorageRejectedVersion) {
+				return StatusError(codes.FailedPrecondition, "Storage write rejected.", writeErr)
+			}
+			if errors.Is(writeErr, runtime.ErrStorageRejectedPermission) {
 				return StatusError(codes.InvalidArgument, "Storage write rejected.", writeErr)
 			}
 			return writeErr

--- a/server/core_storage_test.go
+++ b/server/core_storage_test.go
@@ -152,7 +152,7 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchNotExists(t *testing.T) {
 	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
 
 	assert.Nil(t, acks, "acks was not nil")
-	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
+	assert.Equal(t, codes.FailedPrecondition, code, "code did not match")
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error(), "error message did not match")
 }
@@ -256,7 +256,7 @@ func TestStorageWriteRuntimeGlobalSingleIfMatchExistsFail(t *testing.T) {
 	acks, code, err = StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
 
 	assert.Nil(t, acks, "acks was not nil")
-	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
+	assert.Equal(t, codes.FailedPrecondition, code, "code did not match")
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error(), "error message did not match")
 }
@@ -334,7 +334,7 @@ func TestStorageWriteRuntimeGlobalSingleIfNoneMatchExists(t *testing.T) {
 	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
 
 	assert.Nil(t, acks, "acks was not nil")
-	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
+	assert.Equal(t, codes.FailedPrecondition, code, "code did not match")
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error(), "error message did not match")
 }
@@ -370,7 +370,7 @@ func TestStorageWriteRuntimeGlobalMultipleIfMatchNotExists(t *testing.T) {
 	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, true, ops)
 
 	assert.Nil(t, acks, "acks was not nil")
-	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
+	assert.Equal(t, codes.FailedPrecondition, code, "code did not match")
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error(), "error message did not match")
 }
@@ -635,7 +635,7 @@ func TestStorageWritePipelineIfMatchNotExists(t *testing.T) {
 	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
 
 	assert.Nil(t, acks, "acks was not nil")
-	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
+	assert.Equal(t, codes.FailedPrecondition, code, "code did not match")
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error(), "error message did not match")
 }
@@ -687,7 +687,7 @@ func TestStorageWritePipelineIfMatchExistsFail(t *testing.T) {
 	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
 
 	assert.Nil(t, acks, "acks was not nil")
-	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
+	assert.Equal(t, codes.FailedPrecondition, code, "code did not match")
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error(), "error message did not match")
 }
@@ -828,7 +828,7 @@ func TestStorageWritePipelineIfNoneMatchExists(t *testing.T) {
 	acks, code, err := StorageWriteObjects(context.Background(), logger, db, metrics, storageIdx, false, ops)
 
 	assert.Nil(t, acks, "acks was not nil")
-	assert.Equal(t, codes.InvalidArgument, code, "code did not match")
+	assert.Equal(t, codes.FailedPrecondition, code, "code did not match")
 	assert.NotNil(t, err, "err was nil")
 	assert.Equal(t, "Storage write rejected - version check failed.", err.Error(), "error message did not match")
 }
@@ -2207,10 +2207,10 @@ func TestOCCNotExistsAuthoritative(t *testing.T) {
 
 	statesOutcomes := []writeTestDBState{
 		{0, "", codes.OK, nil, "did not exists"},
-		{1, v, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version match"},
-		{1, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
-		{0, v, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission reject, version match"},
-		{0, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission reject, version does not match"},
+		{1, v, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version match"},
+		{1, `{"a":1}`, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
+		{0, v, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission reject, version match"},
+		{0, `{"a":1}`, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission reject, version does not match"},
 	}
 	testWrite(t, `{"newV": true}`, "*", 1, true, statesOutcomes)
 }
@@ -2221,10 +2221,10 @@ func TestOCCNotExistsNonAuthoritative(t *testing.T) {
 
 	statesOutcomes := []writeTestDBState{
 		{0, "", codes.OK, nil, "did not exists"},
-		{1, v, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version match"},
-		{1, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
-		{0, v, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission reject, version match"},
-		{0, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission reject, version does not match"},
+		{1, v, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version match"},
+		{1, `{"a":1}`, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
+		{0, v, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission reject, version match"},
+		{0, `{"a":1}`, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission reject, version does not match"},
 	}
 	testWrite(t, `{"newV": true}`, "*", 1, false, statesOutcomes)
 }
@@ -2234,9 +2234,9 @@ func TestOCCWriteNonAuthoritative(t *testing.T) {
 	v := "{}"
 
 	statesOutcomes := []writeTestDBState{
-		{0, "", codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "did not exists"},
+		{0, "", codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "did not exists"},
 		{1, v, codes.OK, nil, "existed and permission allows write, version match"},
-		{1, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
+		{1, `{"a":1}`, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
 		{0, v, codes.InvalidArgument, runtime.ErrStorageRejectedPermission, "existed and permission reject, version match"},
 		{0, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedPermission, "existed and permission reject, version does not match"},
 	}
@@ -2248,11 +2248,11 @@ func TestOCCWriteAuthoritative(t *testing.T) {
 	v := "{}"
 
 	statesOutcomes := []writeTestDBState{
-		{0, "", codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "did not exists"},
+		{0, "", codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "did not exists"},
 		{1, v, codes.OK, nil, "existed and permission allows write, version match"},
-		{1, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
+		{1, `{"a":1}`, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission allows write, version does not match"},
 		{0, v, codes.OK, nil, "existed and permission reject, version match"},
-		{0, `{"a":1}`, codes.InvalidArgument, runtime.ErrStorageRejectedVersion, "existed and permission reject, version does not match"},
+		{0, `{"a":1}`, codes.FailedPrecondition, runtime.ErrStorageRejectedVersion, "existed and permission reject, version does not match"},
 	}
 	testWrite(t, `{"newV": true}`, v, 1, true, statesOutcomes)
 }


### PR DESCRIPTION
## Summary
- Storage writes that fail optimistic concurrency (`ErrStorageRejectedVersion`) now return gRPC **`FAILED_PRECONDITION` (9)** instead of **`INVALID_ARGUMENT` (3)** ([#2449](https://github.com/heroiclabs/nakama/issues/2449)).
- Permission denials on write remain **`INVALID_ARGUMENT`**.
- Updates `core_storage_test.go` expectations accordingly.

## Test plan
- [x] `go test ./server/ -run 'TestStorageWriteRuntimeGlobalIfMatchNotExists|TestOCCNotExistsAuthoritative|TestOCCWriteSameValueWithOutdatedVersionFail'` (with `TEST_DB_URL` / Postgres)

Fixes #2449
